### PR TITLE
Config option: Fillers destroy blocks

### DIFF
--- a/common/net/minecraft/src/BuildCraftBuilders.java
+++ b/common/net/minecraft/src/BuildCraftBuilders.java
@@ -80,6 +80,7 @@ public class BuildCraftBuilders {
 	public static BlockBlueprintLibrary libraryBlock;
 	public static ItemBptTemplate templateItem;
 	public static ItemBptBluePrint blueprintItem;
+	public static boolean fillerDestroy;
 
 	private static boolean initialized = false;
 
@@ -123,6 +124,11 @@ public class BuildCraftBuilders {
 				DefaultProps.ARCHITECT_ID);
 		Property libraryId = BuildCraftCore.mainConfiguration.getOrCreateBlockIdProperty("blueprintLibrary.id",
 				DefaultProps.BLUEPRINT_LIBRARY_ID);
+
+		Property fillerDestroyProp = BuildCraftCore.mainConfiguration.getOrCreateBooleanProperty("filler.destroy",
+				Configuration.CATEGORY_GENERAL, DefaultProps.FILLER_DESTROY);
+		fillerDestroyProp.comment = "If true, Filler will destroy blocks instead of breaking them.";
+		fillerDestroy = Boolean.parseBoolean(fillerDestroyProp.value);
 
 		BuildCraftCore.mainConfiguration.save();
 

--- a/common/net/minecraft/src/buildcraft/builders/FillerPattern.java
+++ b/common/net/minecraft/src/buildcraft/builders/FillerPattern.java
@@ -10,6 +10,7 @@
 package net.minecraft.src.buildcraft.builders;
 
 import net.minecraft.src.BuildCraftBlockUtil;
+import net.minecraft.src.BuildCraftBuilders;
 import net.minecraft.src.ItemStack;
 import net.minecraft.src.TileEntity;
 import net.minecraft.src.World;
@@ -95,7 +96,11 @@ public abstract class FillerPattern implements IFillerPattern {
 		}
 
 		if (lastX != Integer.MAX_VALUE) {
-			BuildCraftBlockUtil.breakBlock(world, lastX, lastY, lastZ);
+			if (BuildCraftBuilders.fillerDestroy) {
+				world.setBlockWithNotify(lastX, lastY, lastZ, 0);
+			} else {
+				BuildCraftBlockUtil.breakBlock(world, lastX, lastY, lastZ);
+			}
 		}
 
 		return lastX == Integer.MAX_VALUE;

--- a/common/net/minecraft/src/buildcraft/core/DefaultProps.java
+++ b/common/net/minecraft/src/buildcraft/core/DefaultProps.java
@@ -111,6 +111,7 @@ public class DefaultProps {
 
 	public static boolean CURRENT_CONTINUOUS = false;
 	public static boolean PIPES_ALWAYS_CONNECT = false;
+	public static boolean FILLER_DESTROY = false;
 
 	public static int TRIGGER_REDSTONE_ACTIVE = 1;
 	public static int TRIGGER_REDSTONE_INACTIVE = 2;


### PR DESCRIPTION
Add config option to support Fillers destroying blocks instead of breaking them.
Prevents Fillers from being (ab)used as cheap Quarries.

By popular request. :)
