### PR TITLE
Fix some NPEs on TileEngine when it has not be initialized

### DIFF
--- a/common/buildcraft/energy/TileEngine.java
+++ b/common/buildcraft/energy/TileEngine.java
@@ -425,7 +425,7 @@ public class TileEngine extends TileBuildCraft implements IPowerReceptor, IInven
 
 	@Override
 	public boolean isPipeConnected(ForgeDirection with) {
-		if (engine != null && engine instanceof EngineWood) {
+		if (engine instanceof EngineWood) {
 			return false;
 		}
 


### PR DESCRIPTION
When I added a Redstone Engine to a running pump I got this error.
It is caused by the engine instance not existing at the time of call, due to the engine not being fully initialized.

Stacktrace:
    at buildcraft.energy.TileEngine.fill(TileEngine.java:447)
    at buildcraft.factory.TilePump.g(TilePump.java:134)

The real error is TileEngine, not the pump. It didn't check for engine being null in a few spots that I saw with quick glance.
