### PR TITLE
Fix NullPointerException on wooden pipes when the inventory is empty

### DIFF
--- a/common/net/minecraft/src/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/net/minecraft/src/buildcraft/transport/pipes/PipeItemsWood.java
@@ -103,6 +103,8 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 			IInventory inventory = (IInventory) tile;
 
 			ItemStack[] extracted = checkExtract(inventory, true, pos.orientation.reverse());
+			if (extracted == null)
+				return;
 
 			for(ItemStack stack : extracted) {
 				if (stack == null || stack.stackSize == 0) {


### PR DESCRIPTION
As per the request on #117
