### PR TITLE
Fix iron pipe redstone behaviour.

### DIFF
--- a/common/buildcraft/transport/pipes/PipeLogicIron.java
+++ b/common/buildcraft/transport/pipes/PipeLogicIron.java
@@ -13,6 +13,7 @@ import buildcraft.api.core.Orientations;
 import buildcraft.api.liquids.ITankContainer;
 import buildcraft.api.tools.IToolWrench;
 import buildcraft.api.transport.IPipeEntry;
+import buildcraft.transport.Pipe;
 import buildcraft.transport.TileGenericPipe;
 import net.minecraft.src.EntityPlayer;
 import net.minecraft.src.IInventory;
@@ -46,9 +47,11 @@ public class PipeLogicIron extends PipeLogic {
 
 			TileEntity tile = container.getTile(Orientations.values()[nextMetadata]);
 
-			if (tile instanceof TileGenericPipe)
-				if (((TileGenericPipe) tile).pipe.logic instanceof PipeLogicWood)
+			if (tile instanceof TileGenericPipe) {
+				Pipe pipe = ((TileGenericPipe) tile).pipe;
+				if (pipe.logic instanceof PipeLogicWood || pipe instanceof PipeStructureCobblestone)
 					continue;
+			}
 
 			if (tile instanceof IPipeEntry || tile instanceof IInventory || tile instanceof ITankContainer
 					|| tile instanceof TileGenericPipe) {


### PR DESCRIPTION
Iron pipes ignore structure pipes when switching outputs.
Fix Issue #372.
