### PR TITLE
fixes issue 66

### DIFF
--- a/common/net/minecraft/src/buildcraft/transport/PipeTransportItems.java
+++ b/common/net/minecraft/src/buildcraft/transport/PipeTransportItems.java
@@ -352,8 +352,12 @@ public class PipeTransportItems extends PipeTransport {
 			int i;
 
 			if (APIProxy.isClient(worldObj) || APIProxy.isServerSide())
+			{
 				i = Math.abs(data.item.entityId + xCoord + yCoord + zCoord + data.item.deterministicRandomization)
 						% listOfPossibleMovements.size();
+				data.item.deterministicRandomization*=11;
+						
+			}
 			else
 				i = worldObj.rand.nextInt(listOfPossibleMovements.size());
 


### PR DESCRIPTION
without the patch:
packet 1 has a deterministicRandom (DR) of 1, packet 2 has a DR of 6. 
both hit a junction with 6 tubes (5 potential exits)

both choose exit 1 (1 mod 5, 6 mod 5)
they then (before the next update with a true random) hit another junction - they make the same decision (exit 1 again)

with patch

at the first exit they both choose exit 1, and both items update their DR (both client and server side)
new DR's 11 and 66
at the next exit the first item chooses exit 2 (11 mod 5) while the second packet chooses exit 1(66 mod 5).

11 was chosen as a number which is relatively prime to the number of exits -- eg, if you multiply by 3 or 9, and you have 3 exits, both packets will continue to make the same decision.

Also, if DeterministicRandom was made to be an unsigned int, you could remove the abs here; given this code is called Allot, it'd be a nice performance increase  in the inner loop.

(java's implementation of mod says that the mod of a negative number is negative, and that a negative number mod a positive one is an error; hence why the abs is needed)
