### PR TITLE
Gates don't recognize Redstone Input

### DIFF
--- a/common/buildcraft/transport/gui/ContainerGateInterface.java
+++ b/common/buildcraft/transport/gui/ContainerGateInterface.java
@@ -16,6 +16,7 @@ import buildcraft.api.core.Orientations;
 import buildcraft.api.core.Position;
 import buildcraft.api.gates.ActionManager;
 import buildcraft.api.gates.IAction;
+import buildcraft.api.gates.IOverrideDefaultTriggers;
 import buildcraft.api.gates.ITrigger;
 import buildcraft.api.gates.ITriggerParameter;
 import buildcraft.api.gates.TriggerParameter;
@@ -63,6 +64,10 @@ public class ContainerGateInterface extends BuildCraftContainer {
 		if (!CoreProxy.proxy.isRenderWorld(pipe.worldObj)) {
 			_potentialActions.addAll(pipe.getActions());
 			_potentialTriggers.addAll(ActionManager.getPipeTriggers(pipe));
+
+			TileEntity ptile = pipe.worldObj.getBlockTileEntity(pipe.xCoord, pipe.yCoord, pipe.zCoord);
+			if (ptile instanceof IOverrideDefaultTriggers)
+				_potentialTriggers.addAll( ((IOverrideDefaultTriggers)ptile).getTriggers());
 
 			for (Orientations o : Orientations.dirs()) {
 				Position pos = new Position(pipe.xCoord, pipe.yCoord, pipe.zCoord, o);


### PR DESCRIPTION
Hi,

I tried this setup:

Lever <-> StructurePipe (with Gate A & Wire) <-> StructurePipe (with Wire) <-> StructurePipe (with Gate B & Wire) <-> Redstone Cuircuit

Gate B is set to: "Wire On -> Redstone Output"

in Gate A I can't set "Redstone Input -> Wire Output"

I only can select "Wire On" or "Wire Off" on Input :-/

I also tried with redstone wire instead of lever (in case that it does not recognize the lever) but I can't select Redstone Input anymore.
