### PR TITLE
Change localization to allow mapping inheritance. 

### DIFF
--- a/common/buildcraft/core/utils/Localization.java
+++ b/common/buildcraft/core/utils/Localization.java
@@ -83,6 +83,21 @@ public class Localization {
 				modMappings.clear();
 				modMappings.load(langStream);
 			}
+
+			//If the selected language inherits mappings from another language
+			//we use those first and then we overwrite the common ones with
+			//those in the selected language
+			if (modMappings.containsKey("language.parent")) {
+				langStream = Localization.class.getResourceAsStream(path + modMappings.get("language.parent") + ".properties");
+
+				if (langStream != null) {
+					Properties parentModMappings = new Properties();
+
+					parentModMappings.load(langStream);
+					mappings.putAll(parentModMappings);
+				}
+			}
+
 			mappings.putAll(modMappings);
 
 		} catch (Exception e) {


### PR DESCRIPTION
Now a language like es_AR can use the mappings from a parent language (es_ES) instead of duplicating them, and only specify the ones that are different from the parent.

The child languages only need a field specifying the parent language e.g.:
language.parent=es_ES

Any mappings that are not specified in the file will be inherited from the father language.
