### PR TITLE
Update wooden pipes (again)

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -199,7 +199,7 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 				ItemStack slot = inventory.getStackInSlot(k);
 
 				if (slot != null)
-					if (slot.stackSize > 0 || doRemove)
+					if (slot.stackSize > 0 && doRemove)
 						return inventory.decrStackSize(k, (int) powerProvider.useEnergy(1, slot.stackSize, true));
 					else if (slot.stackSize < 0)
 						{ItemStack k=slot.copy(); k.stackSize=1; return k;}


### PR DESCRIPTION
Wood pipes now taking item stacks right as in Vanilla Minecraft:
if ItemStack's size < 0, it will take one copy of this item.
SirSengir, sorry for repeated pull, but i've several reasons to do it:
1) it's good for creating non-cheating item source, especially for maps
2) I've fixed that error that taken item still was with stackSize<0
If you still don't like it, close this pull, I'll not do it again.
But it is only balanced way to create such thing without adding new blocks, items, installing additional mods e.t.c.
Sorry for my bad English - it's not my native.
