### PR TITLE
Fix interface crashes on SMP with autarchic gates

### DIFF
--- a/common/buildcraft/transport/GateVanilla.java
+++ b/common/buildcraft/transport/GateVanilla.java
@@ -76,7 +76,7 @@ public class GateVanilla extends Gate {
 	}
 
 	// / INFORMATION
-	private boolean hasPulser() {
+	public boolean hasPulser() {
 		return pulser != null;
 	}
 

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -344,6 +344,11 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 		if (worldObj.isRemote){
 			if (pipe == null && packet.getPipeId() != 0){
 				initialize(BlockGenericPipe.createPipe(packet.getPipeId()));
+				if (packet.gateKind != -1) {
+					ItemStack stack = new ItemStack(packet.gateId, 0, packet.gateKind);
+					pipe.gate = new GateVanilla(pipe, stack);
+					pipe.gate.kind = Gate.GateKind.values()[packet.gateKind];
+				}
 			}
 			renderState = packet.getRenderState();
 			worldObj.markBlockAsNeedsUpdate(xCoord, yCoord, zCoord);
@@ -356,7 +361,18 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 
 	public Packet getDescriptionPacket() {
 		bindPipe();
-		PipeRenderStatePacket packet = new PipeRenderStatePacket(this.renderState, this.pipeId, xCoord, yCoord, zCoord);
+		int gateId, gateKind;
+		if (pipe.gate == null) {
+			gateId = 0;
+			gateKind = -1;
+		} else {
+			gateId = BuildCraftTransport.pipeGate.shiftedIndex;
+			if (pipe.gate instanceof GateVanilla &&
+					((GateVanilla) pipe.gate).hasPulser())
+				gateId = BuildCraftTransport.pipeGateAutarchic.shiftedIndex;
+			gateKind = pipe.gate.kind.ordinal();
+		}
+		PipeRenderStatePacket packet = new PipeRenderStatePacket(this.renderState, this.pipeId, xCoord, yCoord, zCoord, gateId, gateKind);
 		return packet.getPacket();
 	}
 

--- a/common/buildcraft/transport/network/PipeRenderStatePacket.java
+++ b/common/buildcraft/transport/network/PipeRenderStatePacket.java
@@ -13,17 +13,21 @@ public class PipeRenderStatePacket extends PacketCoordinates {
 	
 	private PipeRenderState renderState;
 	public int pipeId;
+	public int gateId;
+	public int gateKind;
 	
 	
 	public PipeRenderStatePacket(){
 		
 	}
 	
-	public PipeRenderStatePacket(PipeRenderState renderState, int pipeId, int x, int y, int z) {
+	public PipeRenderStatePacket(PipeRenderState renderState, int pipeId, int x, int y, int z, int gateId, int gateKind) {
 		super(PacketIds.PIPE_DESCRIPTION, x, y, z);
 		this.pipeId = pipeId;
 		this.isChunkDataPacket = true;
 		this.renderState = renderState;
+		this.gateId = gateId;
+		this.gateKind = gateKind;
 	}
 
 	public PipeRenderState getRenderState(){
@@ -35,6 +39,8 @@ public class PipeRenderStatePacket extends PacketCoordinates {
 		super.writeData(data);
 		data.writeInt(pipeId);
 		renderState.writeData(data);
+		data.writeInt(gateId);
+		data.writeInt(gateKind);
 	}
 
 	@Override
@@ -43,6 +49,8 @@ public class PipeRenderStatePacket extends PacketCoordinates {
 		pipeId = data.readInt();
 		renderState = new PipeRenderState();
 		renderState.readData(data);
+		gateId = data.readInt();
+		gateKind = data.readInt();
 	}
 
 	@Override
@@ -56,6 +64,22 @@ public class PipeRenderStatePacket extends PacketCoordinates {
 	
 	public int getPipeId() {
 		return pipeId;
+	}
+
+	public void setGateId(int gateId) {
+		this.gateId = gateId;
+	}
+
+	public int getGateId() {
+		return gateId;
+	}
+
+	public void setGateKind(int gateKind) {
+		this.gateKind = gateKind;
+	}
+
+	public int getGateKind() {
+		return gateKind;
 	}
 
 }


### PR DESCRIPTION
Fixes the crashes on SMP with autarchic gates by correctly synching the gate attached to a pipe, there used to be an NPE accessing the gate attached to the pipe, since it wasn't actually added to the pipe object.
