### PR TITLE
Refactored lasers.

### DIFF
--- a/common/buildcraft/builders/TileBuilder.java
+++ b/common/buildcraft/builders/TileBuilder.java
@@ -235,7 +235,7 @@ public class TileBuilder extends TileBuildCraft implements IBuilderInventory, IP
 		for (BlockIndex b : path) {
 			if (previous != null) {
 				
-				EntityLaser laser = new EntityPowerLaser(worldObj,
+				EntityPowerLaser laser = new EntityPowerLaser(worldObj,
 						new Position(previous.i + 0.5, previous.j + 0.5, previous.k + 0.5),
 						new Position(b.i + 0.5, b.j + 0.5, b.k + 0.5));
 				

--- a/common/buildcraft/builders/TilePathMarker.java
+++ b/common/buildcraft/builders/TilePathMarker.java
@@ -60,7 +60,7 @@ public class TilePathMarker extends TileMarker {
 		if (CoreProxy.proxy.isRenderWorld(worldObj))
 			return;
 
-		EntityLaser laser = new EntityPowerLaser(worldObj, new Position(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5), new Position(pathMarker.xCoord + 0.5, pathMarker.yCoord + 0.5, pathMarker.zCoord + 0.5));
+		EntityPowerLaser laser = new EntityPowerLaser(worldObj, new Position(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5), new Position(pathMarker.xCoord + 0.5, pathMarker.yCoord + 0.5, pathMarker.zCoord + 0.5));
 		laser.show();
 
 		laser.setTexture(DefaultProps.TEXTURE_PATH_ENTITIES + "/laser_1.png");

--- a/common/buildcraft/core/EntityEnergyLaser.java
+++ b/common/buildcraft/core/EntityEnergyLaser.java
@@ -58,27 +58,20 @@ public class EntityEnergyLaser extends EntityLaser {
 	}
 	
 	@Override
-	protected void updateData() {
-		super.updateData();
-		
+	protected void updateDataClient() {
+		super.updateDataClient();
 		powerAverage = (float)decodeDouble(dataWatcher.getWatchableObjectInt(15));
 	}
-	
+
 	@Override
-	public void setPositions(Position head, Position tail) {
-		super.setPositions(head, tail);
+	protected void updateDataServer() {
+		super.updateDataServer();
 		dataWatcher.updateObject(15, Integer.valueOf(encodeDouble((double)powerAverage)));
 	}
 	
 	@Override
-	protected void initClientSide() {
-		super.initClientSide();
+	protected void entityInit() {
+		super.entityInit();
 		dataWatcher.addObject(15, Integer.valueOf(0));
-	}
-	
-	@Override
-	protected void initServerSide() {
-		super.initServerSide();
-		dataWatcher.addObject(15, encodeDouble((double)powerAverage));
 	}
 }

--- a/common/buildcraft/core/EntityPowerLaser.java
+++ b/common/buildcraft/core/EntityPowerLaser.java
@@ -4,6 +4,7 @@ import net.minecraft.src.World;
 import buildcraft.api.core.Position;
 
 public class EntityPowerLaser extends EntityLaser {
+	private String texture;
 
 	public EntityPowerLaser(World world) {
 		super(world);
@@ -13,4 +14,31 @@ public class EntityPowerLaser extends EntityLaser {
 		super(world, head, tail);
 	}
 
+	@Override
+	protected void entityInit() {
+		super.entityInit();
+		dataWatcher.addObject(15, "");
+	}
+
+	@Override
+	public String getTexture() {
+		return texture;
+	}
+
+	public void setTexture(String texture) {
+		this.texture = texture;
+		needsUpdate = true;
+	}
+
+	@Override
+	protected void updateDataClient() {
+		super.updateDataClient();
+		texture = dataWatcher.getWatchableObjectString(15);
+	}
+
+	@Override
+	protected void updateDataServer() {
+		super.updateDataServer();
+		dataWatcher.updateObject(15, texture);
+	}
 }

--- a/common/buildcraft/core/render/RenderLaser.java
+++ b/common/buildcraft/core/render/RenderLaser.java
@@ -1,5 +1,6 @@
 package buildcraft.core.render;
 
+import buildcraft.api.core.Position;
 import net.minecraft.src.Entity;
 import net.minecraft.src.ModelBase;
 import net.minecraft.src.ModelRenderer;
@@ -38,7 +39,9 @@ public class RenderLaser extends Render {
 
 		GL11.glPushMatrix();
 		GL11.glDisable(2896 /* GL_LIGHTING */);
-		GL11.glTranslated(x, y, z);
+
+		Position offset = laser.renderOffset();
+		GL11.glTranslated(x + offset.x, y + offset.y, z + offset.z);
 
 		GL11.glRotatef((float) laser.angleZ, 0, 1, 0);
 		GL11.glRotatef((float) laser.angleY, 0, 0, 1);

--- a/common/buildcraft/silicon/TileLaser.java
+++ b/common/buildcraft/silicon/TileLaser.java
@@ -207,7 +207,9 @@ public class TileLaser extends TileBuildCraft implements IPowerReceptor {
 				assemblyTable.zCoord + 0.475 + (worldObj.rand.nextFloat() - 0.5) / 5F);
 		
 		laser.setPositions(head, tail);
-		laser.show();
+
+		if(!laser.isVisible())
+			laser.show();
 	}
 	
 	protected void removeLaser() {


### PR DESCRIPTION
Any change to the datawatchers after spawn entity and before the client entity gets created aren't getting synced, and then the server things that they were synced so unless if the value changes it wont try to sync it (this was happening to laser.show()). Made it change datawatcher onEntityUpdate (that way the client entity is initialized). The only problem now is that when you load a save, some lasers may not appear depending on your position until you move a few blocks. Fixes #263.

Also added a workaround for the laser showing a block higher than it should after a while on certain positions. Fixes #266.

Moved PowerLaser logic from EntityLaser.
