### PR TITLE
Fix blockActivated not being called on client

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -613,7 +613,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 				if (pipe == null && coreState.pipeId != 0){
 					initialize(BlockGenericPipe.createPipe(coreState.pipeId));
 				}
-				if (pipe != null && GateKind.values()[coreState.gateKind] != GateKind.None) {
+				if (pipe != null && coreState.gateKind != GateKind.None.ordinal()) {
 					if (pipe.gate == null) {
 						pipe.gate = new GateVanilla(pipe);
 					}


### PR DESCRIPTION
Prevents the creation of a ghost gate on the client that was preventing blockActivated from being called on the client.
