### PR TITLE
Fix world-breaking infinite loop in TransactorSimple

### DIFF
--- a/common/buildcraft/core/inventory/TransactorSimple.java
+++ b/common/buildcraft/core/inventory/TransactorSimple.java
@@ -17,8 +17,8 @@ public class TransactorSimple extends Transactor {
 
 		int injected = 0;
 
-		int slot = 0;
-		while ((slot = getPartialSlot(stack, orientation, slot)) >= 0 && injected < stack.stackSize) {
+		int slot = -1;
+		while ((slot = getPartialSlot(stack, orientation, slot + 1)) >= 0 && injected < stack.stackSize) {
 			injected += addToSlot(slot, stack, injected, doAdd);
 		}
 


### PR DESCRIPTION
If TransactorSimple.getPartialStack returns a slot which TransactorSimple.addToSlot cannot add any items to, the transactor will repeatedly try to insert the item into that slot, causing the server to hang.

Currently this can happen if the inventory has a stack limit less than 64, and the number of items in that slot is at least the inventory's stack limit, but less than the item's maximum stack size, as getPartialStack was not updated in [the commit](https://github.com/BuildCraft/BuildCraft/commit/f03c00fba369ecf6538dc491f0387748b9bda26f) that added inventory stack limit support.

This pull request removes any chance of the infinite loop being triggered, now or in the future, by making TransactorSimple.inject only try each slot at most once.

To reproduce the hang:
1. Create a world.
2. Place an RP2 battery box.
3. Place an obsidian pipe on top of the battery box.
4. Throw two of the same stackable item into the obsidian pipe.
