### PR TITLE
Issue 68: Stripping a gate will not clear the pipe of any active actions

### DIFF
--- a/common/net/minecraft/src/buildcraft/transport/Pipe.java
+++ b/common/net/minecraft/src/buildcraft/transport/Pipe.java
@@ -533,7 +533,12 @@ public class Pipe implements IPipe, IDropControlInventory {
 	public void resetGate() {
 		gate = null;
 		activatedTriggers = new Trigger[activatedTriggers.length];
+        triggerParameters = new TriggerParameter[triggerParameters.length];
+        activatedActions = new Action[activatedActions.length];
+        broadcastSignal = new boolean[] { false, false, false, false };
+        broadcastRedstone = false;
 		worldObj.markBlockNeedsUpdate(xCoord, yCoord, zCoord);
+        worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, BuildCraftTransport.genericPipeBlock.blockID);
 	}
 
 	private void resolveActions() {


### PR DESCRIPTION
Reset all gate parameters when gate is stripped from pipe. This includes triggers, trigger parameters, actions, redstone, and pipe wires. It should be safe to turn off the pipe wires since they get stripped off first. Also notifies neighboring blocks of redstone update.
