### PR TITLE
StackUtil.itemsAdded should be >0 when doAdd is false

### DIFF
--- a/common/buildcraft/core/StackUtil.java
+++ b/common/buildcraft/core/StackUtil.java
@@ -235,8 +235,9 @@ public class StackUtil {
 
 					if (doAdd) {
 						stack.stackSize++;
-						itemsAdded++;
 					}
+					itemsAdded++;
+					
 
 					return true;
 				}


### PR DESCRIPTION
all current uses of tryAdding(doAdd:false) which access itemsAdded compare the result to 0.

NOTE: while this does fix the AutoCraftingTable to accept items, it exposes the infinite recursion bug where it recursivly tries to add 1 item, then recurses without changing the stack size. (i'll do a seperate PR for that bug) 
