### PR TITLE
Update common/buildcraft/transport/pipes/PipeItemsWood.java

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -198,11 +198,11 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 
 				ItemStack slot = inventory.getStackInSlot(k);
 
-				if (slot != null && slot.stackSize > 0)
-					if (doRemove)
-						return inventory.decrStackSize(k, (int) powerProvider.useEnergy(1, slot.stackSize, true));
-					else
-						return slot;
+				if (slot != null)
+					if (slot.stackSize > 0 && doRemove)
+ 						return inventory.decrStackSize(k, (int) powerProvider.useEnergy(1, slot.stackSize, true));
+ 					elseif (slot.stackSize < 0 || !doRemove)
+ 						return slot;
 			}
 
 		return null;


### PR DESCRIPTION
Make an option allowing creating infinite item sources (without cheating and changing game balance, only adds new options)
In fact, make wooden pipe do not consume itemstack with negative item counts, giving infinite items instead. Useful for map development.
