### PR TITLE
Improved build.xml - cleaner, reduced build time in most cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/bin
+/build/
+/download/

--- a/build.xml
+++ b/build.xml
@@ -1,13 +1,12 @@
-<project name="Buildcraft" basedir="../" default="main">
-	<property environment="env" />
+<project name="BuildCraft" default="main">
+	<property environment="env"/>
 	<!-- Properties -->
 
 	<property name="build.dir"           value="build"/>
-	<property name="src.dir"             value="BuildCraft"/>
-	<property name="lang.dir"            value="BuildCraft-Localization"/>
+	<property name="src.dir"             value="common"/>
+	<property name="lang.dir"            value="../BuildCraft-Localization"/>
 
 	<property name="download.dir"        value="download"/>
-	<property name="files.minecraft.dir" value="jars"/>
 
 	<property name="classes.dir"         value="${build.dir}/classes"/>
 	<property name="jar.dir"             value="${build.dir}/dist"/>
@@ -17,38 +16,48 @@
 
 	<property name="mcpsrc.dir"          value="${mcp.dir}/src/minecraft"/>
 
-	<property name="mcp.version"         value="722"/>
-	<property name="forge.version"       value="6.4.0.381"/>
-	<property name="bc.version"          value="3.1.8"/>
-
-	<available property="forge-exists" file="${download.dir}/minecraftforge-src-${forge.version}.zip"/>
-	<condition property="should-download-ant-contrib">
-		<or>
-			<available file="${download.dir}/ant-contrib/ant-contrib-1.0b3.jar"/>
-			<available file="${download.dir}/minecraftforge-src-${forge.version}.zip"/>
-		</or>
-	</condition>
-
+	<property name="mcp.version"         value="723"/>
+	<property name="mc.version"          value="1.4.5"/>
+	<property name="forge.version"       value="6.4.0.396"/>
+	<property name="bc.version"          value="3.2.0"/>
 	
+	<property name="mcp.name"            value="mcp${mcp.version}.zip"/>
+	<property name="forge.name"          value="minecraftforge-src-${mc.version}-${forge.version}.zip"/>
+
+	<available property="forge-exists" file="${download.dir}/${forge.name}"/>
+	<available property="mcp-exists" file="${download.dir}/${mcp.name}"/>
+
+	<condition property="out-of-date">
+		<not>
+			<and>
+				<available file="${download.dir}/${mcp.name}"/>
+				<available file="${download.dir}/${forge.name}"/>
+				<available file="${mcpsrc.dir}"/>
+			</and>
+		</not>
+	</condition>
 
 	<mkdir dir="${download.dir}"/>
 
 	<!-- Targets -->
 
+	<!-- Clear build directory -->
 	<target name="clean">
 		<delete dir="${build.dir}"/>
 	</target>
 
-	<!-- Set build number -->
+	<!-- Set full version -->
 	<target name="initialize-version" depends="version-provided,version-not-provided">
 		<property name="bc.version.full"     value="${bc.version}.${build.number}"/>
 		<echo message="Starting build for ${bc.version.full}"/>
 	</target>
 
+	<!-- Set unknown build number -->
 	<target name="version-not-provided" unless="env.BUILD_NUMBER">
-		<buildnumber/>
+		<property name="build.number" value="unknown"/>
 	</target>
 
+	<!-- Set build number from environment -->
 	<target name="version-provided" if="env.BUILD_NUMBER">
 		<property name="build.number" value="${env.BUILD_NUMBER}"/>
 	</target>
@@ -56,84 +65,29 @@
 	<!-- Download necessary files -->
 	<target name="download-files" depends="download-mcp,download-forge"/>
 
-	<!-- Download ant-contrib, necessary to be able to download forge (only if neither forge zip nor ant-contrib exist) -->
-	<target name="download-ant-contrib" unless="should-download-ant-contrib">
-
-		<echo message="Getting: ant-contrib"/>
-		<mkdir dir="${download.dir}/tmp"/>
-
-		<get src="http://sourceforge.net/projects/ant-contrib/files/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.zip/download" dest="${download.dir}/tmp/ant-contrib-1.0b3-bin.zip"/>
-		<get src="http://archive.apache.org/dist/commons/codec/binaries/commons-codec-1.6-bin.zip" dest="${download.dir}/tmp/commons-codec-1.6-bin.zip"/>
-
-		<unzip src="${download.dir}/tmp/ant-contrib-1.0b3-bin.zip" dest="${download.dir}"/>
-		<unzip src="${download.dir}/tmp/commons-codec-1.6-bin.zip" dest="${download.dir}/tmp"/>
-
-		<move todir="${download.dir}/ant-contrib/lib">
-			<fileset file="${download.dir}/tmp/commons-codec-1.6/commons-codec-1.6.jar"/>
-		</move>
-
-		<!-- Delete useless files -->
-		<delete dir="${download.dir}/ant-contrib/docs"/>
-		<delete dir="${download.dir}/tmp"/>
-
-	</target>
-
 	<!-- Download mcp -->
-	<target name="download-mcp">
-
-		<get src="http://mcp.ocean-labs.de/files/mcp${mcp.version}.zip" dest="${download.dir}" usetimestamp="True"/>
-
+	<target name="download-mcp" unless="mcp-exists">
+		<get src="http://mcp.ocean-labs.de/files/${mcp.name}" dest="${download.dir}" usetimestamp="True"/>
 	</target>
 
 	<!-- Download forge (if it doesn't exist) -->
-	<target name="download-forge" depends="download-ant-contrib" unless="forge-exists" >
-
-		<taskdef resource="net/sf/antcontrib/antlib.xml">
-			<classpath>
-				<pathelement location="${download.dir}/ant-contrib/ant-contrib-1.0b3.jar"/>
-				<fileset dir="${download.dir}/ant-contrib/lib">
-					<include name="*.jar"/>
-				</fileset>
-			</classpath>
-		</taskdef>
-
-		<getMethod url="http://files.minecraftforge.net/minecraftforge-src-${forge.version}.zip"
-				   responseDataFile="${download.dir}/minecraftforge-src-${forge.version}.zip">
-			<header name="User-Agent" value="Ant-${ant.version}/${ant.java.version}"/>
-		</getMethod>
-
+	<target name="download-forge" unless="forge-exists" >
+		<get src="http://files.minecraftforge.net/${forge.name}" dest="${download.dir}" usetimestamp="True"/>
 	</target>
 
 	<!-- Setup mcp and forge -->
-	<target name="setup" depends="initialize-version">
+	<target name="setup" depends="download-files" if="out-of-date">
 	
+		<delete dir="${mcp.dir}"/>
+
 		<!-- Unzip them -->
-		<unzip dest="${mcp.dir}">
-			<fileset dir="${download.dir}">
-				<include name="mcp${mcp.version}.zip"/>
-			</fileset>
-		</unzip>
+		<unzip dest="${mcp.dir}" src="${download.dir}/${mcp.name}"/>
 
-		<unzip dest="${mcp.dir}">
-			<fileset dir="${download.dir}">
-				<include name="minecraftforge-src-${forge.version}.zip"/>
-			</fileset>
-		</unzip>
+		<unzip dest="${mcp.dir}" src="${download.dir}/${forge.name}"/>
 
-		<!-- Copy the necessary jars -->
-		<copy todir="${mcp.dir}/jars">
-			<fileset dir="${files.minecraft.dir}"/>
-		</copy>
-
-		<!-- Change executables' permitions -->
-		<chmod file="${mcp.dir}/updatemd5.sh" perm="+x"/>
-		<chmod file="${mcp.dir}/recompile.sh" perm="+x"/>
-		<chmod file="${mcp.dir}/reobfuscate.sh" perm="+x"/>
-		<chmod file="${forge.dir}/install.sh" perm="+x"/>
-
-		<!-- if your building on OSX these 2 should be executable -->
-		<chmod file="${mcp.dir}/runtime/bin/astyle-osx" perm="+x" />
-		<chmod file="${mcp.dir}/runtime/bin/jad-osx" perm="+x" />
+		<!-- Fix executable permissions -->
+		<chmod dir="${mcp.dir}" perm="ugo+rx" includes="**.sh"/>
+		<chmod file="${mcp.dir}/runtime/bin/astyle-osx" perm="ugo+rx"/>
 
 		<!-- Install forge -->
 		<exec dir="${forge.dir}" executable="cmd" osfamily="windows">
@@ -141,23 +95,26 @@
 		</exec>
 
 		<exec dir="${forge.dir}" executable="sh" osfamily="unix">
-			<arg value="install.sh" />
+			<arg value="install.sh"/>
 		</exec>
-
-		<!-- Copy BC source -->
-		<copy todir="${mcpsrc.dir}">
-			<fileset dir="${src.dir}/common">
-				<exclude name="**/buildcraft/devel"/>
-			</fileset>
-			<filterset>
-				<filter token="VERSION" value="${bc.version}" />
-				<filter token="BUILD_NUMBER" value="${build.number}" />
-			</filterset>
-		</copy>
 
 	</target>
 
-	<target name="compile" depends="setup">
+	<target name="compile" depends="initialize-version,setup">
+
+		<delete dir="${classes.dir}"/>
+		<mkdir dir="${classes.dir}"/>
+		
+		<!-- Copy BC source -->
+		<copy todir="${mcpsrc.dir}">
+			<fileset dir="${src.dir}">
+				<exclude name="**/buildcraft/devel"/>
+			</fileset>
+			<filterset>
+				<filter token="VERSION" value="${bc.version.full}"/>
+				<filter token="BUILD_NUMBER" value="${build.number}"/>
+			</filterset>
+		</copy>
 
 		<!-- Recompile -->
 		<exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
@@ -165,16 +122,16 @@
 		</exec>
 
 		<exec dir="${mcp.dir}" executable="sh" osfamily="unix">
-			<arg value="recompile.sh" />
+			<arg value="recompile.sh"/>
 		</exec>
 
-		<!-- Reobf -->
+		<!-- Reobfuscate -->
 		<exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
 			<arg line="/c reobfuscate.bat"/>
 		</exec>
 
 		<exec dir="${mcp.dir}" executable="sh" osfamily="unix">
-			<arg value="reobfuscate.sh" />
+			<arg value="reobfuscate.sh"/>
 		</exec>
 
 		<!-- Copy BC classes -->
@@ -184,7 +141,7 @@
 
 		<!-- Copy resources -->
 		<copy todir="${classes.dir}">
-			<fileset dir="${src.dir}/buildcraft_resources">
+			<fileset dir="buildcraft_resources">
 				<exclude name="build.xml"/>
 				<exclude name="build.number"/>
 			</fileset>
@@ -197,16 +154,21 @@
 			</fileset>
 		</copy>
 
+		<!-- Reset src dir to post-forge-install state -->
+		<delete dir="${mcpsrc.dir}/buildcraft"/>
+
 	</target>
 
-	<!-- Zip the compiled files -->
+	<!-- Package the compiled files -->
 	<target name="package" depends="compile">
 
+		<delete dir="${jar.dir}"/>
+		<mkdir dir="${jar.dir}"/>
 		<jar destfile="${jar.dir}/buildcraft-A-${bc.version.full}.jar" basedir="${classes.dir}"/>
 
 	</target>
 
 	<!-- Default target to run -->
-	<target name="main" depends="initialize-version,download-files,clean,package"/>
+	<target name="main" depends="package"/>
 
 </project>


### PR DESCRIPTION
This makes building BC a two-step process:
- Clone repo
- Run `ant`

Now builds in 'build' directory inside the repo dir - prevents jenkins workspace messiness.  
No longer unnecessarily checks for updates to MCP if the file already exists - MCP doesn't appear to get silent updates, version number always changes.  
Only sets up forge+mcp if forge or MCP have updated, else merely recompiles and reobfuscates.  
Localisations are still in the parent directory - this should probably change in the future.  
Build number is now set to "unknown" when not set as an environment variable by jenkins/whatever. This helps prevent unofficial builds with the same filename as an official build from floating around.  
The commons lib is no longer downloaded - it does not seem to be necessary.

Signed-off-by: Ross Allan rallanpcl@gmail.com
