### PR TITLE
a Transactor should be able to request addition to a specific slot

### DIFF
--- a/common/buildcraft/core/inventory/ITransactor.java
+++ b/common/buildcraft/core/inventory/ITransactor.java
@@ -6,5 +6,6 @@ import buildcraft.api.core.Orientations;
 public interface ITransactor {
 
 	ItemStack add(ItemStack stack, Orientations orientation, boolean doAdd);
+	ItemStack addSpecific(ItemStack stack,int slot, Orientations orientation, boolean doAdd);
 
 }

--- a/common/buildcraft/core/inventory/Transactor.java
+++ b/common/buildcraft/core/inventory/Transactor.java
@@ -15,7 +15,15 @@ public abstract class Transactor implements ITransactor {
 		return added;
 	}
 	
+	@Override
+	public ItemStack addSpecific(ItemStack stack,int slot, Orientations orientation, boolean doAdd) {
+		ItemStack added = stack.copy();
+		added.stackSize = injectSpecific(stack,slot, orientation, doAdd);	
+		return added;
+	}
+	
 	public abstract int inject(ItemStack stack, Orientations orientation, boolean doAdd);
+	public abstract int injectSpecific(ItemStack stack,int slot, Orientations orientation, boolean doAdd);
 	
 	public static ITransactor getTransactorFor(Object object) {
 		

--- a/common/buildcraft/core/inventory/TransactorSimple.java
+++ b/common/buildcraft/core/inventory/TransactorSimple.java
@@ -30,6 +30,16 @@ public class TransactorSimple extends Transactor {
 		return injected;
 	}
 	
+	@Override
+	public int injectSpecific(ItemStack stack, int slot,Orientations orientation, boolean doAdd) {
+		
+		int injected = 0;
+		
+		injected += addToSlot(slot, stack, injected, doAdd);
+		
+		return injected;
+	}
+	
 	protected int getPartialSlot(ItemStack stack, Orientations orientation, int skipAhead) {
 		return getPartialSlot(stack, skipAhead, inventory.getSizeInventory());
 	}

--- a/common/buildcraft/core/inventory/TransactorSpecial.java
+++ b/common/buildcraft/core/inventory/TransactorSpecial.java
@@ -16,5 +16,9 @@ public class TransactorSpecial extends Transactor {
 	public int inject(ItemStack stack, Orientations orientation, boolean doAdd) {
 		return inventory.addItem(stack, doAdd, orientation);
 	}
-
+	
+	@Override
+	public int injectSpecific(ItemStack stack,int slot, Orientations orientation, boolean doAdd) {
+		return inventory.addItem(stack, doAdd, orientation); // a special inventory knows its slots better than we do, trust that it gets it right.
+	}
 }


### PR DESCRIPTION
The autocrafting table searches for a specific slot to add an item, but
then fails to actually place it into that specific slot beacuse
Transactor then decides which slot it should go into -- a
add/injectSpecific funcion call has been added which takes a slot and
tries to put the stack in there. THe exception is the TransactorSPecial
which assumes (even on an addSpecifc call) that the ISpecial is the best
entitty to decide which slot it should go into/

Because the AutoWorkbench tries to split stacks, rather than fill them
(eg making ladders from sticks) large stacks should be added one at a
time to distribute them between internal stacks. There is a minor
performance boos when items get added one per time because the stack
doesn't need to be cloned to prevent change.
