### PR TITLE
Iron pipes should only switch on rising edges.

### DIFF
--- a/common/buildcraft/transport/pipes/PipeLogicIron.java
+++ b/common/buildcraft/transport/pipes/PipeLogicIron.java
@@ -27,7 +27,8 @@ public class PipeLogicIron extends PipeLogic {
 		boolean currentPower = worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord);
 
 		if (currentPower != lastPower) {
-			switchPosition();
+			if (currentPower)
+				switchPosition();
 
 			lastPower = currentPower;
 		}


### PR DESCRIPTION
Push button, see iron pipe switch twice. Kind of difficult to work with. This makes them only switch on rising edges.
