### PR TITLE
Bug report + fix: NullPointerException at [...](GuiRefinery.java:85)

### DIFF
--- a/common/buildcraft/factory/gui/GuiRefinery.java
+++ b/common/buildcraft/factory/gui/GuiRefinery.java
@@ -82,6 +82,10 @@ public class GuiRefinery extends GuiAdvancedInterface {
 		if (slot != null) {
 			LiquidStack liquid = LiquidContainerRegistry.getLiquidForFilledItem(mc.thePlayer.inventory.getItemStack());
 
+			if(liquid == null) {
+				return;
+			}
+
 			container.setFilter(position, liquid.itemID, liquid.itemMeta);
 		}
 	}


### PR DESCRIPTION
Steps to reproduce bug: click a refinery GUI input slot with either a non-LiquidContainer or with nothing.

Note that it would almost certainly be cleaner to just clear the slot instead, but that was getting non-trivial and not something I'd like to edit in a web interface.
