### PR TITLE
Blueprints sync in SMP

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -80,6 +80,7 @@ import buildcraft.core.proxy.CoreProxy;
 import net.minecraft.src.Block;
 import net.minecraft.src.Item;
 import net.minecraft.src.ItemStack;
+import net.minecraft.src.NBTTagCompound;
 import net.minecraftforge.common.Configuration;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.Property;
@@ -361,6 +362,16 @@ public class BuildCraftBuilders {
 			}
 
 		return rootBptIndex;
+	}
+
+	public static ItemStack getBptItemStack(int id, int damage, String name) {
+		ItemStack stack = new ItemStack(id, 1, damage);
+		NBTTagCompound nbt = new NBTTagCompound();
+		if(name != null && !"".equals(name)) {
+			nbt.setString("BptName", name);
+			stack.setTagCompound(nbt);
+		}
+		return stack;
 	}
 
 	public static void addHook(IBuilderHook hook) {

--- a/common/buildcraft/builders/ItemBptBase.java
+++ b/common/buildcraft/builders/ItemBptBase.java
@@ -14,9 +14,11 @@ import java.util.List;
 import buildcraft.BuildCraftBuilders;
 import buildcraft.core.ItemBuildCraft;
 import buildcraft.core.blueprints.BptBase;
+import buildcraft.core.proxy.CoreProxy;
 
 import net.minecraft.src.CreativeTabs;
 import net.minecraft.src.Entity;
+import net.minecraft.src.EntityPlayer;
 import net.minecraft.src.ItemStack;
 import net.minecraft.src.World;
 
@@ -37,11 +39,27 @@ public abstract class ItemBptBase extends ItemBuildCraft {
 	@SuppressWarnings({ "all" })
 	// @Override (client only)
 	public void addInformation(ItemStack itemstack, List list) {
-		BptBase bpt = BuildCraftBuilders.getBptRootIndex().getBluePrint(itemstack.getItemDamage());
-		if (bpt != null) {
-			list.add(bpt.getName());
+		if (itemstack.hasTagCompound() && itemstack.getTagCompound().hasKey("BptName")) {
+			list.add(itemstack.getTagCompound().getString("BptName"));
 		}
 	}
+
+    @Override
+    public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
+		if(CoreProxy.proxy.isSimulating(world)) {
+			BptBase bpt = BuildCraftBuilders.getBptRootIndex().getBluePrint(itemStack.getItemDamage());
+			if(bpt != null) {
+				return BuildCraftBuilders
+					.getBptItemStack(itemStack.itemID, itemStack.getItemDamage(), bpt.getName());
+			}
+		}
+		return itemStack;
+    }
+
+    @Override
+    public boolean getShareTag() {
+		return true;
+    }
 
 	@Override
 	public void onUpdate(ItemStack itemstack, World world, Entity entity, int i, boolean flag) {}

--- a/common/buildcraft/builders/ItemBptBluePrint.java
+++ b/common/buildcraft/builders/ItemBptBluePrint.java
@@ -20,8 +20,7 @@ public class ItemBptBluePrint extends ItemBptBase {
 
 	@Override
 	public int getIconFromDamage(int i) {
-		BptBase bpt = BuildCraftBuilders.getBptRootIndex().getBluePrint(i);
-		if (bpt == null) {
+		if (i == 0) {
 			return 5 * 16 + 2;
 		} else {
 			return 5 * 16 + 3;

--- a/common/buildcraft/builders/ItemBptTemplate.java
+++ b/common/buildcraft/builders/ItemBptTemplate.java
@@ -11,8 +11,7 @@ public class ItemBptTemplate extends ItemBptBase {
 
 	@Override
 	public int getIconFromDamage(int i) {
-		BptBase bpt = BuildCraftBuilders.getBptRootIndex().getBluePrint(i);
-		if (bpt == null) {
+		if (i == 0) {
 			return 5 * 16 + 0;
 		} else {
 			return 5 * 16 + 1;

--- a/common/buildcraft/builders/TileArchitect.java
+++ b/common/buildcraft/builders/TileArchitect.java
@@ -118,14 +118,13 @@ public class TileArchitect extends TileBuildCraft implements IInventory {
 			result.rotateLeft(context);
 		}
 
-		ItemStack stack = items[0].copy();
-
+		ItemStack stack;
 		if (result.equals(BuildCraftBuilders.getBptRootIndex().getBluePrint(lastBptId))) {
 			result = BuildCraftBuilders.getBptRootIndex().getBluePrint(lastBptId);
-			stack.setItemDamage(lastBptId);
+			stack = BuildCraftBuilders.getBptItemStack(items[0].itemID, lastBptId, result.getName());
 		} else {
 			int bptId = BuildCraftBuilders.getBptRootIndex().storeBluePrint(result);
-			stack.setItemDamage(bptId);
+			stack = BuildCraftBuilders.getBptItemStack(items[0].itemID, bptId, result.getName());
 			lastBptId = bptId;
 		}
 

--- a/common/buildcraft/builders/TileBlueprintLibrary.java
+++ b/common/buildcraft/builders/TileBlueprintLibrary.java
@@ -275,9 +275,11 @@ public class TileBlueprintLibrary extends TileBuildCraft implements IInventory {
 
 		if (progressOut == 100 && stack[3] == null) {
 			if (selected > -1 && selected < currentPage.size()) {
-				setInventorySlotContents(3, new ItemStack(stack[2].itemID, 1, currentPage.get(selected).position));
+				BptBase bpt = currentPage.get(selected);
+				setInventorySlotContents(3,
+						BuildCraftBuilders.getBptItemStack(stack[2].itemID, bpt.position, bpt.getName()));
 			} else {
-				setInventorySlotContents(3, new ItemStack(stack[2].itemID, 1, 0));
+				setInventorySlotContents(3, BuildCraftBuilders.getBptItemStack(stack[2].itemID, 0, null));
 			}
 			setInventorySlotContents(2, null);
 		}


### PR DESCRIPTION
Fix #288.
Blueprints names are saved to NBTs when created, instead of loading files client-side.
Also, blueprints can be right-clicked to update their data, allowing for existing blueprints to be updated (and for changes to the blueprint folder).
