### PR TITLE
Fix the merging of ItemStacks with different NBTTagCompound information

### DIFF
--- a/common/buildcraft/core/inventory/TransactorSimple.java
+++ b/common/buildcraft/core/inventory/TransactorSimple.java
@@ -40,7 +40,7 @@ public class TransactorSimple extends Transactor {
 			if(inventory.getStackInSlot(i) == null)
 				continue;
 			
-			if(!inventory.getStackInSlot(i).isItemEqual(stack))
+			if(!inventory.getStackInSlot(i).isItemEqual(stack) || !ItemStack.func_77970_a(inventory.getStackInSlot(i), stack))
 				continue;
 			
 			if(inventory.getStackInSlot(i).stackSize >= inventory.getStackInSlot(i).getMaxStackSize())
@@ -75,7 +75,7 @@ public class TransactorSimple extends Transactor {
 			return remaining;
 		}
 		
-		if(!inventory.getStackInSlot(slot).isItemEqual(stack))
+		if(!inventory.getStackInSlot(slot).isItemEqual(stack) || !ItemStack.func_77970_a(inventory.getStackInSlot(slot), stack))
 			return 0;
 		
 		int space = inventory.getStackInSlot(slot).getMaxStackSize() - inventory.getStackInSlot(slot).stackSize;


### PR DESCRIPTION
This fixes the merging of ItemStacks that had differend NBTTagCompounds but the same item id when adding them to an inventory.

ItemStacks can have the same ItemId and the same damage value but different NBTTagCoumpound information. These ItemStacks shouldn't merge together like the normal Minecraft Container handles the merge try.
