### PR TITLE
move AutoWorkshop insert logic to transaction

### DIFF
--- a/common/buildcraft/core/inventory/TransactorRoundRobbin.java
+++ b/common/buildcraft/core/inventory/TransactorRoundRobbin.java
@@ -1,0 +1,39 @@
+package buildcraft.core.inventory;
+
+import net.minecraft.src.IInventory;
+import net.minecraft.src.ItemStack;
+import buildcraft.api.core.Orientations;
+
+public class TransactorRoundRobbin extends TransactorSimple {
+
+	private IInventory myInventory;
+	public TransactorRoundRobbin(IInventory iInventory) {
+		super(iInventory);
+		myInventory = iInventory;
+	}
+	@Override
+	public int inject(ItemStack stack, Orientations orientation, boolean doAdd) {
+		int oneLessThanStackSize = stack.stackSize - 1;
+		int added = 0;
+		for (int itemLoop = 0; itemLoop<stack.stackSize; ++itemLoop){ // add 1 item n times.
+			int minSimilar = Integer.MAX_VALUE;
+			int minSlot = -1;
+			for (int j = 0; j < myInventory.getSizeInventory() && minSlot > 1; ++j) {
+				ItemStack stackInInventory = myInventory.getStackInSlot(j);
+	
+				if (stackInInventory != null && stackInInventory.stackSize > 0 && stackInInventory.itemID == stack.itemID
+						&& stackInInventory.getItemDamage() == stack.getItemDamage() && stackInInventory.stackSize < minSimilar) {
+					minSimilar = stackInInventory.stackSize;
+					minSlot = j;
+				}
+			}
+	
+			if (minSlot != -1) {
+				added += addToSlot(minSlot, stack, oneLessThanStackSize, doAdd); // add 1 item n times, into the selected slot				
+			} else // nowhere to add this
+				break;
+		}
+		return added;
+	}
+
+}

--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -1,4 +1,6 @@
-/** 
+
+<!-- saved from url=(0137)https://raw.github.com/AartBluestoke/BuildCraft/6d8e8c2bc444cc1fd9ac86ebe5bda910524832be/common/buildcraft/factory/TileAutoWorkbench.java -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"></head><body><pre style="word-wrap: break-word; white-space: pre-wrap;">/** 
  * Copyright (c) SpaceToad, 2011
  * http://www.mod-buildcraft.com
  * 
@@ -14,8 +16,7 @@ import java.util.LinkedList;
 import buildcraft.api.core.Orientations;
 import buildcraft.api.core.Position;
 import buildcraft.api.inventory.ISpecialInventory;
-import buildcraft.core.inventory.ITransactor;
-import buildcraft.core.inventory.TransactorSimple;
+import buildcraft.core.inventory.TransactorRoundRobbin;
 import buildcraft.core.utils.Utils;
 
 import net.minecraft.src.Container;
@@ -26,6 +27,7 @@ import net.minecraft.src.InventoryCrafting;
 import net.minecraft.src.ItemStack;
 import net.minecraft.src.NBTTagCompound;
 import net.minecraft.src.TileEntity;
+import net.minecraftforge.common.ISidedInventory;
 
 public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 
@@ -134,7 +136,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 	public ItemStack findRecipe() {
 		InventoryCrafting craftMatrix = new LocalInventoryCrafting();
 
-		for (int i = 0; i < getSizeInventory(); ++i) {
+		for (int i = 0; i &lt; getSizeInventory(); ++i) {
 			ItemStack stack = getStackInSlot(i);
 
 			craftMatrix.setInventorySlotContents(i, stack);
@@ -148,15 +150,15 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 	public ItemStack extractItem(boolean doRemove, boolean removeRecipe) {
 		InventoryCrafting craftMatrix = new LocalInventoryCrafting();
 
-		LinkedList<StackPointer> pointerList = new LinkedList<StackPointer>();
+		LinkedList&lt;StackPointer&gt; pointerList = new LinkedList&lt;StackPointer&gt;();
 
 		int itemsToLeave = (removeRecipe ? 0 : 1);
 
-		for (int i = 0; i < getSizeInventory(); ++i) {
+		for (int i = 0; i &lt; getSizeInventory(); ++i) {
 			ItemStack stack = getStackInSlot(i);
 
 			if (stack != null) {
-				if (stack.stackSize <= itemsToLeave) {
+				if (stack.stackSize &lt;= itemsToLeave) {
 					StackPointer pointer = getNearbyItem(stack.itemID, stack.getItemDamage());
 
 					if (pointer == null) {
@@ -199,7 +201,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 		return resultStack;
 	}
 
-	public void resetPointers(LinkedList<StackPointer> pointers) {
+	public void resetPointers(LinkedList&lt;StackPointer&gt; pointers) {
 		for (StackPointer p : pointers) {
 			ItemStack item = p.inventory.getStackInSlot(p.index);
 
@@ -252,10 +254,10 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 		} else if (tile instanceof IInventory) {
 			IInventory inventory = Utils.getInventory((IInventory) tile);
 
-			for (int j = 0; j < inventory.getSizeInventory(); ++j) {
+			for (int j = 0; j &lt; inventory.getSizeInventory(); ++j) {
 				ItemStack stack = inventory.getStackInSlot(j);
 
-				if (stack != null && stack.stackSize > 0 && stack.itemID == itemId && stack.getItemDamage() == damage) {
+				if (stack != null &amp;&amp; stack.stackSize &gt; 0 &amp;&amp; stack.itemID == itemId &amp;&amp; stack.getItemDamage() == damage) {
 					inventory.decrStackSize(j, 1);
 
 					StackPointer result = new StackPointer();
@@ -285,33 +287,8 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 	@Override
 	public int addItem(ItemStack stack, boolean doAdd, Orientations from) {
 		
-		ITransactor transactor = new TransactorSimple(this);
-
-		int minSimilar = Integer.MAX_VALUE;
-		int minSlot = -1;
-
-		for (int j = 0; j < getSizeInventory(); ++j) {
-			ItemStack stackInInventory = getStackInSlot(j);
-
-			if (stackInInventory != null && stackInInventory.stackSize > 0 && stackInInventory.itemID == stack.itemID
-					&& stackInInventory.getItemDamage() == stack.getItemDamage() && stackInInventory.stackSize < minSimilar) {
-				minSimilar = stackInInventory.stackSize;
-				minSlot = j;
-			}
-		}
-
-		if (minSlot != -1) {
-			ItemStack added = transactor.add(stack, from, doAdd);
-			ItemStack remaining = stack.copy();
-			remaining.stackSize -= added.stackSize;
-			
-			if(doAdd && remaining.stackSize >= 0)
-				added.stackSize += addItem(remaining, doAdd, from);
-			
-			return added.stackSize;
-		} else
-			return 0;
-
+		TransactorRoundRobbin transactor = new TransactorRoundRobbin((IInventory) this);
+		return transactor.inject(stack, from, doAdd);
 	}
 
 	@Override
@@ -320,3 +297,4 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 	}
 
 }
+</pre></body></html>


### PR DESCRIPTION
a TransactionRoundRobin inserts the tiles one by one into the existing stack of the same type, with the smallest size - auto-ballencing the stack size.

Also, now with No Recursion ( so it is harder for bugs/corner cases to cause a stack overflow )

( and i've finally cleaned up all my patches, so the commit network is neat again)
