### PR TITLE
Update common/buildcraft/energy/EngineWood.java

### DIFF
--- a/common/buildcraft/energy/EngineWood.java
+++ b/common/buildcraft/energy/EngineWood.java
@@ -61,7 +61,7 @@ public class EngineWood extends Engine {
 
 		if (tile.isRedstonePowered) {
 			if ((tile.worldObj.getWorldTime() % 20) == 0) {
-				energy++;
+				this.addEnergy(1.0F);
 			}
 		}
 	}


### PR DESCRIPTION
This will make it preform explosion checking even if it dousn't get energy from an external energy source!
