### PR TITLE
Fix AdvancedSlot rendering

### DIFF
--- a/common/buildcraft/core/gui/GuiAdvancedInterface.java
+++ b/common/buildcraft/core/gui/GuiAdvancedInterface.java
@@ -166,6 +166,7 @@ public abstract class GuiAdvancedInterface extends GuiBuildCraft {
 			int i2 = (mouseX - cornerX);
 			int k2 = mouseY - cornerY;
 			drawCreativeTabHoveringText(s, i2, k2);
+			RenderHelper.enableGUIStandardItemLighting();
 		}
 	}
 }


### PR DESCRIPTION
Fixes a bug where hovering over an AdvancedSlot would incorrectly render the held item:
<img src="http://i.imgur.com/2EBoX.png" alt="" title="Hosted by imgur.com" />
