### PR TITLE
Update common/buildcraft/transport/pipes/PipeItemsWood.java

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -68,7 +68,7 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 
 	@Override
 	public void setPowerProvider(IPowerProvider provider) {
-		provider = powerProvider;
+		powerProvider = provider;
 	}
 
 	@Override


### PR DESCRIPTION
I believe setPowerProvider(IPowerProvider) was backwards, as it didn't allow the powerProvider field to be modified.
