### PR TITLE
Fixed game breaking power bug!

### DIFF
--- a/common/buildcraft/transport/PipeTransportPower.java
+++ b/common/buildcraft/transport/PipeTransportPower.java
@@ -184,7 +184,7 @@ public class PipeTransportPower extends PipeTransport {
 			internalPower = internalNextPower;
 			internalNextPower = next;
 			for (int i = 0; i < nextPowerQuery.length; i++) {
-				if (powerQuery[i] == 0.0d) {
+				if (powerQuery[i] == 0.0d && internalNextPower[i] > 0) {
 					internalNextPower[i]-=1;
 				}
 			}


### PR DESCRIPTION
cpw's new power code didn't take in to account that internalPower might be zero when powerQuery is zero, such as when a cable is not being used, being placed, or a machine has not been loaded yet. This caused the internal power to drop in to negatives. Breaking all power because the internal power value would end up around negative 60 thousand MJ,

This if fixes it all. Tested by me, should have no side effects.
