### PR TITLE
Enable facade creation for extra blocks

### DIFF
--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -101,6 +101,8 @@ public class BuildCraftCore {
 	public static int updateFactor = 10;
 
 	public static long longUpdateFactor = 40;
+	
+	public static String facadeIdList;
 
 	public static BuildCraftConfiguration mainConfiguration;
 
@@ -199,7 +201,11 @@ public class BuildCraftCore {
 			if (itemLifespan < 100) {
 				itemLifespan = 100;
 			}
-
+			
+			Property facadeIds = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "facadeBlockIds", "");
+			facadeIds.comment = "a comma delimited list of additional block IDs to add as facades, subtypes will be added automatically";
+			facadeIdList = facadeIds.getString();
+			
 			Property powerFrameworkClass = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "power.framework",
 					"buildcraft.energy.PneumaticPowerFramework");
 

--- a/common/buildcraft/transport/ItemFacade.java
+++ b/common/buildcraft/transport/ItemFacade.java
@@ -2,6 +2,7 @@ package buildcraft.transport;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -15,6 +16,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftTransport;
 import buildcraft.api.recipes.AssemblyRecipe;
 import buildcraft.core.CreativeTabBuildCraft;
@@ -95,6 +97,8 @@ public class ItemFacade extends ItemBuildCraft {
 	}
 
 	public static void initialize() {
+	    Set<Integer> facadeBlockIds = Sets.newHashSet();
+	    
 		for (Field f : Block.class.getDeclaredFields()) {
 			if (Modifier.isStatic(f.getModifiers()) && Block.class.isAssignableFrom(f.getType())) {
 				Block b;
@@ -112,19 +116,31 @@ public class ItemFacade extends ItemBuildCraft {
 						continue;
 					}
 				}
-				ItemStack base = new ItemStack(b, 1);
-				if (base.getHasSubtypes()) {
-					Set<String> names = Sets.newHashSet();
-					for (int meta = 0; meta < 15; meta++) {
-						ItemStack is = new ItemStack(b, 1, meta);
-						if (!Strings.isNullOrEmpty(is.getItemName()) && names.add(is.getItemName())) {
-							ItemFacade.addFacade(is);
-						}
-					}
-				} else {
-					ItemFacade.addFacade(base);
-				}
+				facadeBlockIds.add(b.blockID);
 			}
+		}
+
+		for (String id : BuildCraftCore.facadeIdList.trim().split("\\s*,\\s*")) {
+		    try {
+		        facadeBlockIds.add(Integer.parseInt(id));
+		    } catch (Exception e) {
+		        continue;
+		    }
+		}
+		
+		for (int blockId : facadeBlockIds) {
+		    ItemStack base = new ItemStack(blockId, 1, -1);
+	        if (base.getHasSubtypes()) {
+	            Set<String> names = Sets.newHashSet();
+	            for (int meta = 0; meta < 15; meta++) {
+	                ItemStack is = new ItemStack(blockId, 1, meta);
+	                if (!Strings.isNullOrEmpty(is.getItemName()) && names.add(is.getItemName())) {
+	                    ItemFacade.addFacade(is);
+	                }
+	            }
+	        } else {
+	            ItemFacade.addFacade(base);
+	        }
 		}
 	}
 


### PR DESCRIPTION
Adds a configuration option allowing the end user to specify a comma delimited
list of block IDs to be added to BuildCraft as facades.

BuildCraft currently cycles through the standard Minecraft blocks and adds
those automatically, but mods which add their own blocks must tell BuildCraft
to create facades. Those mods which do not, lack facades completely. A prime
example of this is RedPower2 with Marble, Basalt and their subtypes.
