### PR TITLE
API change: query for refinery recipes, now with Collections.unmodifiableSortedSet

### DIFF
--- a/common/buildcraft/api/recipes/RefineryRecipe.java
+++ b/common/buildcraft/api/recipes/RefineryRecipe.java
@@ -9,6 +9,7 @@
 
 package buildcraft.api.recipes;
 
+import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -22,6 +23,10 @@ public class RefineryRecipe implements Comparable<RefineryRecipe> {
 		if (!recipes.contains(recipe)) {
 			recipes.add(recipe);
 		}
+	}
+
+	public static SortedSet<RefineryRecipe> getRecipes() {
+		return Collections.unmodifiableSortedSet(recipes);
 	}
 
 	public static RefineryRecipe findRefineryRecipe(LiquidStack liquid1, LiquidStack liquid2) {


### PR DESCRIPTION
As per discussion in #516, resubmitting with java.util.Collections instead of the guava libraries.
