### PR TITLE
Bulletproof the Box class against accidental world corruption and bugs.

### DIFF
--- a/common/buildcraft/core/Box.java
+++ b/common/buildcraft/core/Box.java
@@ -58,7 +58,8 @@ public class Box implements IBox {
 		this.xMax = xMax;
 		this.yMax = yMax;
 		this.zMax = zMax;
-		initialized = true;
+		initialized = !(xMin == Integer.MAX_VALUE || yMin == Integer.MAX_VALUE || zMin == Integer.MAX_VALUE || xMax == Integer.MAX_VALUE ||
+		                yMax == Integer.MAX_VALUE || zMax == Integer.MAX_VALUE );
 	}
 
 	public void initialize(Box box) {


### PR DESCRIPTION
In some rare cases the Box's initialize() may be supplied with
coordinates equal to INT_MAX while theoretically being initialized.
Normally this would be harmless, as with every coordinate being
INT_MAX the resulting box's dimensions are zero, however anywhere
where one of the coordinates is actually used in a loop with a
"i <= coord" condition the loop counter will overflow and bad things
will happen, e.g. in FillerFlattener.iteratePattern, where
I encountered this bug, an array will overflow and take down the
whole game with it resulting in a corrupted world. (As broken INT_MAX
coordinates will get saved in NBT tags.)
