### PR TITLE
Fix for destroying a tilemarker.

### DIFF
--- a/common/buildcraft/builders/TileMarker.java
+++ b/common/buildcraft/builders/TileMarker.java
@@ -365,7 +365,7 @@ public class TileMarker extends TileBuildCraft implements IAreaProvider {
 				}
 			}
 
-			if (markerOrigin != this) {
+			if (markerOrigin != this && markerOrigin != null) {
 				markerOrigin.origin = new Origin();
 			}
 
@@ -376,8 +376,9 @@ public class TileMarker extends TileBuildCraft implements IAreaProvider {
 					mark.updateSignals();
 				}
 			}
-
-			markerOrigin.updateSignals();
+			if (markerOrigin != null) {
+				markerOrigin.updateSignals();
+			}
 		}
 
 		if (signals != null) {


### PR DESCRIPTION
If you try to destroy activated tilemarker (with red laser), minecraft crash with the next stacktrace:

```
java.lang.NullPointerException
    at buildcraft.builders.TileMarker.destroy(TileMarker.java:369)
    at buildcraft.builders.TileMarker.func_70313_j(TileMarker.java:328)
    at net.minecraft.world.chunk.Chunk.func_76627_f(Chunk.java:1058)
    at net.minecraft.world.World.func_72932_q(World.java:2925)
    at net.minecraft.world.chunk.Chunk.func_76592_a(Chunk.java:722)
    at net.minecraft.world.World.func_72832_d(World.java:554)
    at net.minecraft.world.World.func_94571_i(World.java:683)
    at net.minecraft.block.Block.removeBlockByPlayer(Block.java:1629)
    at net.minecraft.client.multiplayer.PlayerControllerMP.func_78751_a(PlayerControllerMP.java:154)
    at net.minecraft.client.multiplayer.PlayerControllerMP.func_78744_a(PlayerControllerMP.java:81)
    at net.minecraft.client.multiplayer.PlayerControllerMP.func_78743_b(PlayerControllerMP.java:193)
    at net.minecraft.client.Minecraft.func_71402_c(Minecraft.java:1305)
    at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1791)
    at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:831)
    at net.minecraft.client.Minecraft.run(Minecraft.java:756)
    at java.lang.Thread.run(Thread.java:722)
```
