### PR TITLE
Refactored Localization.java to support addon localizations.

### DIFF
--- a/buildcraft_client/net/minecraft/src/mod_BuildCraftCore.java
+++ b/buildcraft_client/net/minecraft/src/mod_BuildCraftCore.java
@@ -32,6 +32,7 @@ import net.minecraft.src.buildcraft.core.RenderEntityBlock;
 import net.minecraft.src.buildcraft.core.RenderLaser;
 import net.minecraft.src.buildcraft.core.RenderRobot;
 import net.minecraft.src.buildcraft.core.Utils;
+import net.minecraft.src.buildcraft.core.utils.Localization;
 import net.minecraft.src.buildcraft.transport.TileGenericPipe;
 import net.minecraft.src.forge.MinecraftForgeClient;
 import net.minecraft.src.forge.NetworkMod;
@@ -87,6 +88,9 @@ public class mod_BuildCraftCore extends NetworkMod {
 			MinecraftForgeClient.preloadTexture(DefaultProps.TEXTURE_BLOCKS);
 			MinecraftForgeClient.preloadTexture(DefaultProps.TEXTURE_ITEMS);
 			MinecraftForgeClient.preloadTexture(DefaultProps.TEXTURE_EXTERNAL);
+			
+			//Initialize localization
+			Localization.addLocalization("/lang/buildcraft/", DefaultProps.DEFAULT_LANGUAGE);
 
 			initialized = true;
 		}

--- a/common/net/minecraft/src/buildcraft/core/DefaultProps.java
+++ b/common/net/minecraft/src/buildcraft/core/DefaultProps.java
@@ -26,6 +26,8 @@ public class DefaultProps {
 	public static String TEXTURE_ITEMS = "/gfx/buildcraft/items/items.png";
 	public static String TEXTURE_ICONS = TEXTURE_PATH_GUI + "/icons.png";
 	public static String TEXTURE_TRIGGERS = TEXTURE_PATH_GUI + "/triggers.png";
+	
+	public static final String DEFAULT_LANGUAGE = "en_US";
 
 	public static int WOODEN_GEAR_ID = 3800;
 	public static int STONE_GEAR_ID = 3801;

--- a/common/net/minecraft/src/buildcraft/core/utils/StringUtil.java
+++ b/common/net/minecraft/src/buildcraft/core/utils/StringUtil.java
@@ -3,6 +3,6 @@ package net.minecraft.src.buildcraft.core.utils;
 public class StringUtil {
 
 	public static String localize(String key) {
-		return Localization.instance.get(key);
+		return Localization.get(key);
 	}
 }


### PR DESCRIPTION
Now any addon can call addLocalization("/lang/addonName/", "en_US"); or something like that in the client, and buildcraft will load the current addon localization from that folder, and also load the appropriate localization whenever the language changes.
