### PR TITLE
Some efficiency improvements to the pipe renderer.

### DIFF
--- a/buildcraft_client/net/minecraft/src/buildcraft/transport/RenderPipe.java
+++ b/buildcraft_client/net/minecraft/src/buildcraft/transport/RenderPipe.java
@@ -49,7 +49,7 @@ public class RenderPipe extends TileEntitySpecialRenderer {
 	
 	final static private int renderDistanceSq = 24 * 24;
 	
-	final static private int numItemsToRender = 5;
+	final static private int numItemsToRender = 10;
 
 	private final static EntityItem dummyEntityItem = new EntityItem(null);
 


### PR DESCRIPTION
You guys might be interested in this. Some efficiency improvements for pipe rendering.

Added a distance check of 24 blocks to the pipe tile renderer. The distance check is pretty cheap, and hopefully this might reduce some of the client's workload. Distance can be adjust via the renderDistanceSq var if desired.

Normal tile entity are rendered up to 64 blocks away, unfortunately that value is hard coded in TileEntityRenderer or the additional distance check wouldn't be needed.

Also made a few other tweaks that should improve things slightly. Including capping the number of items a pipe can render in it.

This is all tested and works.
