### PR TITLE
Check for nulls in stacks returned from extractItem.

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -131,7 +131,9 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 			ItemStack[] stacks = ((ISpecialInventory) inventory).extractItem(doRemove, from, (int)powerProvider.getEnergyStored());
 			if (stacks != null && doRemove) {
 				for (ItemStack stack : stacks) {
-					powerProvider.useEnergy(stack.stackSize, stack.stackSize, true);
+					if (stack != null) {
+						powerProvider.useEnergy(stack.stackSize, stack.stackSize, true);
+					}
 				}
 			}
 			return stacks;


### PR DESCRIPTION
@Speedyrv said he encountered a crash with this code using Forestry apiaries. Given that it's an NPE, and that there's a null check in the caller, I added one here too.
