### PR TITLE
Machine Power Request Alteration

### DIFF
--- a/common/buildcraft/factory/TileMachine.java
+++ b/common/buildcraft/factory/TileMachine.java
@@ -15,13 +15,14 @@ import buildcraft.core.TileBuildCraft;
 
 public abstract class TileMachine extends TileBuildCraft implements IMachine, IPowerReceptor {
 
-	@Override
-	public int powerRequest() {
-		if (isActive()) {
-			return getPowerProvider().getMaxEnergyReceived();
-		} else {
-			return 0;
-		}
-	}
+    @Override
+    public int powerRequest() {
+
+        if (isActive()) {
+            return (int) Math.ceil(Math.min(getPowerProvider().getMaxEnergyReceived(), getPowerProvider().getMaxEnergyStored() - getPowerProvider().getEnergyStored()));
+        } else {
+            return 0;
+        }
+    }
 
 }


### PR DESCRIPTION
Adjustment to machine power request behavior - machines requesting more
energy than they can possibly use when at/near maximum stored energy
results in improper power network distribution behavior. This simple
change corrects that so that power is not wasted far above the level
that it should be.

Ex: A quarry requests 200 MJ/t but can only possibly use 39 MJ/t max. (Actually far less.)
As conductive pipes distribute based on this request value, smaller
machines may get passed over by a conductive pipe only to have "useful"
power be completely wasted at a quarry due to overfill. Note that if
there is not enough energy on the system to power the quarry at max
speed, the 200 MJ/t request is still used in the "weighting" calculation
for distribution.

Under this change, generation in excess of the total system load will be
lost at the wooden pipes on a power network, and generation vs load
should be a much more straightforward and sensible calculation. Total
power consumed by the system is reduced only insofar as that
distribution will operate properly and ensure that all machines on a
network are running at maximum speed before waste occurs.
