### PR TITLE
Move getBlock and getItem stuff out of preInit

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -114,6 +114,60 @@ public class BuildCraftBuilders {
 
 	@Init
 	public void load(FMLInitializationEvent evt) {
+		Property templateItemId = BuildCraftCore.mainConfiguration.getItem("templateItem.id", DefaultProps.TEMPLATE_ITEM_ID);
+		Property blueprintItemId = BuildCraftCore.mainConfiguration.getItem("blueprintItem.id", DefaultProps.BLUEPRINT_ITEM_ID);
+		Property markerId = BuildCraftCore.mainConfiguration.getBlock("marker.id", DefaultProps.MARKER_ID);
+		Property pathMarkerId = BuildCraftCore.mainConfiguration.getBlock("pathMarker.id", DefaultProps.PATH_MARKER_ID);
+		Property fillerId = BuildCraftCore.mainConfiguration.getBlock("filler.id", DefaultProps.FILLER_ID);
+		Property builderId = BuildCraftCore.mainConfiguration.getBlock("builder.id", DefaultProps.BUILDER_ID);
+		Property architectId = BuildCraftCore.mainConfiguration.getBlock("architect.id", DefaultProps.ARCHITECT_ID);
+		Property libraryId = BuildCraftCore.mainConfiguration.getBlock("blueprintLibrary.id", DefaultProps.BLUEPRINT_LIBRARY_ID);
+
+		Property fillerDestroyProp = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_GENERAL,"filler.destroy", DefaultProps.FILLER_DESTROY);
+		fillerDestroyProp.comment = "If true, Filler will destroy blocks instead of breaking them.";
+		fillerDestroy = fillerDestroyProp.getBoolean(DefaultProps.FILLER_DESTROY);
+
+		templateItem = new ItemBptTemplate(Integer.parseInt(templateItemId.value));
+		templateItem.setItemName("templateItem");
+		LanguageRegistry.addName(templateItem, "Template");
+
+		blueprintItem = new ItemBptBluePrint(Integer.parseInt(blueprintItemId.value));
+		blueprintItem.setItemName("blueprintItem");
+		LanguageRegistry.addName(blueprintItem, "Blueprint");
+
+		markerBlock = new BlockMarker(Integer.parseInt(markerId.value));
+		CoreProxy.proxy.registerBlock(markerBlock.setBlockName("markerBlock"));
+		CoreProxy.proxy.addName(markerBlock, "Land Mark");
+
+		pathMarkerBlock = new BlockPathMarker(Integer.parseInt(pathMarkerId.value));
+		CoreProxy.proxy.registerBlock(pathMarkerBlock.setBlockName("pathMarkerBlock"));
+		CoreProxy.proxy.addName(pathMarkerBlock, "Path Mark");
+
+		fillerBlock = new BlockFiller(Integer.parseInt(fillerId.value));
+		CoreProxy.proxy.registerBlock(fillerBlock.setBlockName("fillerBlock"));
+		CoreProxy.proxy.addName(fillerBlock, "Filler");
+
+		builderBlock = new BlockBuilder(Integer.parseInt(builderId.value));
+		CoreProxy.proxy.registerBlock(builderBlock.setBlockName("builderBlock"));
+		CoreProxy.proxy.addName(builderBlock, "Builder");
+
+		architectBlock = new BlockArchitect(Integer.parseInt(architectId.value));
+		CoreProxy.proxy.registerBlock(architectBlock.setBlockName("architectBlock"));
+		CoreProxy.proxy.addName(architectBlock, "Architect Table");
+
+		libraryBlock = new BlockBlueprintLibrary(Integer.parseInt(libraryId.value));
+		CoreProxy.proxy.registerBlock(libraryBlock.setBlockName("libraryBlock"));
+		CoreProxy.proxy.addName(libraryBlock, "Blueprint Library");
+
+		GameRegistry.registerTileEntity(TileMarker.class, "Marker");
+		GameRegistry.registerTileEntity(TileFiller.class, "Filler");
+		GameRegistry.registerTileEntity(TileBuilder.class, "net.minecraft.src.builders.TileBuilder");
+		GameRegistry.registerTileEntity(TileArchitect.class, "net.minecraft.src.builders.TileTemplate");
+		GameRegistry.registerTileEntity(TilePathMarker.class, "net.minecraft.src.builders.TilePathMarker");
+		GameRegistry.registerTileEntity(TileBlueprintLibrary.class, "net.minecraft.src.builders.TileBlueprintLibrary");
+
+		BuildCraftCore.mainConfiguration.save();
+
 		// Create filler registry
 		FillerManager.registry = new FillerRegistry();
 
@@ -216,71 +270,6 @@ public class BuildCraftBuilders {
 			loadRecipes();
 		}
 
-	}
-
-	@PreInit
-	public void initialize(FMLPreInitializationEvent evt) {
-		Property templateItemId = BuildCraftCore.mainConfiguration.getItem("templateItem.id", DefaultProps.TEMPLATE_ITEM_ID);
-		Property blueprintItemId = BuildCraftCore.mainConfiguration.getItem("blueprintItem.id", DefaultProps.BLUEPRINT_ITEM_ID);
-		Property markerId = BuildCraftCore.mainConfiguration.getBlock("marker.id", DefaultProps.MARKER_ID);
-		Property pathMarkerId = BuildCraftCore.mainConfiguration.getBlock("pathMarker.id", DefaultProps.PATH_MARKER_ID);
-		Property fillerId = BuildCraftCore.mainConfiguration.getBlock("filler.id", DefaultProps.FILLER_ID);
-		Property builderId = BuildCraftCore.mainConfiguration.getBlock("builder.id", DefaultProps.BUILDER_ID);
-		Property architectId = BuildCraftCore.mainConfiguration.getBlock("architect.id", DefaultProps.ARCHITECT_ID);
-		Property libraryId = BuildCraftCore.mainConfiguration.getBlock("blueprintLibrary.id", DefaultProps.BLUEPRINT_LIBRARY_ID);
-
-		Property fillerDestroyProp = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_GENERAL,"filler.destroy", DefaultProps.FILLER_DESTROY);
-		fillerDestroyProp.comment = "If true, Filler will destroy blocks instead of breaking them.";
-		fillerDestroy = fillerDestroyProp.getBoolean(DefaultProps.FILLER_DESTROY);
-
-		templateItem = new ItemBptTemplate(Integer.parseInt(templateItemId.value));
-		templateItem.setItemName("templateItem");
-		LanguageRegistry.addName(templateItem, "Template");
-
-		blueprintItem = new ItemBptBluePrint(Integer.parseInt(blueprintItemId.value));
-		blueprintItem.setItemName("blueprintItem");
-		LanguageRegistry.addName(blueprintItem, "Blueprint");
-
-		markerBlock = new BlockMarker(Integer.parseInt(markerId.value));
-		CoreProxy.proxy.registerBlock(markerBlock.setBlockName("markerBlock"));
-		CoreProxy.proxy.addName(markerBlock, "Land Mark");
-
-		pathMarkerBlock = new BlockPathMarker(Integer.parseInt(pathMarkerId.value));
-		CoreProxy.proxy.registerBlock(pathMarkerBlock.setBlockName("pathMarkerBlock"));
-		CoreProxy.proxy.addName(pathMarkerBlock, "Path Mark");
-
-		fillerBlock = new BlockFiller(Integer.parseInt(fillerId.value));
-		CoreProxy.proxy.registerBlock(fillerBlock.setBlockName("fillerBlock"));
-		CoreProxy.proxy.addName(fillerBlock, "Filler");
-
-		builderBlock = new BlockBuilder(Integer.parseInt(builderId.value));
-		CoreProxy.proxy.registerBlock(builderBlock.setBlockName("builderBlock"));
-		CoreProxy.proxy.addName(builderBlock, "Builder");
-
-		architectBlock = new BlockArchitect(Integer.parseInt(architectId.value));
-		CoreProxy.proxy.registerBlock(architectBlock.setBlockName("architectBlock"));
-		CoreProxy.proxy.addName(architectBlock, "Architect Table");
-
-		libraryBlock = new BlockBlueprintLibrary(Integer.parseInt(libraryId.value));
-		CoreProxy.proxy.registerBlock(libraryBlock.setBlockName("libraryBlock"));
-		CoreProxy.proxy.addName(libraryBlock, "Blueprint Library");
-
-		GameRegistry.registerTileEntity(TileMarker.class, "Marker");
-		GameRegistry.registerTileEntity(TileFiller.class, "Filler");
-		GameRegistry.registerTileEntity(TileBuilder.class, "net.minecraft.src.builders.TileBuilder");
-		GameRegistry.registerTileEntity(TileArchitect.class, "net.minecraft.src.builders.TileTemplate");
-		GameRegistry.registerTileEntity(TilePathMarker.class, "net.minecraft.src.builders.TilePathMarker");
-		GameRegistry.registerTileEntity(TileBlueprintLibrary.class, "net.minecraft.src.builders.TileBlueprintLibrary");
-
-		BuildCraftCore.mainConfiguration.save();
-
-		// public static final Block music;
-		// public static final Block cloth;
-		// public static final Block tilledField;
-		// public static final BlockPortal portal;
-		// public static final Block trapdoor;
-
-		// STANDARD BLOCKS
 	}
 
 	public static void loadRecipes() {

--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -144,8 +144,7 @@ public class BuildCraftCore {
 	public static BuildCraftCore instance;
 
 	@PreInit
-	public void loadConfiguration(FMLPreInitializationEvent evt) {
-
+	public void preInit(FMLPreInitializationEvent evt) {
 		Version.versionCheck();
 
 		bcLog.setParent(FMLLog.getLogger());
@@ -154,6 +153,9 @@ public class BuildCraftCore {
 		bcLog.info("http://www.mod-buildcraft.com");
 
 		mainConfiguration = new BuildCraftConfiguration(new File(evt.getModConfigurationDirectory(), "buildcraft/main.conf"));
+	}
+
+	public void loadConfiguration() {
 		try
 		{
 			mainConfiguration.load();
@@ -236,6 +238,8 @@ public class BuildCraftCore {
 
 	@Init
 	public void initialize(FMLInitializationEvent evt) {
+		loadConfiguration();
+
 		//MinecraftForge.registerConnectionHandler(new ConnectionHandler());
 		ActionManager.registerTriggerProvider(new DefaultTriggerProvider());
 		ActionManager.registerActionProvider(new DefaultActionProvider());

--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -87,22 +87,6 @@ public class BuildCraftEnergy {
 
 	@Init
 	public static void load(FMLInitializationEvent evt) {
-		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
-		GameRegistry.registerWorldGenerator(new OilPopulate());
-
-		new BptBlockEngine(engineBlock.blockID);
-
-		if (BuildCraftCore.loadDefaultRecipes)
-		{
-			loadRecipes();
-		}
-		EnergyProxy.proxy.registerBlockRenderers();
-		EnergyProxy.proxy.registerTileEntities();
-		EnergyProxy.proxy.registerTextureFX();
-	}
-
-	@PreInit
-	public void initialize(FMLPreInitializationEvent evt) {
 		Property engineId = BuildCraftCore.mainConfiguration.getBlock("engine.id", DefaultProps.ENGINE_ID);
 		Property oilStillId = BuildCraftCore.mainConfiguration.getBlock("oilStill.id", DefaultProps.OIL_STILL_ID);
 		Property oilMovingId = BuildCraftCore.mainConfiguration.getBlock("oilMoving.id", DefaultProps.OIL_MOVING_ID);
@@ -157,6 +141,19 @@ public class BuildCraftEnergy {
 
 		LiquidContainerRegistry.registerLiquid(new LiquidContainerData(new LiquidStack(oilStill, LiquidContainerRegistry.BUCKET_VOLUME), new ItemStack(bucketOil), new ItemStack(Item.bucketEmpty)));
 		LiquidContainerRegistry.registerLiquid(new LiquidContainerData(new LiquidStack(fuel, LiquidContainerRegistry.BUCKET_VOLUME), new ItemStack(bucketFuel), new ItemStack(Item.bucketEmpty)));
+
+		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
+		GameRegistry.registerWorldGenerator(new OilPopulate());
+
+		new BptBlockEngine(engineBlock.blockID);
+
+		if (BuildCraftCore.loadDefaultRecipes)
+		{
+			loadRecipes();
+		}
+		EnergyProxy.proxy.registerBlockRenderers();
+		EnergyProxy.proxy.registerTileEntities();
+		EnergyProxy.proxy.registerTextureFX();
 	}
 
 	public static void loadRecipes() {

--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -121,36 +121,6 @@ public class BuildCraftFactory {
 	}
 	@Init
 	public void load(FMLInitializationEvent evt) {
-		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
-
-//		EntityRegistry.registerModEntity(EntityMechanicalArm.class, "bcMechanicalArm", EntityIds.MECHANICAL_ARM, instance, 50, 1, true);
-
-		CoreProxy.proxy.registerTileEntity(TileQuarry.class, "Machine");
-		CoreProxy.proxy.registerTileEntity(TileMiningWell.class, "MiningWell");
-		CoreProxy.proxy.registerTileEntity(TileAutoWorkbench.class, "AutoWorkbench");
-		CoreProxy.proxy.registerTileEntity(TilePump.class, "net.minecraft.src.buildcraft.factory.TilePump");
-		CoreProxy.proxy.registerTileEntity(TileTank.class, "net.minecraft.src.buildcraft.factory.TileTank");
-		CoreProxy.proxy.registerTileEntity(TileRefinery.class, "net.minecraft.src.buildcraft.factory.Refinery");
-
-		if (!hopperDisabled) {
-			CoreProxy.proxy.registerTileEntity(TileHopper.class, "net.minecraft.src.buildcraft.factory.TileHopper");
-		}
-
-		FactoryProxy.proxy.initializeTileEntities();
-		FactoryProxy.proxy.initializeEntityRenders();
-		drillTexture = 2 * 16 + 1;
-
-		new BptBlockAutoWorkbench(autoWorkbenchBlock.blockID);
-		new BptBlockFrame(frameBlock.blockID);
-		new BptBlockRefinery(refineryBlock.blockID);
-		new BptBlockTank(tankBlock.blockID);
-
-		if (BuildCraftCore.loadDefaultRecipes)
-			loadRecipes();
-	}
-
-	@PreInit
-	public void initialize(FMLPreInitializationEvent evt) {
 		allowMining = Boolean.parseBoolean(BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_GENERAL,"mining.enabled", true).value);
 
 		Property minigWellId = BuildCraftCore.mainConfiguration.getBlock("miningWell.id", DefaultProps.MINING_WELL_ID);
@@ -206,6 +176,33 @@ public class BuildCraftFactory {
 		}
 
 		BuildCraftCore.mainConfiguration.save();
+
+		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
+
+//		EntityRegistry.registerModEntity(EntityMechanicalArm.class, "bcMechanicalArm", EntityIds.MECHANICAL_ARM, instance, 50, 1, true);
+
+		CoreProxy.proxy.registerTileEntity(TileQuarry.class, "Machine");
+		CoreProxy.proxy.registerTileEntity(TileMiningWell.class, "MiningWell");
+		CoreProxy.proxy.registerTileEntity(TileAutoWorkbench.class, "AutoWorkbench");
+		CoreProxy.proxy.registerTileEntity(TilePump.class, "net.minecraft.src.buildcraft.factory.TilePump");
+		CoreProxy.proxy.registerTileEntity(TileTank.class, "net.minecraft.src.buildcraft.factory.TileTank");
+		CoreProxy.proxy.registerTileEntity(TileRefinery.class, "net.minecraft.src.buildcraft.factory.Refinery");
+
+		if (!hopperDisabled) {
+			CoreProxy.proxy.registerTileEntity(TileHopper.class, "net.minecraft.src.buildcraft.factory.TileHopper");
+		}
+
+		FactoryProxy.proxy.initializeTileEntities();
+		FactoryProxy.proxy.initializeEntityRenders();
+		drillTexture = 2 * 16 + 1;
+
+		new BptBlockAutoWorkbench(autoWorkbenchBlock.blockID);
+		new BptBlockFrame(frameBlock.blockID);
+		new BptBlockRefinery(refineryBlock.blockID);
+		new BptBlockTank(tankBlock.blockID);
+
+		if (BuildCraftCore.loadDefaultRecipes)
+			loadRecipes();
 	}
 
 	public static void loadRecipes() {

--- a/common/buildcraft/BuildCraftSilicon.java
+++ b/common/buildcraft/BuildCraftSilicon.java
@@ -52,22 +52,6 @@ public class BuildCraftSilicon {
 
 	@Init
 	public void load(FMLInitializationEvent evt) {
-		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
-		CoreProxy.proxy.registerTileEntity(TileLaser.class, "net.minecraft.src.buildcraft.factory.TileLaser");
-		CoreProxy.proxy.registerTileEntity(TileAssemblyTable.class, "net.minecraft.src.buildcraft.factory.TileAssemblyTable");
-		CoreProxy.proxy.registerTileEntity(TileAssemblyAdvancedWorkbench.class, "net.minecraft.src.buildcraft.factory.TileAssemblyAdvancedWorkbench");
-
-		new BptBlockRotateMeta(laserBlock.blockID, new int[] { 2, 5, 3, 4 }, true);
-		new BptBlockInventory(assemblyTableBlock.blockID);
-
-		if (BuildCraftCore.loadDefaultRecipes)
-			loadRecipes();
-
-		SiliconProxy.proxy.registerRenderers();
-	}
-
-	@PreInit
-	public void initialize(FMLPreInitializationEvent evt) {
 		Property laserId = BuildCraftCore.mainConfiguration.getBlock("laser.id", DefaultProps.LASER_ID);
 
 		Property assemblyTableId = BuildCraftCore.mainConfiguration.getBlock("assemblyTable.id", DefaultProps.ASSEMBLY_TABLE_ID);
@@ -89,6 +73,18 @@ public class BuildCraftSilicon {
 		redstoneChipset = new ItemRedstoneChipset(Integer.parseInt(redstoneChipsetId.value));
 		redstoneChipset.setItemName("redstoneChipset");
 
+		NetworkRegistry.instance().registerGuiHandler(instance, new GuiHandler());
+		CoreProxy.proxy.registerTileEntity(TileLaser.class, "net.minecraft.src.buildcraft.factory.TileLaser");
+		CoreProxy.proxy.registerTileEntity(TileAssemblyTable.class, "net.minecraft.src.buildcraft.factory.TileAssemblyTable");
+		CoreProxy.proxy.registerTileEntity(TileAssemblyAdvancedWorkbench.class, "net.minecraft.src.buildcraft.factory.TileAssemblyAdvancedWorkbench");
+
+		new BptBlockRotateMeta(laserBlock.blockID, new int[] { 2, 5, 3, 4 }, true);
+		new BptBlockInventory(assemblyTableBlock.blockID);
+
+		if (BuildCraftCore.loadDefaultRecipes)
+			loadRecipes();
+
+		SiliconProxy.proxy.registerRenderers();
 	}
 
 	public static void loadRecipes() {

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -206,9 +206,8 @@ public class BuildCraftTransport {
 
 	private static LinkedList<PipeRecipe> pipeRecipes = new LinkedList<PipeRecipe>();
 
-	@PreInit
-	public void preInitialize(FMLPreInitializationEvent evt)
-	{
+	@Init
+	public void load(FMLInitializationEvent evt) {
 		try
 		{
 			Property alwaysConnect = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_GENERAL,"pipes.alwaysConnect", DefaultProps.PIPES_ALWAYS_CONNECT);
@@ -222,7 +221,7 @@ public class BuildCraftTransport {
 			Property durability = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "pipes.durability", DefaultProps.PIPES_DURABILITY);
 			durability.comment = "How long a pipe will take to break";
 			pipeDurability = (float)durability.getDouble(DefaultProps.PIPES_DURABILITY);
-			
+
 			Property exclusionItemList = BuildCraftCore.mainConfiguration.get( Configuration.CATEGORY_BLOCK,"woodenPipe.item.exclusion", "");
 
 			String[] excludedItemBlocks = exclusionItemList.value.split(",");
@@ -305,10 +304,7 @@ public class BuildCraftTransport {
 		{
 			BuildCraftCore.mainConfiguration.save();
 		}
-	}
 
-	@Init
-	public void load(FMLInitializationEvent evt) {
 		// Register connection handler
 		//MinecraftForge.registerConnectionHandler(new ConnectionHandler());
 


### PR DESCRIPTION
So, I expect this to be a somewhat controversial pull request, as I moved a lot of stuff around under the hood. [According to GregoriusT in the IC2 forum](http://forum.industrial-craft.net/index.php?page=Thread&postID=88959#post88959), initializing blocks and items in @PreInit is a bad idea.

However, given how tightly interwoven reading the config values and initializing the blocks are in Buildcraft, the change I've made just moves _both_ to the @Init phase. This has worked reasonably well for me (by which I mean, it hasn't managed to crash unexpectedly), but more knowledgeable heads than I should take a look at the change and make or suggest improvements.
