### PR TITLE
Remove EntityBlock "collision".

### DIFF
--- a/common/buildcraft/core/EntityBlock.java
+++ b/common/buildcraft/core/EntityBlock.java
@@ -89,8 +89,4 @@ public class EntityBlock extends Entity {
 		nbttagcompound.setDouble("kSize", kSize);
 	}
 
-	@Override
-	public boolean canBeCollidedWith() {
-		return !isDead;
-	}
 }


### PR DESCRIPTION
canBeCollidedWith doesn't stop entities from going through, and instead,  stops players from left/right clicking the blocks behind them. (This can be observed from quarry and landmark lasers)

Basically, it serves no useful purpose, and is obstructive to players.
(If EntityBlocks should  actually be collidable, I'll to fix the collision code instead.)
