### PR TITLE
Tanks should sync to the client (set hasUpdate)

### DIFF
--- a/common/buildcraft/factory/TileTank.java
+++ b/common/buildcraft/factory/TileTank.java
@@ -161,7 +161,12 @@ public class TileTank extends TileBuildCraft implements ITankContainer
         }
 
         int used = below.tank.fill(tank.getLiquid(), true);
-        tank.drain(used, true);
+        if(used>0) {
+            hasUpdate= true; // not redundant because tank.drain operates on an ILiquidTank, not a tile
+            below.hasUpdate=true; // redundant because below.fill sets hasUpdate
+
+            tank.drain(used, true);
+        }
     }
 
     /* ITANKCONTAINER */
@@ -183,9 +188,14 @@ public class TileTank extends TileBuildCraft implements ITankContainer
         while(tankToFill != null && resource.amount > 0){
             int used = tankToFill.tank.fill(resource, doFill);
             resource.amount -= used;
+            if(used>0)
+                tankToFill.hasUpdate=true;
+
             totalUsed += used;
             tankToFill = getTankAbove(tankToFill);
         }
+        if(totalUsed>0)
+            hasUpdate= true;
         return totalUsed;
     }
 
@@ -198,7 +208,9 @@ public class TileTank extends TileBuildCraft implements ITankContainer
     @Override
     public LiquidStack drain(int tankIndex, int maxEmpty, boolean doDrain)
     {
-        return getBottomTank().tank.drain(maxEmpty, doDrain);
+        TileTank bottom=getBottomTank();
+    	bottom.hasUpdate=true;
+        return bottom.tank.drain(maxEmpty, doDrain);
     }
 
     @Override


### PR DESCRIPTION
Tanks do not set hasUpdate anywhere, and so never send the client any updates: 
client side tanks don't visually change.
client de-syncs cause buckets to behave wonky (server thinks the bucket you hold is full, client thinks the bucket you hold is empty, you right click an "empty" bucket, and you place the liquid instead.

this patch resolves the first, and mostly resolves the second. it is still possible to get a visually incorrect bucket if you right click a bucket on a client-side-empty,server-side-has-liquid tank. (ie, before a sync occurs)
