### PR TITLE
Filler Flatten only reaching 128

### DIFF
--- a/common/buildcraft/builders/FillerFlattener.java
+++ b/common/buildcraft/builders/FillerFlattener.java
@@ -73,7 +73,7 @@ public class FillerFlattener extends FillerPattern {
 		if (lastX != Integer.MAX_VALUE)
 			return false;
 
-		return !empty(xMin, yMin, zMin, xMax, 64 * 2, zMax, tile.worldObj);
+		return !empty(xMin, yMin, zMin, xMax, 64 * 4, zMax, tile.worldObj);
 	}
 
 	@Override


### PR DESCRIPTION
Now goes to the full 256 instead of 128.
This helps greatly with instances where ExtraBiomesXL is installed as it's ground on certain biomes is level 128
