### PR TITLE
Makes wooden pipe feasible choice with golden pipes for liquid transfer,...

### DIFF
--- a/common/net/minecraft/src/buildcraft/transport/pipes/PipeLiquidsWood.java
+++ b/common/net/minecraft/src/buildcraft/transport/pipes/PipeLiquidsWood.java
@@ -42,6 +42,9 @@ public class PipeLiquidsWood extends Pipe implements IPowerReceptor {
 		powerProvider = PowerFramework.currentFramework.createPowerProvider();
 		powerProvider.configure(50, 1, 1, 1, 1);
 		powerProvider.configurePowerPerdition(1, 1);
+		
+		((PipeTransportLiquids) transport).flowRate = 80;
+		((PipeTransportLiquids) transport).travelDelay = 2;
 	}
 
 	/**


### PR DESCRIPTION
That change is rather important it set of builds I did, and due to fact that wooden pipes do not join each other it won't brake a game.

I had to do it with my copy of BC3.1.6 and I believe that it should stay like that.

With default values wooden pipe is not transferring liquid fast enough acting as bottle neck in my factory systems. Also it causes my factory to explode due to overheating of combustion engines....

As a side note i already compiled BC with this change and it works fine.
