### PR TITLE
Fix item drop on world load.

### DIFF
--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -403,6 +403,7 @@ public class PipeTransportItems extends PipeTransport {
 				// two versions - ignore these errors.
 			}
 		}
+		delay = 2;
 	}
 
 	@Override


### PR DESCRIPTION
This fixes the bug, that sometimes items inside pipes drop when the World loads, even when they have valid destinations to go to. This adds a little delay so that the tileBuffer inside the pipe can create correctly.
