### PR TITLE
Remove static modifier from contributions inside EntityPassiveItem.

### DIFF
--- a/common/buildcraft/core/EntityPassiveItem.java
+++ b/common/buildcraft/core/EntityPassiveItem.java
@@ -29,7 +29,7 @@ import buildcraft.core.proxy.CoreProxy;
 
 public class EntityPassiveItem implements IPipedItem {
 
-	private static TreeMap<String, IPassiveItemContribution> contributions = new TreeMap<String, IPassiveItemContribution>();
+	private TreeMap<String, IPassiveItemContribution> contributions = new TreeMap<String, IPassiveItemContribution>();
 	protected static int maxId = 0;
 	protected World worldObj;
 


### PR DESCRIPTION
As long as i havn't missed anything, this static doesn't make any sense. Every access to that list is done relative to an existing Object and doesn't pass any additional information, only the NBTTagCompund where things should be saved to. By removing the modifier the list can be used to store information unique for the Item instance. That would be usefull to store additional information of an item inside the item itself and let it keep that information even on a world reload. 
