### PR TITLE
Additional transactor fix for getInventoryStackLimit

### DIFF
--- a/common/buildcraft/core/inventory/TransactorSimple.java
+++ b/common/buildcraft/core/inventory/TransactorSimple.java
@@ -45,7 +45,7 @@ public class TransactorSimple extends Transactor {
 				continue;
 			}
 
-			if (inventory.getStackInSlot(i).stackSize >= inventory.getStackInSlot(i).getMaxStackSize()) {
+			if (inventory.getStackInSlot(i).stackSize >= inventory.getStackInSlot(i).getMaxStackSize() || inventory.getStackInSlot(i).stackSize >= inventory.getInventoryStackLimit()) {
 				continue;
 			}
 


### PR DESCRIPTION
Fix getPartialSlot for inventories with a getInventoryStackLimit less than the item's max stack size
