### PR TITLE
Make RenderTank respect Block Metadata

### DIFF
--- a/common/buildcraft/factory/render/RenderTank.java
+++ b/common/buildcraft/factory/render/RenderTank.java
@@ -49,7 +49,7 @@ public class RenderTank extends TileEntitySpecialRenderer {
 
 		BlockInterface block = new BlockInterface();
 		if (liquidId < Block.blocksList.length && Block.blocksList[liquidId] != null)
-			block.texture = Block.blocksList[liquidId].blockIndexInTexture;
+			block.texture = Block.blocksList[liquidId].getBlockTextureFromSideAndMetadata(0, damage);
 		else if(Item.itemsList[liquidId] != null)
 			block.texture = Item.itemsList[liquidId].getIconFromDamage(damage);
 		else


### PR DESCRIPTION
Tested that it does not break existing functionality, I've no current way to test if it implements what it says it does unless I write a mod with multiple liquids that have metadata.

In theory it should work just fine, and it doesn't break existing liquids
http://i.imgur.com/qsfFE.png

Also as far as I can tell, there is no reason damage value item liquids should have issues.
I don't see how this code could fail:

if (x.containsKey(damage)){
   return x.get(damage);
}

Anyway, if someone could write a test to see if multi-color block liquids and item liquids render correctly, that would be great.
