### PR TITLE
AutoWorkbench should return !0 when doAdd is false

### DIFF
--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -285,6 +285,18 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 	public int addItem(ItemStack stack, boolean doAdd, Orientations from) {
 		StackUtil stackUtils = new StackUtil(stack);
 
+		if(stack.stackSize>1 && doAdd){
+			ItemStack clonedStack = stack.copy();
+			int added =0;
+			while(clonedStack.stackSize>1){
+				ItemStack oneStack = clonedStack.splitStack(1);
+				added +=addItem(oneStack,doAdd,from);
+			}
+			added +=addItem(clonedStack,doAdd,from);
+			return added;
+			
+		}		
+		
 		int minSimilar = Integer.MAX_VALUE;
 		int minSlot = -1;
 		int space=0;
@@ -307,15 +319,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 			return Math.min(space,stack.stackSize);
 		
 		if (minSlot != -1) {
-			if (stackUtils.tryAdding(this, minSlot, doAdd, false)) {
-				if (doAdd && stack.stackSize != 0) {
-					addItem(stack, doAdd, from);
-				}
-
-				return stackUtils.itemsAdded;
-			} else {
-				return stackUtils.itemsAdded;
-			}
+			return stackUtils.tryAdding(this, minSlot, doAdd, false)?1:0;			
 		} else {
 			return 0;
 		}


### PR DESCRIPTION
if doAdd is false, the AutoWorkBench now estimates the amount of free space it has, and return that as how many can be added. This resolves MustHave issue #160.
if addItem(doAdd:false) returns 0, some code branches assume that this item can not recieve anything, when it can.

Tested with obsidian pipe connected to workbench, chest next to workbench, hopper above, and general pipes providing. All are delivered as expected.
