### PR TITLE
Machines should no longer send items to Sandstone pipes 

### DIFF
--- a/common/buildcraft/core/utils/Utils.java
+++ b/common/buildcraft/core/utils/Utils.java
@@ -148,8 +148,12 @@ public class Utils {
 
 			TileEntity pipeEntry = w.getBlockTileEntity((int) pos.x, (int) pos.y, (int) pos.z);
 
-			if (pipeEntry instanceof IPipeEntry && ((IPipeEntry) pipeEntry).acceptItems())
+			if (pipeEntry instanceof IPipeEntry && ((IPipeEntry) pipeEntry).acceptItems()) {
+				if( pipeEntry instanceof IPipeConnection )
+					if( !((IPipeConnection) pipeEntry).isPipeConnected(from.reverse()) )
+						continue;
 				possiblePipes.add(Orientations.values()[j]);
+			}
 		}
 
 		if (possiblePipes.size() > 0) {


### PR DESCRIPTION
Fixes quarries inserting items to Sandstone pipes.

Addresses #317 and offers a better solution than #330.

Util.addToRandomPipeEntry() now checks if the possible destinations would accept input, and checks if the pipe is indeed connected.
