### PR TITLE
Fixed typo

### DIFF
--- a/common/buildcraft/api/power/PowerFramework.java
+++ b/common/buildcraft/api/power/PowerFramework.java
@@ -13,7 +13,7 @@ import net.minecraft.nbt.NBTTagCompound;
 
 public abstract class PowerFramework {
 
-	static private String baseNBTName = "net.minecraft.src.buildcarft.Power";
+	static private String baseNBTName = "net.minecraft.src.buildcraft.Power";
 
 	public static PowerFramework currentFramework;
 


### PR DESCRIPTION
The NBT base name was set to "buildcarft"
