### PR TITLE
Log coordinates of invalid pipes

### DIFF
--- a/common/buildcraft/transport/ItemPipe.java
+++ b/common/buildcraft/transport/ItemPipe.java
@@ -17,6 +17,7 @@ import net.minecraft.world.World;
 import buildcraft.BuildCraftTransport;
 import buildcraft.core.IItemPipe;
 import buildcraft.core.ItemBuildCraft;
+import buildcraft.BuildCraftCore;
 
 public class ItemPipe extends ItemBuildCraft implements IItemPipe {
 
@@ -67,6 +68,10 @@ public class ItemPipe extends ItemBuildCraft implements IItemPipe {
 		if (entityplayer.canCurrentToolHarvestBlock(i, j, k) && world.canPlaceEntityOnSide(blockID, i, j, k, false, side, entityplayer)) {
 
 			Pipe pipe = BlockGenericPipe.createPipe(itemID);
+			if (pipe == null) {
+				BuildCraftCore.bcLog.warning("Pipe failed to create during placement at "+i+","+j+","+k);
+				return true;
+			}
 			if (BlockGenericPipe.placePipe(pipe, world, i, j, k, blockID, 0)) {
 
 				Block.blocksList[blockID].onBlockPlacedBy(world, i, j, k, entityplayer);

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -122,7 +122,9 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 
 		if (pipe != null) {
 			pipe.readFromNBT(nbttagcompound);
-		}
+		} else {
+			BuildCraftCore.bcLog.warning("Pipe failed to load from NBT at "+xCoord+","+yCoord+","+zCoord);
+        }
 
 		for (int i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
 			facadeBlocks[i] = nbttagcompound.getInteger("facadeBlocks[" + i + "]");
@@ -292,6 +294,8 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 
 		if (pipe != null) {
 			pipe.initialize();
+		} else {
+			BuildCraftCore.bcLog.warning("Pipe failed to initialize pipe at "+xCoord+","+yCoord+","+zCoord);
 		}
 
 		initialized = true;


### PR DESCRIPTION
Currently, pipes with unknown metadata spam the log with "Detected pipe with unknown key (-1). Did you remove a buildcraft addon?".

This pull request adds the coordinates of the invalid pipes, to help administrators in tracking down the broken pipes.
