### PR TITLE
TranslatorSimple changed to support compatibility.

### DIFF
--- a/common/buildcraft/core/inventory/TransactorSimple.java
+++ b/common/buildcraft/core/inventory/TransactorSimple.java
@@ -19,13 +19,19 @@ public class TransactorSimple extends Transactor {
 
 		int slotIndex = 0;
 		int slot = 0;
-		while ((slot = getPartialSlot(stack, orientation, slotIndex++)) >= 0 && injected < stack.stackSize) {
-			injected += addToSlot(slot, stack, injected, doAdd);
+		while (slotIndex < inventory.getSizeInventory() && injected < stack.stackSize) {
+			slot = getPartialSlot(stack, orientation, slotIndex++);
+			if (slot != -1){
+				injected += addToSlot(slot, stack, injected, doAdd);
+			}
 		}
 
 		slotIndex = 0;
-		while ((slot = getEmptySlot(stack, orientation, slotIndex++)) >= 0 && injected < stack.stackSize) {
-			injected += addToSlot(slot, stack, injected, doAdd);
+		while (slotIndex < inventory.getSizeInventory() && injected < stack.stackSize) {
+			slot = getEmptySlot(stack, orientation, slotIndex++);
+			if (slot != -1){
+				injected += addToSlot(slot, stack, injected, doAdd);
+			}
 		}
 		inventory.onInventoryChanged();
 		return injected;


### PR DESCRIPTION
This change was made to buildcraft would work better when a IInventory returned false when calling func_102007_a function. Now continues to check other slots. (Maybe you're using func_102007_a to return true if you want items to only go into a specific slot and not out.)
