### PR TITLE
Fixed NPE crash with Factorization Barrels

### DIFF
--- a/common/buildcraft/core/utils/Localization.java
+++ b/common/buildcraft/core/utils/Localization.java
@@ -51,6 +51,9 @@ public class Localization {
 	 * @return
 	 */
 	public static synchronized String get(String key) {
+        if (getCurrentLanguage() == null) {
+            return key;
+        }
 		if (!getCurrentLanguage().equals(loadedLanguage)) {
 			defaultMappings.clear();
 			mappings.clear();


### PR DESCRIPTION
Factorization attempts to get the localization serverside, so this is just a fix for the resulting crash. Ideally, the Factorization author will fix their code to prevent this.
