### PR TITLE
fix filter shift-click

### DIFF
--- a/common/buildcraft/builders/gui/ContainerFiller.java
+++ b/common/buildcraft/builders/gui/ContainerFiller.java
@@ -12,6 +12,7 @@ package buildcraft.builders.gui;
 import buildcraft.core.gui.BuildCraftContainer;
 import net.minecraft.src.EntityPlayer;
 import net.minecraft.src.IInventory;
+import net.minecraft.src.ItemStack;
 import net.minecraft.src.Slot;
 
 public class ContainerFiller extends BuildCraftContainer {
@@ -51,6 +52,26 @@ public class ContainerFiller extends BuildCraftContainer {
 	@Override
 	public boolean canInteractWith(EntityPlayer entityplayer) {
 		return fillerInventory.isUseableByPlayer(entityplayer);
+	}
+	
+	@Override
+	public ItemStack transferStackInSlot(int i) {
+		ItemStack itemstack = null;
+		Slot slot = (Slot) inventorySlots.get(i);
+		if (slot != null && slot.getHasStack()) {
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if (i < getInventorySize()) {
+				if (!mergeItemStack(itemstack1, getInventorySize(), inventorySlots.size(), true))
+					return null;
+			} else if (!mergeItemStack(itemstack1, 9, getInventorySize(), false))
+				return null;
+			if (itemstack1.stackSize == 0)
+				slot.putStack(null);
+			else
+				slot.onSlotChanged();
+		}
+		return itemstack;
 	}
 
 }

--- a/common/buildcraft/core/gui/BuildCraftContainer.java
+++ b/common/buildcraft/core/gui/BuildCraftContainer.java
@@ -41,4 +41,7 @@ public abstract class BuildCraftContainer extends Container {
 		return itemstack;
 	}
 
+	public int getInventorySize(){
+		return inventorySize;
+	}
 }


### PR DESCRIPTION
The gui should not direct stacks moved by shift-click to the filter area, just to the inventory area.

A more general solution would require the Container to know what inventory it was associated with so it could do the correct ISided tests, so it could know that the first 9 slots in its list were out of bounds for default item movement.
