### PR TITLE
builder places the actual block consumed, rather than what is in the template 

### DIFF
--- a/common/buildcraft/api/blueprints/BptBlock.java
+++ b/common/buildcraft/api/blueprints/BptBlock.java
@@ -91,11 +91,15 @@ public class BptBlock {
 	 * fullfilled, and once with the real inventory. Implementer is responsible
 	 * for updating req (with the remaining requirements if any) and stack
 	 * (after usage)
+	 * 
+	 * returns: what was used (similer to req, but created from stack, so that any NBT based differences are drawn from the correct source)
 	 */
-	public void useItem(BptSlotInfo slot, IBptContext context, ItemStack req, ItemStack stack) {
+	public ItemStack useItem(BptSlotInfo slot, IBptContext context, ItemStack req, ItemStack stack) {
+		ItemStack result = stack.copy();
 		if (stack.isItemStackDamageable()) {
 			if (req.getItemDamage() + stack.getItemDamage() <= stack.getMaxDamage()) {
 				stack.setItemDamage(req.getItemDamage() + stack.getItemDamage());
+				result.setItemDamage(req.getItemDamage());
 				req.stackSize = 0;
 			}
 
@@ -104,6 +108,7 @@ public class BptBlock {
 			}
 		} else {
 			if (stack.stackSize >= req.stackSize) {
+				result.stackSize = req.stackSize;
 				stack.stackSize -= req.stackSize;
 				req.stackSize = 0;
 			} else {
@@ -119,6 +124,7 @@ public class BptBlock {
 			stack.stackSize = 1;
 			stack.setItemDamage(0);
 		}
+		return result;
 	}
 
 	/**

--- a/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
+++ b/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
@@ -11,6 +11,7 @@ package buildcraft.core.blueprints;
 
 import java.util.Comparator;
 import java.util.LinkedList;
+import java.util.ListIterator;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
@@ -48,7 +49,7 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 				return -1;
 			else if (o1.getItemDamage() < o2.getItemDamage())
 				return 1;
-
+				
 			return 0;
 		}
 	});
@@ -239,10 +240,12 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 			for (ItemStack invStk : tmpInv)
 				if (invStk != null && reqStk.itemID == invStk.itemID && invStk.stackSize > 0) {
 
-					if (!invStk.isItemStackDamageable() && (reqStk.getItemDamage() != invStk.getItemDamage()))
-						continue;
+					if (!invStk.isItemStackDamageable() && (reqStk.getItemDamage() != invStk.getItemDamage())){
+						continue; // it doesn't match, try again
+					}
 
 					try {
+						
 						slot.useItem(context, reqStk, invStk);
 					} catch (Throwable t) {
 						// Defensive code against errors in implementers
@@ -278,7 +281,12 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 
 		}
 
-		for (ItemStack reqStk : tmpReq) {
+		ListIterator<ItemStack> itr = tmpReq.listIterator();
+		
+		while(itr.hasNext()) {
+			ItemStack reqStk = itr.next();
+			boolean smallStack = reqStk.stackSize == 1;
+			ItemStack usedStack = reqStk;
 			int size = inv.getSizeInventory();
 			for (int i = 0; i <= size; ++i) {
 				if (!inv.isBuildingMaterial(i)) {
@@ -293,7 +301,7 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 						continue;
 
 					try {
-						slot.useItem(context, reqStk, invStk);
+						usedStack = slot.useItem(context, reqStk, invStk);
 					} catch (Throwable t) {
 						// Defensive code against errors in implementers
 						t.printStackTrace();
@@ -312,6 +320,8 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 
 			if (reqStk.stackSize != 0)
 				return;
+			if(smallStack)
+				itr.set(usedStack); // set to the actual item used.
 		}
 
 		return;
@@ -332,7 +342,7 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 					return 1;
 				else if (o1.getItemDamage() < o2.getItemDamage())
 					return -1;
-
+				
 				return 0;
 			}
 		});

--- a/common/buildcraft/core/blueprints/BptSlot.java
+++ b/common/buildcraft/core/blueprints/BptSlot.java
@@ -50,8 +50,9 @@ public class BptSlot extends BptSlotInfo {
 		BlueprintManager.blockBptProps[blockId].buildBlock(this, context);
 	}
 
-	public void useItem(IBptContext context, ItemStack req, ItemStack stack) {
-		BlueprintManager.blockBptProps[blockId].useItem(this, context, req, stack);
+	// returns what was used
+	public ItemStack useItem(IBptContext context, ItemStack req, ItemStack stack) {
+		return BlueprintManager.blockBptProps[blockId].useItem(this, context, req, stack);
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
in almost all cases there is no difference, but there have been reports
that mod items with inventories get the inventories duplicated. this
should fix that.

should fix #5, but i don't have any other mods installed in my MCP install to check, and that bug report doesn't give any specific examples.
