### PR TITLE
No option to disable online version check on startup

### DIFF
--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -39,7 +39,6 @@ import buildcraft.core.ItemWrench;
 import buildcraft.core.RedstonePowerFramework;
 import buildcraft.core.SpringPopulate;
 import buildcraft.core.TickHandlerCoreClient;
-import buildcraft.core.Version;
 import buildcraft.core.blueprints.BptItem;
 import buildcraft.core.network.EntityIds;
 import buildcraft.core.network.PacketHandler;
@@ -153,8 +152,6 @@ public class BuildCraftCore {
 
 	@PreInit
 	public void loadConfiguration(FMLPreInitializationEvent evt) {
-
-		Version.versionCheck();
 
 		bcLog.setParent(FMLLog.getLogger());
 		bcLog.info("Starting BuildCraft " + Version.getVersion());


### PR DESCRIPTION
There is no configurable option to disable the online version check on startup, adding many seconds to the startup time, and utterly useless when BuildCraft is included in server mod packs/etc.

Please either remove it entirely, or at the very least add a config option to disable it.
