### PR TITLE
API change request: add a way to query for refinery recipes.

### DIFF
--- a/common/buildcraft/api/recipes/RefineryRecipe.java
+++ b/common/buildcraft/api/recipes/RefineryRecipe.java
@@ -12,6 +12,8 @@ package buildcraft.api.recipes;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import com.google.common.collect.ImmutableSortedSet;
+
 import net.minecraftforge.liquids.LiquidStack;
 
 public class RefineryRecipe implements Comparable<RefineryRecipe> {
@@ -22,6 +24,10 @@ public class RefineryRecipe implements Comparable<RefineryRecipe> {
 		if (!recipes.contains(recipe)) {
 			recipes.add(recipe);
 		}
+	}
+
+	public static SortedSet<RefineryRecipe> getRecipes() {
+		return ImmutableSortedSet.copyof(recipes);
 	}
 
 	public static RefineryRecipe findRefineryRecipe(LiquidStack liquid1, LiquidStack liquid2) {


### PR DESCRIPTION
Since my LiquidUU mod adds a few refinery recipes (among other things), one of my users has asked for an NEI plugin and noted there's no way to ask for a current list of the recipes -- so here's a possible implementation for that. It's a fairly trivial change, just calls out to Guava's ImmutableSortedSet to provide a copy of RefineryRecipe.recipes.

Unfortunately, I don't have an MCP environment with a new enough Forge set up to test it, so I might've missed an import (though I hope not). Feel free to reject this pull request and make the change properly, if it seems it should work in a different way.
