### PR TITLE
Update common/buildcraft/transport/TileGenericPipe.java

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -493,7 +493,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 				t.refresh();
 
 				if (t.getTile() != null) {
-					pipeConnectionsBuffer[i] = isPipeConnected(t.getTile(), ForgeDirection.VALID_DIRECTIONS[i].getOpposite());
+					pipeConnectionsBuffer[i] = isPipeConnected(t.getTile(), ForgeDirection.VALID_DIRECTIONS[i]);
 
 					if (t.getTile() instanceof TileGenericPipe) {
 						TileGenericPipe pipe = (TileGenericPipe) t.getTile();


### PR DESCRIPTION
if we want to know if "with" is on "side" of us, we should ask if "this" is on "side.getOpposite()" of it.

either that, or the other check against pipe1 needs getOpposite -- they both can't be right.

(i'm not sure which is correct, given king's recent commit)
