### PR TITLE
IronEngines (combustion) have an inventory slot also, for buckets.

### DIFF
--- a/common/net/minecraft/src/buildcraft/energy/TileEngine.java
+++ b/common/net/minecraft/src/buildcraft/energy/TileEngine.java
@@ -264,7 +264,7 @@ public class TileEngine extends TileBuildCraft implements IPowerReceptor, IInven
 
 	@Override
 	public int getSizeInventory() {
-		if (engine instanceof EngineStone) {
+		if (engine instanceof EngineStone || engine instanceof EngineIron) {
 			return 1;
 		} else {
 			return 0;


### PR DESCRIPTION
For some reason redpower pneumatic tubes can deliver lava buckets to a IC2 geothermal engine, and BC Steam engine but do not interface with a Combustion engine; i believe this is the fault.
