### PR TITLE
Update common/buildcraft/transport/ItemFacade.java to facades won't be consumed in creative mode

### DIFF
--- a/common/buildcraft/transport/ItemFacade.java
+++ b/common/buildcraft/transport/ItemFacade.java
@@ -77,7 +77,8 @@ public class ItemFacade extends ItemBuildCraft {
 			return true;
 		} else {
 			if (((TileGenericPipe)tile).addFacade(Orientations.values()[side], ItemFacade.getBlockId(stack.getItemDamage()), ItemFacade.getMetaData(stack.getItemDamage()))){
-				stack.stackSize--;	
+				if (!player.capabilities.isCreativeMode)
+					stack.stackSize--;	
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Facades won't be consumed in creative mode.
