### PR TITLE
Allow autocrafting tables to pull directly from adjacent autocrafting tables

### DIFF
--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -193,7 +193,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 					StackPointer pointer = getNearbyItem(stack);
 
 					if (pointer == null) {
-						if(stack.getItem().getContainerItem() == null && !stack.isItemStackDamageable()) {
+						if(stack.getItem().getContainerItem() == null) { /* can craft damageable items, but don't know where to put containers for containeritems */
 							if(!craftNearbyItem(stack, doRemove, prevCrafters)) {
 								resetPointers(pointerList);
 								return null;


### PR DESCRIPTION
This functionality seems useful for autocrafting things that need more than one crafting step while avoiding a ton of extra pipes and stuff to extract from intermediate crafting tables.
