### PR TITLE
Added Engine Energy Provider update call

### DIFF
--- a/common/buildcraft/energy/TileEngine.java
+++ b/common/buildcraft/energy/TileEngine.java
@@ -100,6 +100,7 @@ public class TileEngine extends TileBuildCraft implements IPowerReceptor, IInven
 		}
 
 		engine.update();
+		provider.update(this);
 
 		float newPistonSpeed = engine.getPistonSpeed();
 		if (newPistonSpeed != serverPistonSpeed) {


### PR DESCRIPTION
I'm pretty sure this call needs to be here. Without it, Engines can't transfer power from one to another (doWork() is never called).
