### PR TITLE
math.ceil() is very slow

### DIFF
--- a/common/buildcraft/transport/PipeTransportPower.java
+++ b/common/buildcraft/transport/PipeTransportPower.java
@@ -123,8 +123,8 @@ public class PipeTransportPower extends PipeTransport {
 
 							nearbyTransport.receiveEnergy(ForgeDirection.VALID_DIRECTIONS[j].getOpposite(), watts);
 
-							displayPower[j] += (short) Math.ceil(watts * DISPLAY_POWER_FACTOR);
-							displayPower[i] += (short) Math.ceil(watts * DISPLAY_POWER_FACTOR);
+							displayPower[j] += (short) (watts * DISPLAY_POWER_FACTOR + .9999);
+							displayPower[i] += (short) (watts * DISPLAY_POWER_FACTOR + .9999);
 
 							internalPower[i] -= watts;
 						} else if (tiles[j] instanceof IPowerReceptor) {
@@ -135,8 +135,8 @@ public class PipeTransportPower extends PipeTransport {
 							if (prov != null) {
 								prov.receiveEnergy((float) watts, ForgeDirection.VALID_DIRECTIONS[j].getOpposite());
 
-								displayPower[j] += (short) Math.ceil(watts * DISPLAY_POWER_FACTOR);
-								displayPower[i] += (short) Math.ceil(watts * DISPLAY_POWER_FACTOR);
+								displayPower[j] += (short) (watts * DISPLAY_POWER_FACTOR + .9999);
+								displayPower[i] += (short) (watts * DISPLAY_POWER_FACTOR + .9999);
 
 								internalPower[i] -= watts;
 							}


### PR DESCRIPTION
![slowCeiling](https://f.cloud.github.com/assets/1892829/165762/ada347c4-7972-11e2-9e61-dd86dfaac954.png)
math.ceil is almost 100% of the cpu cost of pipePowerWood and transport.pipeTransportPower

(full nps from 
https://www.dropbox.com/s/01ywgc8lnyr2es2/1361111585024.nps?dl=1
several hundred k items extracted from ex-dim barrels, sent to a set of act's, crafted to blocks, and then sent back to barrels.

sendStack->queueRoutedItem() is to do with logistics HUD display, and is being worked on lag-wise also.)
