### PR TITLE
Made pipes slightly harder to break

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
 	<property name="mcpsrc.dir"          value="${mcp.dir}/src/minecraft"/>
 
 	<property name="mcp.version"         value="723"/>
-	<property name="forge.version"       value="1.4.5-6.4.0.396"/>
+	<property name="forge.version"       value="1.4.5-6.4.1.408"/>
 	<property name="bc.version"          value="3.1.8"/>
 
 	<available property="forge-exists" file="${download.dir}/minecraftforge-src-${forge.version}.zip"/>

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -99,6 +99,7 @@ public class BuildCraftTransport {
 	public static boolean alwaysConnectPipes;
 	public static boolean usePipeLoss;
 	public static int maxItemsInPipes;
+	public static float pipeDuribility;
 
 	public static Item pipeWaterproof;
 	public static Item pipeGate;
@@ -218,6 +219,10 @@ public class BuildCraftTransport {
 			pipeLoss.comment = "Set to false to turn off energy loss over distance on all power pipes";
 			usePipeLoss = pipeLoss.getBoolean(DefaultProps.USE_PIPELOSS);
 
+			Property duribility = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "pipes.duribility", DefaultProps.PIPES_DURIBILITY);
+			duribility.comment = "How long a pipe will take to break";
+			pipeDuribility = (float)duribility.getDouble(DefaultProps.PIPES_DURIBILITY);
+			
 			Property exclusionItemList = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_BLOCK,"woodenPipe.item.exclusion", "");
 
 			String[] excludedItemBlocks = exclusionItemList.value.split(",");

--- a/common/buildcraft/core/DefaultProps.java
+++ b/common/buildcraft/core/DefaultProps.java
@@ -117,6 +117,7 @@ public class DefaultProps {
 
 	public static boolean CURRENT_CONTINUOUS = false;
 	public static boolean PIPES_ALWAYS_CONNECT = false;
+	public static double  PIPES_DURIBILITY = 0.25D;
 	public static boolean FILLER_DESTROY = false;
 	public static boolean USE_PIPELOSS = true;
 

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -51,6 +51,11 @@ public class BlockGenericPipe extends BlockContainer {
 	}
 
 	@Override
+	public float getBlockHardness(World par1World, int par2, int par3, int par4) {
+		return BuildCraftTransport.pipeDuribility;
+	}
+	
+	@Override
 	public int getRenderType() {
 		return TransportProxy.pipeModel;
 	}


### PR DESCRIPTION
Configuration option added
Also updated build.xml ( Required, previous forge version didn't have
double support in Configuration )

Sorry about the build.xml change, I know this is normally a lead dev job, but without it, BC would not build with this patch, I'd rather double support than dividing and multiplying an integer. 

This felt more elegant.

Note: All parts tested with latest forge, mcp and latest bc with this merged on top.
