### PR TITLE
Remove ability for robot to remove bedrock

### DIFF
--- a/common/buildcraft/core/EntityRobot.java
+++ b/common/buildcraft/core/EntityRobot.java
@@ -164,7 +164,7 @@ public class EntityRobot extends Entity implements IEntityAdditionalSpawnData {
 		List<BlockIndex> potentialDestinations = new ArrayList<BlockIndex>();
 		for (BlockIndex blockIndex : moveArea.getBlocksInArea()) {
 
-			if (BlockUtil.isSoftBlock(worldObj, blockIndex.i, blockIndex.j, blockIndex.k) && movementBoundary.contains(blockIndex)) {
+			if (BlockUtil.isSoftBlock(worldObj, blockIndex.i, blockIndex.j, blockIndex.k) && movementBoundary.contains(blockIndex) && BlockUtil.canChamgeBlock(worldObj, blockIndex.i, blockIndex.j, blockIndex.k)) {
 				potentialDestinations.add(blockIndex);
 			}
 		}


### PR DESCRIPTION
This should fix issue #519 as well as stop builders and anything else using the bot from destroying bedrock and other block deemed unbreakable.
