### PR TITLE
#240 fix build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,60 +1,66 @@
 <project name="Buildcraft" basedir="../" default="main">
-    
+    <taskdef resource="net/sf/antcontrib/antlib.xml">
+        <classpath>
+            <pathelement location="/usr/share/java/ant-contrib.jar"/>
+            <pathelement location="/usr/share/java/commons-httpclient.jar"/>
+        </classpath>
+    </taskdef>
+    <property environment="env" />
     <!-- Properties -->
-    
+
     <property name="build.dir"           value="build"/>
     <property name="src.dir"             value="src"/>
-    
+
     <property name="download.dir"        value="download"/>
     <property name="files.minecraft.dir" value="jars"/>
-    
+
     <property name="classes.dir"         value="${build.dir}/classes"/>
     <property name="jar.dir"             value="${build.dir}/dist"/>
-          
+
     <property name="mcp.dir"             value="${build.dir}/mcp"/>
     <property name="forge.dir"           value="${mcp.dir}/forge"/>
-      
+
     <property name="clientsrc.dir"       value="${mcp.dir}/src/minecraft"/>
-          
+
     <property name="mcp.version"         value="72"/>
     <property name="forge.version"       value="4.0.0.232"/>
     <property name="bc.version"          value="3.1.8"/>
-    <property name="bc.version.full"     value="${bc.version}.${BUILD_NUMBER}"/>
-    
+    <property name="bc.version.full"     value="${bc.version}.${env.BUILD_NUMBER}"/>
+
     <echo message="Starting build for ${bc.version.full}"/>
-	
+
     <!-- Targets -->
-    
+
     <target name="clean">
         <delete dir="${build.dir}"/>
     </target>
-    
+
     <target name="setup">
-        
+
         <mkdir dir="${download.dir}"/>
-        
+
         <get src="http://mcp.ocean-labs.de/files/mcp${mcp.version}.zip" dest="${download.dir}" usetimestamp="True"/>
-        <getMethod url="http://files.minecraftforge.net/minecraftforge-src-${forge.version}.zip" 
-            dest="${download.dir}" usetimestamp="True">
-        	<header name="User-Agent" value="Ant-${ant.version}/${ant.java.version}" />
-    	</getMethod>
-        
+        <getMethod url="http://files.minecraftforge.net/minecraftforge-src-${forge.version}.zip"
+            responseDataFile="${download.dir}/minecraftforge-src-${forge.version}.zip">
+            <header name="User-Agent" value="Ant-${ant.version}/${ant.java.version}" />
+        </getMethod>
+
         <unzip dest="${mcp.dir}">
             <fileset dir="${download.dir}">
                 <include name="mcp*.zip"/>
             </fileset>
         </unzip>
-        
+
         <unzip dest="${mcp.dir}">
             <fileset dir="${download.dir}">
                 <include name="minecraftforge-src-*.zip"/>
             </fileset>
         </unzip>
-        
+
         <copy todir="${mcp.dir}/jars">
             <fileset dir="${files.minecraft.dir}"/>
         </copy>
-        
+
         <chmod file="${mcp.dir}/updatemd5.sh" perm="+x"/>
         <chmod file="${mcp.dir}/recompile.sh" perm="+x"/>
         <chmod file="${mcp.dir}/reobfuscate.sh" perm="+x"/>
@@ -63,16 +69,16 @@
         <!-- if your building on OSX these 2 should be executable -->
         <chmod file="${mcp.dir}/runtime/bin/astyle-osx" perm="+x" />
         <chmod file="${mcp.dir}/runtime/bin/jad-osx" perm="+x" />
-        
+
         <!-- Install forge -->
         <exec dir="${forge.dir}" executable="cmd" osfamily="windows">
             <arg line="/c install.cmd"/>
         </exec>
-        
+
         <exec dir="${forge.dir}" executable="sh" osfamily="unix">
             <arg value="install.sh" />
         </exec>
-        
+
         <!-- Copy BC source -->
         <copy todir="${clientsrc.dir}">
             <fileset dir="${src.dir}/common">
@@ -82,47 +88,47 @@
                 <filter token="VERSION" value="${bc.version}" />
             </filterset>
         </copy>
-        
+
     </target>
-    
+
     <target name="compile" depends="setup">
-        
+
         <!-- Recompile -->
         <exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
             <arg line="/c recompile.bat"/>
         </exec>
-        
+
         <exec dir="${mcp.dir}" executable="sh" osfamily="unix">
             <arg value="recompile.sh" />
         </exec>
-        
+
         <!-- Reobf -->
         <exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
             <arg line="/c reobfuscate.bat"/>
         </exec>
-        
+
         <exec dir="${mcp.dir}" executable="sh" osfamily="unix">
             <arg value="reobfuscate.sh" />
         </exec>
-        
+
         <!-- Copy BC classes -->
         <copy todir="${classes.dir}/client">
             <fileset dir="${mcp.dir}/reobf/minecraft"/>
         </copy>
-        
+
         <!-- Copy resoucres -->
         <copy todir="${classes.dir}/client">
             <fileset dir="${src.dir}/buildcraft_resources"/>
         </copy>
-        
+
     </target>
-    
+
     <target name="package" depends="compile">
-        
+
         <jar destfile="${jar.dir}/buildcraft-A-${bc.version.full}.jar" basedir="${classes.dir}/client"/>
-        
+
     </target>
-    
+
     <target name="main" depends="clean,package"/>
 
 </project>


### PR DESCRIPTION
Fixes the missing "getMethod" Task.

You have to install ant-contrib and common-httpclient for it.

the getMethod is necessary to avoid the User-Agent check on minecraftforge.
