### PR TITLE
Facade shouldPassSneakingClickToBlock

### DIFF
--- a/common/buildcraft/transport/ItemFacade.java
+++ b/common/buildcraft/transport/ItemFacade.java
@@ -140,6 +140,12 @@ public class ItemFacade extends ItemBuildCraft {
 		return ((encoded & 0xFFF0) >>> 4);
 	}
 
+	@Override
+	public boolean shouldPassSneakingClickToBlock(World worldObj, int x, int y, int z ) {
+		// Simply send shift click to the pipe / mod block.
+		return true;
+	}
+
 	public static void addFacade(ItemStack itemStack) {
 		allFacades.add(new ItemStack(BuildCraftTransport.facadeItem, 1, ItemFacade.encode(itemStack.itemID, itemStack.getItemDamage())));
 


### PR DESCRIPTION
Patch to allow other mod blocks which support facades to remove them just as they are removed from pipes. via sneak clicking with a facade.

I tested this and it seems pipes already handle this correctly.
