### PR TITLE
AutoWorkbench should only add n items

### DIFF
--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -300,14 +300,14 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 
 		if (minSlot != -1) {
 			if (stackUtils.tryAdding(this, minSlot, doAdd, false)) {
+				if(doAdd)
+					stack.stackSize--;
+				
 				if (doAdd && stack.stackSize != 0) {
 					addItem(stack, doAdd, from);
 				}
-
-				return stackUtils.itemsAdded;
-			} else {
-				return stackUtils.itemsAdded;
 			}
+			return stackUtils.itemsAdded;
 		} else {
 			return 0;
 		}


### PR DESCRIPTION
stackUtils.tryAdding does not de-increment the stack it adds from. Without this patch the recursive addItem call will continue going until all available stacks/slots are full.

To trigger bug use a hopper to feed an AutoWorkbench which is making ladders. add 1 stick. observer that all stick stacks are now full 64 stacks.
