### PR TITLE
Update common/buildcraft/transport/PipeTransportItems.java

### DIFF
--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -153,7 +153,7 @@ public class PipeTransportItems extends PipeTransport {
 				return false;
 			return ((PipeTransportItems)pipe.pipe.transport).inputOpen(o);
 		} else if (entity instanceof IPipeEntry){
-			return true;
+			return ((IPipeEntry) entity).acceptItems();
 		} else if (entity instanceof IInventory)
 			if (new StackUtil(item.getItemStack()).checkAvailableSlot((IInventory) entity, false, o.reverse()))
 				return true;


### PR DESCRIPTION
It wasn't checking if an adjacent pipe would accept input from that orientation, 
Now it is. 

It's certainly a (minor) bug, since it ignores the inputOpen(Orientation) check, which is by default true. 

However, for my mod i need that check to work.
