### PR TITLE
OilBucketHandler should @ForgeSubscribe to its event.

### DIFF
--- a/common/buildcraft/energy/OilBucketHandler.java
+++ b/common/buildcraft/energy/OilBucketHandler.java
@@ -11,17 +11,31 @@ package buildcraft.energy;
 
 import buildcraft.BuildCraftEnergy;
 import net.minecraft.src.ItemStack;
+import net.minecraft.src.MovingObjectPosition;
 import net.minecraft.src.World;
-import net.minecraft.src.forge.IBucketHandler;
+import net.minecraftforge.event.ForgeSubscribe;
+import net.minecraftforge.event.entity.player.FillBucketEvent;
 
-public class OilBucketHandler implements IBucketHandler {
+public class OilBucketHandler{
+	
+    @ForgeSubscribe
+    public void onBucketFill(FillBucketEvent event){
+    	ItemStack result=fillCustomBucket(event.world,event.target);
+    	if(result==null)
+    	{
+    		return;
+    	}
+    	event.result=result;
+    	event.setHandeled();
+    	return;
+    	
+    }
+	public ItemStack fillCustomBucket(World w,MovingObjectPosition pos) {
+		int blockID=w.getBlockId(pos.blockX,pos.blockY,pos.blockZ);
+		if (( blockID== BuildCraftEnergy.oilStill.blockID || blockID == BuildCraftEnergy.oilMoving.blockID)
+				&& w.getBlockMetadata(pos.blockX,pos.blockY,pos.blockZ) == 0) {
 
-	@Override
-	public ItemStack fillCustomBucket(World w, int i, int j, int k) {
-		if ((w.getBlockId(i, j, k) == BuildCraftEnergy.oilStill.blockID || w.getBlockId(i, j, k) == BuildCraftEnergy.oilMoving.blockID)
-				&& w.getBlockMetadata(i, j, k) == 0) {
-
-			w.setBlockWithNotify(i, j, k, 0);
+			w.setBlockWithNotify(pos.blockX,pos.blockY,pos.blockZ, 0);
 
 			return new ItemStack(BuildCraftEnergy.bucketOil);
 		} else {


### PR DESCRIPTION
Updates the OilBucketHandler to handle the event, rather than extend the class;

The two functions should probably be merged, but i structured it this way to show what i changed and what was left as it was.
