### PR TITLE
Optional Localizations

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -157,7 +157,7 @@
 
 	</target>
 
-	<target name="compile" depends="setup">
+	<target name="compile" depends="setup,localization-check">
 
 		<!-- Recompile -->
 		<exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
@@ -191,12 +191,22 @@
 		</copy>
 
 		<!-- Copy localizations -->
+		<antcall target="copy-localizations"/>
+		
+	</target>
+	
+	<target name="copy-localizations" depends="localization-check" if="localizations.exist">
 		<copy todir="${classes.dir}">
 			<fileset dir="${lang.dir}">
 				<exclude name="README.md"/>
 			</fileset>
 		</copy>
-
+	</target>
+	
+	<target name="localization-check">
+		<condition property="localizations.exist">
+			<available file="${lang.dir}" type="dir"/>
+		</condition>
 	</target>
 
 	<!-- Zip the compiled files -->


### PR DESCRIPTION
Update the build.xml to ignore copying localizations if they don't exist.

Alternatively, the README.md could be updated to state that this directory isn't optional.
