### PR TITLE
Sandstone pipes do not transport to machines.

### DIFF
--- a/common/buildcraft/transport/PipeTransportSandStone.java
+++ b/common/buildcraft/transport/PipeTransportSandStone.java
@@ -1,0 +1,8 @@
+package buildcraft.transport;
+
+public class PipeTransportSandStone extends PipeTransportItems {
+	@Override
+	public boolean acceptItems() {
+		return false;
+	}
+}

--- a/common/buildcraft/transport/pipes/PipeItemsSandstone.java
+++ b/common/buildcraft/transport/pipes/PipeItemsSandstone.java
@@ -13,10 +13,11 @@ import buildcraft.api.core.Orientations;
 import buildcraft.core.DefaultProps;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeTransportItems;
+import buildcraft.transport.PipeTransportSandStone;
 
 public class PipeItemsSandstone extends Pipe{
 	public PipeItemsSandstone(int itemID) {
-		super(new PipeTransportItems(), new PipeLogicSandstone(), itemID);
+		super(new PipeTransportSandStone(), new PipeLogicSandstone(), itemID);
 	}
 	 
 	@Override


### PR DESCRIPTION
fixes #317

issues remaining:
liquid sandstone need a liquid variant on this, so you can run pipes past pumps; either that, or the quarry (and other machines) should just use the isconnected pipe test.

quarries will still put items into combustion engines, if there is no pipe available.
