### PR TITLE
Allow patterns to decide how much power to use.

### DIFF
--- a/common/buildcraft/api/filler/IFillerPattern.java
+++ b/common/buildcraft/api/filler/IFillerPattern.java
@@ -3,6 +3,7 @@ package buildcraft.api.filler;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 
 public interface IFillerPattern {
 
@@ -10,7 +11,9 @@ public interface IFillerPattern {
 
 	public void setId(int id);
 
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace);
+	public float expectedPowerUse();
+
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power);
 
 	public String getTextureFile();
 

--- a/common/buildcraft/builders/FillerFillAll.java
+++ b/common/buildcraft/builders/FillerFillAll.java
@@ -12,12 +12,13 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 
 public class FillerFillAll extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace,IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -26,7 +27,7 @@ public class FillerFillAll extends FillerPattern {
 		int yMax = (int) box.pMax().y;
 		int zMax = (int) box.pMax().z;
 
-		return !fill(xMin, yMin, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj);
+		return fill(xMin, yMin, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj, power);
 	}
 
 	@Override

--- a/common/buildcraft/builders/FillerFillPyramid.java
+++ b/common/buildcraft/builders/FillerFillPyramid.java
@@ -12,12 +12,13 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 
 public class FillerFillPyramid extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -33,6 +34,8 @@ public class FillerFillPyramid extends FillerPattern {
 		int height;
 
 		int stepY;
+		
+		float powerUsed = -1;
 
 		if (tile.yCoord <= yMin) {
 			stepY = 1;
@@ -47,14 +50,15 @@ public class FillerFillPyramid extends FillerPattern {
 		}
 
 		while (step <= xSize / 2 && step <= zSize / 2 && height >= yMin && height <= yMax) {
-			if (fill(xMin + step, height, zMin + step, xMax - step, height, zMax - step, stackToPlace, tile.worldObj))
-				return false;
+			powerUsed = fill(xMin + step, height, zMin + step, xMax - step, height, zMax - step, stackToPlace, tile.worldObj, power);
+			if (powerUsed>=0)
+				return powerUsed;
 
 			step++;
 			height += stepY;
 		}
 
-		return true;
+		return powerUsed;
 	}
 
 	@Override

--- a/common/buildcraft/builders/FillerFillStairs.java
+++ b/common/buildcraft/builders/FillerFillStairs.java
@@ -12,12 +12,13 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 
 public class FillerFillStairs extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -33,6 +34,8 @@ public class FillerFillStairs extends FillerPattern {
 		int heightStep;
 		int dimX = 0;
 		int dimZ = 0;
+
+		float powerUsed = -1;
 
 		if (tile.yCoord <= yMin) {
 			height = yMin;
@@ -120,8 +123,9 @@ public class FillerFillStairs extends FillerPattern {
 		if (kind == 0) {
 			while (x2 - x1 + 1 > 0 && z2 - z1 + 1 > 0 && x2 - x1 < sizeX && z2 - z1 < sizeZ && height >= yMin && height <= yMax) {
 
-				if (fill(x1, height, z1, x2, height, z2, stackToPlace, tile.worldObj))
-					return false;
+				powerUsed = fill(x1, height, z1, x2, height, z2, stackToPlace, tile.worldObj, power);
+				if(powerUsed>=0)
+					return powerUsed;
 
 				if (heightStep == 1) {
 					x1 += steps[0];
@@ -175,8 +179,9 @@ public class FillerFillStairs extends FillerPattern {
 
 				}
 
-				if (fill(x1, height, z1, x2, height, z2, stackToPlace, tile.worldObj))
-					return false;
+				powerUsed = fill(x1, height, z1, x2, height, z2, stackToPlace, tile.worldObj, power);
+				if (powerUsed >=0)
+					return powerUsed;
 
 				dimX += stepDiagX;
 				dimZ += stepDiagZ;
@@ -185,7 +190,7 @@ public class FillerFillStairs extends FillerPattern {
 			}
 		}
 
-		return true;
+		return powerUsed;
 	}
 
 	@Override

--- a/common/buildcraft/builders/FillerFillWalls.java
+++ b/common/buildcraft/builders/FillerFillWalls.java
@@ -12,12 +12,13 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 
 public class FillerFillWalls extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -26,25 +27,23 @@ public class FillerFillWalls extends FillerPattern {
 		int yMax = (int) box.pMax().y;
 		int zMax = (int) box.pMax().z;
 
-		if (fill(xMin, yMin, zMin, xMax, yMin, zMax, stackToPlace, tile.worldObj))
-			return false;
+		float powerUsed = fill(xMin, yMin, zMin, xMax, yMin, zMax, stackToPlace, tile.worldObj, power);
+		if (powerUsed>=0)
+			return powerUsed;
 
-		if (fill(xMin, yMin, zMin, xMin, yMax, zMax, stackToPlace, tile.worldObj))
-			return false;
-
-		if (fill(xMin, yMin, zMin, xMax, yMax, zMin, stackToPlace, tile.worldObj))
-			return false;
-
-		if (fill(xMax, yMin, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj))
-			return false;
-
-		if (fill(xMin, yMin, zMax, xMax, yMax, zMax, stackToPlace, tile.worldObj))
-			return false;
-
-		if (fill(xMin, yMax, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj))
-			return false;
-
-		return true;
+		powerUsed = fill(xMin, yMin, zMin, xMin, yMax, zMax, stackToPlace, tile.worldObj, power);
+		if (powerUsed>=0)
+			return powerUsed;
+		powerUsed = fill(xMin, yMin, zMin, xMax, yMax, zMin, stackToPlace, tile.worldObj, power);
+		if (powerUsed>=0)
+			return powerUsed;
+		powerUsed = fill(xMax, yMin, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj, power);
+		if (powerUsed>=0)
+			return powerUsed;
+		powerUsed = fill(xMin, yMin, zMax, xMax, yMax, zMax, stackToPlace, tile.worldObj, power);
+		if (powerUsed>=0)
+			return powerUsed;
+		return fill(xMin, yMax, zMin, xMax, yMax, zMax, stackToPlace, tile.worldObj, power);
 	}
 
 	@Override

--- a/common/buildcraft/builders/FillerFlattener.java
+++ b/common/buildcraft/builders/FillerFlattener.java
@@ -12,6 +12,7 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.proxy.CoreProxy;
 import buildcraft.core.utils.BlockUtil;
@@ -19,7 +20,7 @@ import buildcraft.core.utils.BlockUtil;
 public class FillerFlattener extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -46,7 +47,7 @@ public class FillerFlattener extends FillerPattern {
 			for (int x = xMin; x <= xMax; ++x) {
 				for (int z = zMin; z <= zMax; ++z) {
 					if (!BlockUtil.canChangeBlock(tile.worldObj, x, y, z))
-						return true;
+						return -1;
 					if (!blockedColumns[x - xMin][z - zMin]) {
 						if (!BlockUtil.isSoftBlock(tile.worldObj, x, y, z)) {
 							blockedColumns[x - xMin][z - zMin] = true;
@@ -71,9 +72,9 @@ public class FillerFlattener extends FillerPattern {
 		}
 
 		if (lastX != Integer.MAX_VALUE)
-			return false;
+			return -1;
 
-		return !empty(xMin, yMin, zMin, xMax, 64 * 4, zMax, tile.worldObj);
+		return empty(xMin, yMin, zMin, xMax, 64 * 2, zMax, tile.worldObj, power);
 	}
 
 	@Override

--- a/common/buildcraft/builders/FillerRemover.java
+++ b/common/buildcraft/builders/FillerRemover.java
@@ -12,12 +12,13 @@ package buildcraft.builders;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import buildcraft.api.core.IBox;
+import buildcraft.api.power.IPowerProvider;
 import buildcraft.core.DefaultProps;
 
 public class FillerRemover extends FillerPattern {
 
 	@Override
-	public boolean iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace) {
+	public float iteratePattern(TileEntity tile, IBox box, ItemStack stackToPlace, IPowerProvider power) {
 		int xMin = (int) box.pMin().x;
 		int yMin = (int) box.pMin().y;
 		int zMin = (int) box.pMin().z;
@@ -26,7 +27,7 @@ public class FillerRemover extends FillerPattern {
 		int yMax = (int) box.pMax().y;
 		int zMax = (int) box.pMax().z;
 
-		return !empty(xMin, yMin, zMin, xMax, yMax, zMax, tile.worldObj);
+		return empty(xMin, yMin, zMin, xMax, yMax, zMax, tile.worldObj, power);
 	}
 
 	@Override

--- a/common/buildcraft/builders/TileFiller.java
+++ b/common/buildcraft/builders/TileFiller.java
@@ -54,7 +54,7 @@ public class TileFiller extends TileBuildCraft implements ISidedInventory, IPowe
 	public TileFiller() {
 		contents = new ItemStack[getSizeInventory()];
 		powerProvider = PowerFramework.currentFramework.createPowerProvider();
-		powerProvider.configure(20, 25, 50, 25, 100);
+		powerProvider.configure(10, 25, 100, 25, 100);
 		powerProvider.configurePowerPerdition(25, 40);
 	}
 
@@ -106,7 +106,7 @@ public class TileFiller extends TileBuildCraft implements ISidedInventory, IPowe
 		if (lastMode == Mode.Off)
 			return;
 
-		if (powerProvider.useEnergy(25, 25, true) < 25)
+		if (powerProvider.useEnergy(currentPattern.expectedPowerUse(), currentPattern.expectedPowerUse(), false) < currentPattern.expectedPowerUse())
 			return;
 
 		if (box.isInitialized() && currentPattern != null && !done) {
@@ -123,7 +123,7 @@ public class TileFiller extends TileBuildCraft implements ISidedInventory, IPowe
 				}
 			}
 
-			done = currentPattern.iteratePattern(this, box, stack);
+			done = currentPattern.iteratePattern(this, box, stack, powerProvider)<0;
 
 			if (stack != null && stack.stackSize == 0) {
 				contents[stackId] = null;
@@ -381,7 +381,7 @@ public class TileFiller extends TileBuildCraft implements ISidedInventory, IPowe
 
 	/**
 	 * Get the start of the side inventory.
-	 *
+	 * 
 	 * @param side
 	 *            The global side to get the start of range.
 	 */
@@ -393,7 +393,7 @@ public class TileFiller extends TileBuildCraft implements ISidedInventory, IPowe
 
 	/**
 	 * Get the size of the side inventory.
-	 *
+	 * 
 	 * @param side
 	 *            The global side.
 	 */


### PR DESCRIPTION
power use of -1 indicates completion.
currently fill takes 25 mj, empty takes 200
todo: add config options (i dont know how)

this is in response to the chatter against commit e073bf604cece47c39bb3d1513beb0746ca3758e
