### PR TITLE
BUGFIX 406: Placing signs on Facades

### DIFF
--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -360,7 +360,9 @@ public class BlockGenericPipe extends BlockContainer {
 			} else if (entityplayer.getCurrentEquippedItem() == null) {
 
 				// Fall through the end of the test
-
+			} else if (entityplayer.getCurrentEquippedItem().itemID == Item.sign.shiftedIndex){
+				// Sign will be placed anyway, so lets show the sign gui
+				return false;
 			} else if (entityplayer.getCurrentEquippedItem().getItem() instanceof ItemPipe)
 				return false;
 			else if (entityplayer.getCurrentEquippedItem().getItem() instanceof IToolWrench) {


### PR DESCRIPTION
Bug: https://github.com/SirSengir/BuildCraft/issues/406

Simple fix to get signs showing GUI on Pipes ( And in turn, Facades )

Wasn't sure if the signs should only display on Facades or should display on both Pipe and Facade, so it's a simple fix for both. 

My first Pull Request so I welcome any suggestions and constructive criticism.

http://i.imgur.com/EWD24.png

Thanks,
NeverCast
