### PR TITLE
Simple change to make BlockUtils consider isAirBlock when creating an ItemStack for a block.

### DIFF
--- a/common/buildcraft/core/utils/BlockUtil.java
+++ b/common/buildcraft/core/utils/BlockUtil.java
@@ -32,7 +32,7 @@ public class BlockUtil {
 		if (block == null)
 			return null;
 
-		if (block.isAirBlock(world, i, j, k)
+		if (block.isAirBlock(world, i, j, k))
 			return null;
 
 		int meta = world.getBlockMetadata(i, j, k);


### PR DESCRIPTION
It's my understanding that this is the point of isAirBlock. To designate a block as something that should be completely ignored. If I'm incorrect, just ignore this.
