### PR TITLE
BuildCraft Frame patches

### DIFF
--- a/common/net/minecraft/src/buildcraft/builders/TileArchitect.java
+++ b/common/net/minecraft/src/buildcraft/builders/TileArchitect.java
@@ -290,6 +290,7 @@ public class TileArchitect extends TileBuildCraft implements IInventory {
 
 	@Override
 	public void invalidate() {
+		super.invalidate();
 		destroy();
 	}
 

--- a/common/net/minecraft/src/buildcraft/builders/TileBuilder.java
+++ b/common/net/minecraft/src/buildcraft/builders/TileBuilder.java
@@ -507,6 +507,7 @@ public class TileBuilder extends TileBuildCraft implements IBuilderInventory, IP
 
 	@Override
 	public void invalidate() {
+		super.invalidate();
 		destroy();
 	}
 

--- a/common/net/minecraft/src/buildcraft/builders/TileFiller.java
+++ b/common/net/minecraft/src/buildcraft/builders/TileFiller.java
@@ -290,6 +290,7 @@ public class TileFiller extends TileBuildCraft implements ISpecialInventory, IPo
 
 	@Override
 	public void invalidate() {
+		super.invalidate();
 		destroy();
 	}
 

--- a/common/net/minecraft/src/buildcraft/builders/TileMarker.java
+++ b/common/net/minecraft/src/buildcraft/builders/TileMarker.java
@@ -334,6 +334,7 @@ public class TileMarker extends TileBuildCraft implements IAreaProvider {
 
 	@Override
 	public void invalidate() {
+		super.invalidate();
 		destroy();
 	}
 

--- a/common/net/minecraft/src/buildcraft/core/TileBuildCraft.java
+++ b/common/net/minecraft/src/buildcraft/core/TileBuildCraft.java
@@ -48,7 +48,7 @@ public abstract class TileBuildCraft extends TileEntity implements ISynchronized
 
 	@Override
 	public void updateEntity() {
-		if (!init) {
+		if (!init && !isInvalid()) {
 			initialize();
 			init = true;
 		}
@@ -58,6 +58,13 @@ public abstract class TileBuildCraft extends TileEntity implements ISynchronized
 
 			receptor.getPowerProvider().update(receptor);
 		}
+	}
+	
+	@Override
+	public void invalidate()
+	{
+		init = false;
+		super.invalidate();
 	}
 
 	public void initialize() {

--- a/common/net/minecraft/src/buildcraft/factory/TilePump.java
+++ b/common/net/minecraft/src/buildcraft/factory/TilePump.java
@@ -344,6 +344,7 @@ public class TilePump extends TileMachine implements IMachine, IPowerReceptor {
 
 	@Override
 	public void invalidate() {
+		super.invalidate();
 		destroy();
 	}
 
@@ -352,6 +353,9 @@ public class TilePump extends TileMachine implements IMachine, IPowerReceptor {
 		if (tube != null) {
 			APIProxy.removeEntity(tube);
 			tube = null;
+			tubeY = Double.NaN;
+			aimY = 0;
+			blocksToPump.clear();
 		}
 	}
 

--- a/common/net/minecraft/src/buildcraft/transport/BlockGenericPipe.java
+++ b/common/net/minecraft/src/buildcraft/transport/BlockGenericPipe.java
@@ -518,12 +518,12 @@ public class BlockGenericPipe extends BlockContainer implements IBlockPipe, ITex
 
 	public static Pipe getPipe(IBlockAccess blockAccess, int i, int j, int k) {
 		
-		TileGenericPipe tile = (TileGenericPipe) blockAccess.getBlockTileEntity(i, j, k);
-
-		if (tile != null && !tile.isInvalid())
-			return tile.pipe;
+		TileEntity tile = blockAccess.getBlockTileEntity(i, j, k);
 		
-		return null;
+		if(!(tile instanceof TileGenericPipe) || tile.isInvalid())
+			return null;
+		
+		return ((TileGenericPipe)tile).pipe;
 	}
 
 	public static boolean isFullyDefined(Pipe pipe) {

--- a/common/net/minecraft/src/buildcraft/transport/TileGenericPipe.java
+++ b/common/net/minecraft/src/buildcraft/transport/TileGenericPipe.java
@@ -103,7 +103,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ILiqu
 
 	@Override
 	public void invalidate() {
-		
+		initialized = false;
 		super.invalidate();
 
 //		if (BlockGenericPipe.isValid(pipe))
@@ -112,6 +112,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ILiqu
 
 	@Override
 	public void validate() {
+		super.validate();
 		bindPipe();
 	}
 


### PR DESCRIPTION
```
Patches so that pumps and pipes can be moved by frames properly, other buildcraft tiles not tested
```
