### PR TITLE
Update common/buildcraft/transport/TileGenericPipe.java

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -502,12 +502,14 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 				}
 			}
 
-			for (int i = 0; i < tileBuffer.length; ++i)
+			for (int i = 0; i < tileBuffer.length; ++i) {
 				if (oldConnections[i] != pipeConnectionsBuffer[i]) {
-					Position pos = new Position(xCoord, yCoord, zCoord, ForgeDirection.VALID_DIRECTIONS[i]);
-					pos.moveForwards(1.0);
-					scheduleRenderUpdate();
+					TileBuffer t = tileBuffer[i];
+					if (t.getTile() != null && t.getTile() instanceof TileGenericPipe) {
+						((TileGenericPipe) t.getTile()).scheduleRenderUpdate();
+					}
 				}
+			}
 		}
 	}
 


### PR DESCRIPTION
the old loop was useless, simply stepping to the next block, then calling update on this.

"this" is flagged for a render update on exit from this function call in the main Update thread, so calling this.scheduleRenderUpdate() does nothing; this loop was probably intended to flag all neighbors for a render update after "this" changed state. (either that, or this loop can be removed).

given that bc works without graphical glitches at the moment, either there is excessive over-rendering elsewhere, or this loop can be completely removed.
