### PR TITLE
Compatibility fix to pipes with custom connection logic 

### DIFF
--- a/common/net/minecraft/src/buildcraft/transport/TileGenericPipe.java
+++ b/common/net/minecraft/src/buildcraft/transport/TileGenericPipe.java
@@ -383,6 +383,9 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ILiqu
 				&& !pipe1.transport.allowsConnect(pipe2.transport))
 			return false;
 
+		if (pipe2 != null && !( pipe2.isPipeConnected(this)))
+			return false;
+
 		return pipe1 != null ? pipe1.isPipeConnected(with) : false;
 	}
 


### PR DESCRIPTION
Compatibility fix to pipes with custom connection logic (e.g. pipes from Additional Buildcraft Objects)
