### PR TITLE
ConnectionMatrix changed to save memory.

### DIFF
--- a/common/buildcraft/transport/utils/ConnectionMatrix.java
+++ b/common/buildcraft/transport/utils/ConnectionMatrix.java
@@ -32,14 +32,19 @@ public class ConnectionMatrix {
 	}
 
 	public void writeData(DataOutputStream data) throws IOException {
-		for (int i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
-			data.writeBoolean(_connected[i]);
+		byte write = 0;
+		for (byte i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
+			if (this._connected[i]){
+				write |= 1 << i;
+			}
 		}
+		data.writeByte(write);
 	}
 
 	public void readData(DataInputStream data) throws IOException {
+		byte read = data.readByte();
 		for (int i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
-			_connected[i] = data.readBoolean();
+			_connected[i] = (read & (1 << i)) != 0;;
 		}
 	}
 }


### PR DESCRIPTION
While looking at the buildcraft code, I noticed that this is extremely innifetient. For saving, it writes 6 bytes to just store 6 booleans to save what the pipe is connected to. This changes sets each bits in a byte to write all 6 booleans. Now only uses 1 byte instead of 6.

It turns out that this never gets written to the disk. It is used for syncing. This will still save my horrible 80 gigabyte monthly usage allowance a couple of megs.
