### PR TITLE
Fix bug in power distribution (Generic and Wooden Pipe)

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -418,7 +418,9 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 
 	@Override
 	public int powerRequest() {
-		return getPowerProvider().getMaxEnergyReceived();
+		if (BlockGenericPipe.isValid(pipe) && pipe instanceof IPowerReceptor)
+			return ((IPowerReceptor) pipe).powerRequest();
+		return 0;
 	}
 
 	@Override

--- a/common/buildcraft/transport/pipes/PipePowerWood.java
+++ b/common/buildcraft/transport/pipes/PipePowerWood.java
@@ -108,9 +108,14 @@ public class PipePowerWood extends Pipe implements IPowerReceptor {
 						energyToRemove = 1;
 					}
 
-					float energyUsed = powerProvider.useEnergy(1, energyToRemove, true);
+					float energyUsable = powerProvider.useEnergy(1, energyToRemove, false);
 
-					trans.receiveEnergy(o.getOpposite(), energyUsed);
+					float energySend = Math.min(energyUsable, ((PipeTransportPower)transport).powerQuery[o.ordinal()]);
+					if(energySend > 0)
+					{
+						trans.receiveEnergy(o.getOpposite(), energySend);
+						powerProvider.useEnergy(1, energySend, true);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
TileGenericPipe.java:
- fixes not calling powerRequest of IPowerReceptor-Pipe

PipePowerWood.java:
- fixes exploding pipes directly behind of a wooden pipe if no power-consumer exists, instead it will only extract the power amount which is requested by the consumers

see:

![2013-03-04_17 59 50](https://f.cloud.github.com/assets/656249/226474/032f7d26-8633-11e2-833b-57616c14f9ca.png)
