### PR TITLE
Markers destroy all lasers when broken.

### DIFF
--- a/common/buildcraft/builders/TileMarker.java
+++ b/common/buildcraft/builders/TileMarker.java
@@ -354,13 +354,21 @@ public class TileMarker extends TileBuildCraft implements IAreaProvider {
 						entity.setDead();
 					}
 				}
+				markerOrigin.lasers = null;
 			}
 
 			for (TileWrapper m : o.vect) {
 				TileMarker mark = m.getMarker(worldObj);
 
 				if (mark != null) {
-					mark.lasers = null;
+					if(mark.lasers != null) {
+						for (EntityBlock entity : mark.lasers) {
+							if (entity != null) {
+								entity.setDead();
+							}
+						}
+						mark.lasers = null;
+					}
 
 					if (mark != this) {
 						mark.origin = new Origin();
@@ -368,7 +376,6 @@ public class TileMarker extends TileBuildCraft implements IAreaProvider {
 				}
 			}
 
-			markerOrigin.lasers = null;
 
 			if (markerOrigin != this) {
 				markerOrigin.origin = new Origin();


### PR DESCRIPTION
Markers no longer leave lasers "floating" around on the client when broken by hand or a quarry.
Also fix a NPE.
