### PR TITLE
Using an ItemStack-sensitive version of getContainerItem for consumeItem

### DIFF
--- a/common/buildcraft/core/utils/Utils.java
+++ b/common/buildcraft/core/utils/Utils.java
@@ -481,8 +481,8 @@ public class Utils {
 
 	public static ItemStack consumeItem(ItemStack stack) {
 		if (stack.stackSize == 1) {
-			if (stack.getItem().getContainerItem() != null)
-				return new ItemStack(stack.getItem().getContainerItem(), 1);
+			if (stack.getItem().hasContainerItem())
+				return stack.getItem().getContainerItemStack(stack);
 			else
 				return null;
 		} else {


### PR DESCRIPTION
The method consumeItem will use getContainerItemStack instead of getContainerItem in case the container has metadata that needs to be carried over.
