### PR TITLE
Pipes should not use metadata.

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsIron.java
+++ b/common/buildcraft/transport/pipes/PipeItemsIron.java
@@ -34,9 +34,7 @@ public class PipeItemsIron extends Pipe {
 		if (direction == ForgeDirection.UNKNOWN)
 			return baseTexture;
 		else {
-			int metadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-			if (metadata == direction.ordinal())
+			if (((PipeLogicIron) logic).direction == direction)
 				return baseTexture;
 			else
 				return plainTexture;

--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -57,9 +57,7 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 		if (direction == ForgeDirection.UNKNOWN)
 			return baseTexture;
 		else {
-			int metadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-			if (metadata == direction.ordinal())
+			if (((PipeLogicWood) logic).direction == direction)
 				return plainTexture;
 			else
 				return baseTexture;
@@ -81,24 +79,19 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 		if (powerProvider.getEnergyStored() <= 0)
 			return;
 
-		World w = worldObj;
-
-		int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-		if (meta > 5)
+		ForgeDirection direction = ((PipeLogicWood) logic).direction;
+		if (direction == ForgeDirection.UNKNOWN)
 			return;
 
-		Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.values()[meta]);
-		pos.moveForwards(1);
-		TileEntity tile = w.getBlockTileEntity((int) pos.x, (int) pos.y, (int) pos.z);
+		TileEntity tile = container.getTile(direction);
 
 		if (tile instanceof IInventory) {
-         if (!PipeManager.canExtractItems(this, w, (int) pos.x, (int) pos.y, (int) pos.z))
+         if (!PipeManager.canExtractItems(this, worldObj, tile.xCoord, tile.yCoord, tile.zCoord))
             return;
 
          IInventory inventory = (IInventory) tile;
 
-         ItemStack[] extracted = checkExtract(inventory, true, pos.orientation.getOpposite());
+         ItemStack[] extracted = checkExtract(inventory, true, direction.getOpposite());
          if (extracted == null)
             return;
 
@@ -108,13 +101,10 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
                   continue;
             }
 
-            Position entityPos = new Position(pos.x + 0.5, pos.y + Utils.getPipeFloorOf(stack), pos.z + 0.5,
-                  pos.orientation.getOpposite());
-
+            Position entityPos = new Position(tile.xCoord + 0.5, tile.yCoord + Utils.getPipeFloorOf(stack), tile.zCoord + 0.5,
+                  direction.getOpposite());
             entityPos.moveForwards(0.5);
-
-            IPipedItem entity = new EntityPassiveItem(w, entityPos.x, entityPos.y, entityPos.z, stack);
-
+            IPipedItem entity = new EntityPassiveItem(worldObj, entityPos.x, entityPos.y, entityPos.z, stack);
             ((PipeTransportItems) transport).entityEntering(entity, entityPos.orientation);
          }
       }
@@ -126,10 +116,9 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 	 * on the position of the pipe.
 	 */
 	public ItemStack[] checkExtract(IInventory inventory, boolean doRemove, ForgeDirection from) {
-
 		/// ISPECIALINVENTORY
 		if (inventory instanceof ISpecialInventory) {
-			ItemStack[] stacks = ((ISpecialInventory) inventory).extractItem(doRemove, from, (int)powerProvider.getEnergyStored());
+			ItemStack[] stacks = ((ISpecialInventory) inventory).extractItem(doRemove, from, (int) powerProvider.getEnergyStored());
 			if (stacks != null && doRemove) {
 				for (ItemStack stack : stacks) {
 					if (stack != null) {
@@ -154,7 +143,6 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 				return new ItemStack[] { result };
 		} else if (inventory.getSizeInventory() == 2) {
 			// This is an input-output inventory
-
 			int slotIndex = 0;
 
 			if (from == ForgeDirection.DOWN || from == ForgeDirection.UP)
@@ -171,7 +159,6 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 					return new ItemStack[] { slot };
 		} else if (inventory.getSizeInventory() == 3) {
 			// This is a furnace-like inventory
-
 			int slotIndex = 0;
 
 			if (from == ForgeDirection.UP)
@@ -204,7 +191,6 @@ public class PipeItemsWood extends Pipe implements IPowerReceptor {
 	public ItemStack checkExtractGeneric(IInventory inventory, boolean doRemove, ForgeDirection from, int start, int stop) {
 		for (int k = start; k <= stop; ++k)
 			if (inventory.getStackInSlot(k) != null && inventory.getStackInSlot(k).stackSize > 0) {
-
 				ItemStack slot = inventory.getStackInSlot(k);
 
 				if (slot != null && slot.stackSize > 0)

--- a/common/buildcraft/transport/pipes/PipeLiquidsIron.java
+++ b/common/buildcraft/transport/pipes/PipeLiquidsIron.java
@@ -32,9 +32,7 @@ public class PipeLiquidsIron extends Pipe {
 		if (direction == ForgeDirection.UNKNOWN)
 			return baseTexture;
 		else {
-			int metadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-			if (metadata == direction.ordinal())
+			if (((PipeLogicIron) logic).direction == direction)
 				return baseTexture;
 			else
 				return plainTexture;

--- a/common/buildcraft/transport/pipes/PipeLiquidsWood.java
+++ b/common/buildcraft/transport/pipes/PipeLiquidsWood.java
@@ -53,19 +53,14 @@ public class PipeLiquidsWood extends Pipe implements IPowerReceptor {
 		if (powerProvider.getEnergyStored() <= 0)
 			return;
 
-		World w = worldObj;
-
-		int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-		if (meta > 5)
+		ForgeDirection direction = ((PipeLogicWood) logic).direction;
+		if (direction == ForgeDirection.UNKNOWN)
 			return;
 
-		Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.values()[meta]);
-		pos.moveForwards(1);
-		TileEntity tile = w.getBlockTileEntity((int) pos.x, (int) pos.y, (int) pos.z);
+		TileEntity tile = container.getTile(direction);
 
 		if (tile instanceof ITankContainer) {
-         if (!PipeManager.canExtractLiquids(this, w, (int) pos.x, (int) pos.y, (int) pos.z))
+         if (!PipeManager.canExtractLiquids(this, worldObj, tile.xCoord, tile.yCoord, tile.zCoord))
             return;
 
          if (liquidToExtract <= LiquidContainerRegistry.BUCKET_VOLUME)
@@ -87,26 +82,20 @@ public class PipeLiquidsWood extends Pipe implements IPowerReceptor {
 	public void updateEntity() {
 		super.updateEntity();
 
-		int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-		if (liquidToExtract > 0 && meta < 6) {
-			Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.values()[meta]);
-			pos.moveForwards(1);
-
-			TileEntity tile = worldObj.getBlockTileEntity((int) pos.x, (int) pos.y, (int) pos.z);
+		ForgeDirection direction = ((PipeLogicWood) logic).direction;
+		if (liquidToExtract > 0 && direction != ForgeDirection.UNKNOWN) {
+			TileEntity tile = container.getTile(direction);
 
 			if (tile instanceof ITankContainer) {
 				ITankContainer container = (ITankContainer) tile;
-
 				int flowRate = ((PipeTransportLiquids) transport).flowRate;
-
-				LiquidStack extracted = container.drain(pos.orientation.getOpposite(), liquidToExtract > flowRate ? flowRate : liquidToExtract, false);
-
+				LiquidStack extracted = container.drain(direction.getOpposite(), liquidToExtract > flowRate ? flowRate : liquidToExtract, false);
                 int inserted = 0;
-                if(extracted != null) {
-                    inserted = ((PipeTransportLiquids) transport).fill(pos.orientation, extracted, true);
 
-                    container.drain(pos.orientation.getOpposite(), inserted, true);
+                if(extracted != null) {
+                    inserted = ((PipeTransportLiquids) transport).fill(direction, extracted, true);
+
+                    container.drain(direction.getOpposite(), inserted, true);
                 }
 
 				liquidToExtract -= inserted;
@@ -124,13 +113,12 @@ public class PipeLiquidsWood extends Pipe implements IPowerReceptor {
 		if (direction == ForgeDirection.UNKNOWN)
 			return baseTexture;
 		else {
-			int metadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-			if (metadata == direction.ordinal())
+			if (((PipeLogicWood) logic).direction == direction)
 				return plainTexture;
 			else
 				return baseTexture;
-		}	}
+		}
+	}
 
 
 	@Override

--- a/common/buildcraft/transport/pipes/PipePowerWood.java
+++ b/common/buildcraft/transport/pipes/PipePowerWood.java
@@ -48,9 +48,7 @@ public class PipePowerWood extends Pipe implements IPowerReceptor {
 		if (direction == ForgeDirection.UNKNOWN)
 			return baseTexture;
 		else {
-			int metadata = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
-
-			if (metadata == direction.ordinal())
+			if (((PipeLogicWood) logic).direction == direction)
 				return plainTexture;
 			else
 				return baseTexture;
@@ -59,7 +57,7 @@ public class PipePowerWood extends Pipe implements IPowerReceptor {
 
 	@Override
 	public void setPowerProvider(IPowerProvider provider) {
-		provider = powerProvider;
+		powerProvider = provider;
 	}
 
 	@Override


### PR DESCRIPTION
Worl.setBlockMetadata(Chunk.setBlockIDWithMetadata) recreates TileEntity.
It causes that items in pipe disappear from the screen.
