### PR TITLE
Override canCommandSenderUseCommand

### DIFF
--- a/common/buildcraft/core/CommandBuildCraft.java
+++ b/common/buildcraft/core/CommandBuildCraft.java
@@ -24,6 +24,11 @@ public class CommandBuildCraft extends CommandBase {
 	public String getCommandUsage(ICommandSender sender) {
 		return "/" + this.getCommandName() + " help";
 	}
+	
+	@Override
+	public boolean canCommandSenderUseCommand(ICommandSender par1ICommandSender) {
+		return true;
+	}
 
 	@Override
 	public List getCommandAliases() {


### PR DESCRIPTION
This allows users to use the /Buildcraft command without needing to
enable cheats in the world creation menu

Also fixes issue #610
