### PR TITLE
Ant Build Issue with Forge Download (fixed)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -97,10 +97,7 @@
 			</classpath>
 		</taskdef>
 
-		<getMethod url="http://files.minecraftforge.net/minecraftforge-src-${forge.version}.zip"
-				   responseDataFile="${download.dir}/minecraftforge-src-${forge.version}.zip">
-			<header name="User-Agent" value="Ant-${ant.version}/${ant.java.version}"/>
-		</getMethod>
+		<get src="http://files.minecraftforge.net/minecraftforge-src-${forge.version}.zip" dest="${download.dir}" usetimestamp="True"/>
 
 	</target>
 


### PR DESCRIPTION
> [mr10movie](https://github.com/mr10movie) Issue 380:
> 
> > BUILD FAILED
> >     C:\Users\REDACTED\Desktop\Minecraft\compile\build.xml:101: Type getMethod: A class
> >     needed by class class net.sf.antcontrib.net.httpclient.GetMethodTask cannot be
> >     found: org/apache/commons/httpclient/params/HttpMethodParams
> 
> I also had this same issue when I downloaded the BuildCraft repo and typed "ant" into the command window in the buildcraft directory having ant installed.

OK, I fixed the commit malfunction so that the Github dif thing is working properly. The fix is still in the commit attached.
