### PR TITLE
NPE on assembly table.

### DIFF
--- a/buildcraft_client/net/minecraft/src/buildcraft/silicon/GuiAssemblyTable.java
+++ b/buildcraft_client/net/minecraft/src/buildcraft/silicon/GuiAssemblyTable.java
@@ -133,6 +133,9 @@ public class GuiAssemblyTable extends GuiAdvancedInterface {
 
 		if (position != -1) {
 			RecipeSlot slot = (RecipeSlot) slots[position];
+			
+			if (slot.recipe == null)
+				return;
 
 			SelectionMessage message = new SelectionMessage();
 


### PR DESCRIPTION
Fixed an null pointer exception when clicking an empty slot in the recipes of the assembly table reported by iamamitten.
