### PR TITLE
Update forge.version/forge download link for .384+

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -26,7 +26,7 @@
 	<condition property="should-download-ant-contrib">
 		<or>
 			<available file="${download.dir}/ant-contrib/ant-contrib-1.0b3.jar"/>
-			<available file="${download.dir}/minecraftforge-src-1.4.5-${forge.version}.zip"/>
+			<available file="${download.dir}/minecraftforge-src-${mc.version}-${forge.version}.zip"/>
 		</or>
 	</condition>
 


### PR DESCRIPTION
The forge download links recently changed (.384+) after LexManos added the version number to the changelogs, so I added that in and updated forge.version.
(This change is not necessary until you update to Forge 6.4.0.384)
