### PR TITLE
Quary should not use energy when 0 movement would result

### DIFF
--- a/common/buildcraft/factory/TileQuarry.java
+++ b/common/buildcraft/factory/TileQuarry.java
@@ -134,10 +134,13 @@ public class TileQuarry extends TileMachine implements IArmListener, IMachine, I
 			arm.setArmSpeed(0);
 			float energyToUse = 2 + powerProvider.getEnergyStored() / 1000;
 
-			float energy = powerProvider.useEnergy(energyToUse, energyToUse, true);
+			boolean enoughStep=(0.015 + energyToUse / 200F)>(1F/32F); // (otherwise the movement is rounded to 0 and the energy absorbed with no movement)
+			if(enoughStep){
+				float energy = powerProvider.useEnergy(energyToUse, energyToUse, true);
 
-			if (energy > 0) {
-				arm.doMove(0.015 + energy / 200F);
+				if (energy > 0) {
+					arm.doMove(0.015 + energy / 200F);
+				}
 			}
 		}
 


### PR DESCRIPTION
Position is stored in 1/32's so if the movement is less than that, it will take the energy, then not move at all. This means that energy less than about 3.2/tick will never move the quary arm.
