### PR TITLE
Pipe Connection fixes

### DIFF
--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -130,8 +130,8 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 		updateSignalState();
 	}
 
-	public boolean isPipeConnected(TileEntity tile) {
-		return logic.isPipeConnected(tile) && transport.isPipeConnected(tile);
+	public boolean isPipeConnected(TileEntity tile, ForgeDirection side) {
+		return logic.isPipeConnected(tile) && transport.isPipeConnected(tile, side);
 	}
 
 	/**

--- a/common/buildcraft/transport/PipeTransport.java
+++ b/common/buildcraft/transport/PipeTransport.java
@@ -49,7 +49,7 @@ public abstract class PipeTransport {
 		this.container = tile;
 	}
 
-	public boolean isPipeConnected(TileEntity tile) {
+	public boolean isPipeConnected(TileEntity tile, ForgeDirection side) {
 		return true;
 	}
 

--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -480,7 +480,7 @@ public class PipeTransportItems extends PipeTransport {
 	}
 
 	@Override
-	public boolean isPipeConnected(TileEntity tile) {
+	public boolean isPipeConnected(TileEntity tile, ForgeDirection side) {
 		return tile instanceof TileGenericPipe || tile instanceof IPipeEntry || tile instanceof ISpecialInventory
 				|| (tile instanceof IInventory && ((IInventory) tile).getSizeInventory() > 0) || (tile instanceof IMachine && ((IMachine) tile).manageSolids());
 	}

--- a/common/buildcraft/transport/PipeTransportLiquids.java
+++ b/common/buildcraft/transport/PipeTransportLiquids.java
@@ -491,11 +491,11 @@ public class PipeTransportLiquids extends PipeTransport implements ITankContaine
 	}
 
 	@Override
-	public boolean isPipeConnected(TileEntity tile) {
+	public boolean isPipeConnected(TileEntity tile, ForgeDirection side) {
 		if (tile instanceof ITankContainer) {
 			ITankContainer liq = (ITankContainer) tile;
 
-			if (liq.getTanks(ForgeDirection.UNKNOWN) != null && liq.getTanks(ForgeDirection.UNKNOWN).length > 0)
+			if (liq.getTanks(side) != null && liq.getTanks(side).length > 0)
 				return true;
 		}
 

--- a/common/buildcraft/transport/PipeTransportPower.java
+++ b/common/buildcraft/transport/PipeTransportPower.java
@@ -58,7 +58,7 @@ public class PipeTransportPower extends PipeTransport {
 	SafeTimeTracker tracker = new SafeTimeTracker();
 
 	@Override
-	public boolean isPipeConnected(TileEntity tile) {
+	public boolean isPipeConnected(TileEntity tile, ForgeDirection side) {
 		return tile instanceof TileGenericPipe || tile instanceof IMachine || tile instanceof IPowerReceptor;
 	}
 

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -458,7 +458,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 			return null;
 	}
 
-	public boolean isPipeConnected(TileEntity with) {
+	public boolean isPipeConnected(TileEntity with, ForgeDirection side) {
 		Pipe pipe1 = pipe;
 		Pipe pipe2 = null;
 
@@ -473,10 +473,10 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 				&& !pipe1.transport.allowsConnect(pipe2.transport))
 			return false;
 
-		if (pipe2 != null && !(pipe2.isPipeConnected(this)))
+		if (pipe2 != null && !(pipe2.isPipeConnected(this, side)))
 			return false;
 
-		return pipe1 != null ? pipe1.isPipeConnected(with) : false;
+		return pipe1 != null ? pipe1.isPipeConnected(with, side) : false;
 	}
 
 	private void computeConnections() {
@@ -489,18 +489,18 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 				t.refresh();
 
 				if (t.getTile() != null) {
-					pipeConnectionsBuffer[i] = isPipeConnected(t.getTile());
+					pipeConnectionsBuffer[i] = isPipeConnected(t.getTile(), ForgeDirection.VALID_DIRECTIONS[i].getOpposite());
 
 					if (t.getTile() instanceof TileGenericPipe) {
 						TileGenericPipe pipe = (TileGenericPipe) t.getTile();
-						pipe.pipeConnectionsBuffer[ForgeDirection.values()[i].getOpposite().ordinal()] = pipeConnectionsBuffer[i];
+						pipe.pipeConnectionsBuffer[ForgeDirection.VALID_DIRECTIONS[i].getOpposite().ordinal()] = pipeConnectionsBuffer[i];
 					}
 				}
 			}
 
 			for (int i = 0; i < tileBuffer.length; ++i)
 				if (oldConnections[i] != pipeConnectionsBuffer[i]) {
-					Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.values()[i]);
+					Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.VALID_DIRECTIONS[i]);
 					pos.moveForwards(1.0);
 					scheduleRenderUpdate();
 				}


### PR DESCRIPTION
Minor change to pipe connection call - allows for proper sided checks; liquid pipes no longer query vs ForgeDirection.UNKNOWN.

Also changed a couple of the .values() calls to the VALID_DIRECTIONS static array. There are quite a few still left in the code, but I was unsure if it was safe to change them in all cases.

Signed-off-by: King Lemming kinglemming@gmail.com
