### PR TITLE
Oil should use getTerrainBlock if it wants to stay under 256

### DIFF
--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -104,8 +104,8 @@ public class BuildCraftEnergy {
 	@PreInit
 	public void initialize(FMLPreInitializationEvent evt) {
 		Property engineId = BuildCraftCore.mainConfiguration.getBlock("engine.id", DefaultProps.ENGINE_ID);
-		Property oilStillId = BuildCraftCore.mainConfiguration.getBlock("oilStill.id", DefaultProps.OIL_STILL_ID);
-		Property oilMovingId = BuildCraftCore.mainConfiguration.getBlock("oilMoving.id", DefaultProps.OIL_MOVING_ID);
+		Property oilMovingId = BuildCraftCore.mainConfiguration.getTerrainBlock(Configuration.CATEGORY_BLOCK, "oilMoving.id", DefaultProps.OIL_MOVING_ID, "Oil is part of terrain generation and needs a block ID under 256");
+		Property oilStillId = BuildCraftCore.mainConfiguration.getTerrainBlock(Configuration.CATEGORY_BLOCK, "oilStill.id", DefaultProps.OIL_STILL_ID, "Still oil needs to be at oilMoving.id + 1");
 		Property bucketOilId = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_ITEM,"bucketOil.id", DefaultProps.BUCKET_OIL_ID);
 		Property bucketFuelId = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_ITEM,"bucketFuel.id", DefaultProps.BUCKET_FUEL_ID);
 		Property itemFuelId = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_ITEM,"fuel.id", DefaultProps.FUEL_ID);


### PR DESCRIPTION
It's used in terrain generation, therefore needs a block ID under 256 -- getBlock will erroneously assign it around 4095.

Well, honestly, I didn't actually look at the oil spawning code to check if it really absolutely needs to be under 256 -- I'm just trusting that Covert knew what he was doing when he left its block IDs down there when doing commit b4e7451ad188169f3bb850277efe64d7318b139a. If this was just an oversight, feel free to reject this pull request.
