### PR TITLE
Added WorldGen options to BC API

### DIFF
--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -19,6 +19,7 @@ import net.minecraft.entity.EntityList;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Icon;
+import net.minecraft.world.biome.BiomeGenBase;
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.Configuration;
 import net.minecraftforge.common.IPlantable;
@@ -27,6 +28,7 @@ import net.minecraftforge.common.Property;
 import net.minecraftforge.event.ForgeSubscribe;
 import buildcraft.api.core.BuildCraftAPI;
 import buildcraft.api.core.IIconProvider;
+import buildcraft.api.core.WorldGen;
 import buildcraft.api.gates.ActionManager;
 import buildcraft.api.power.PowerFramework;
 import buildcraft.core.BlockIndex;
@@ -280,6 +282,9 @@ public class BuildCraftCore {
 		ActionManager.registerTriggerProvider(new DefaultTriggerProvider());
 		ActionManager.registerActionProvider(new DefaultActionProvider());
 
+		WorldGen.biomeBlacklist.add(BiomeGenBase.sky.biomeID);
+		WorldGen.biomeBlacklist.add(BiomeGenBase.hell.biomeID);
+		WorldGen.biomeWhitelist.add(BiomeGenBase.desert.biomeID);
 		if (BuildCraftCore.modifyWorld) {
 			MinecraftForge.EVENT_BUS.register(new SpringPopulate());
 		}

--- a/common/buildcraft/api/core/WorldGen.java
+++ b/common/buildcraft/api/core/WorldGen.java
@@ -1,0 +1,79 @@
+package buildcraft.api.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.world.biome.BiomeGenBase;
+
+
+/**
+ * 
+ * @author Aroma1997
+ *
+ */
+public class WorldGen {
+	public static List<Integer> biomeBlacklist = new ArrayList<Integer>();
+	public static List<Integer> biomeWhitelist = new ArrayList<Integer>();
+	/**
+	 * Add a Biome to the Blacklist, where Buildcraft does not generate.
+	 * @param biomeGenBase the Biome
+	 */
+	public static void addBiomeToBlacklist(BiomeGenBase biomeGenBase) {
+		biomeBlacklist.add(biomeGenBase.biomeID);
+	}
+	/**
+	 * Add a Biome to the Blacklist, where Buildcraft does not generate.
+	 * @param biomeGenBase the BiomeID
+	 */
+	public static void addBiomeToBlacklist(int biomeGenBaseID) {
+		biomeBlacklist.add(biomeGenBaseID);
+	}
+	
+	/**
+	 * Add a Biome to the Whitelist, where Buildcraft does extremely generate. (like Oil in deserts)
+	 * @param biomeGenBase the Biome
+	 */
+	public static void addBiomeToWhitelist(BiomeGenBase biomeGenBase) {
+		biomeWhitelist.add(biomeGenBase.biomeID);
+	}
+	/**
+	 * Add a Biome to the Whitelist, where Buildcraft does extremely generate. (like Oil in deserts)
+	 * @param biomeGenBase the BiomeID
+	 */
+	public static void addBiomeToWhitelist(int biomeGenBaseID) {
+		biomeWhitelist.add(biomeGenBaseID);
+	}
+	
+	/**
+	 * Check, if the biome is on the blacklist, or not.
+	 * @param biomegenbase the Biome
+	 * @return if BC should generate in the world
+	 */
+	public static boolean generateInBiome(BiomeGenBase biomegenbase) {
+		int biomeID = biomegenbase.biomeID;
+		for (int biomeNumber = 0; biomeNumber < WorldGen.biomeBlacklist.size(); biomeNumber++) {
+			if (WorldGen.biomeBlacklist.get(biomeNumber) == biomeID) {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
+	/**
+	 * Check, if the biome is on the whitelist, or not.
+	 * @param biomegenbase the Biome
+	 * @return if BC should generate in the world
+	 */
+	public static boolean isBiomeWhitelisted(BiomeGenBase biomegenbase) {
+		int biomeID = biomegenbase.biomeID;
+		for (int biomeNumber = 0; biomeNumber < WorldGen.biomeWhitelist.size(); biomeNumber++) {
+			if (WorldGen.biomeWhitelist.get(biomeNumber) == biomeID) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+
+}

--- a/common/buildcraft/core/SpringPopulate.java
+++ b/common/buildcraft/core/SpringPopulate.java
@@ -16,9 +16,10 @@ import net.minecraftforge.event.ForgeSubscribe;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import buildcraft.BuildCraftCore;
+import buildcraft.api.core.WorldGen;
 
 public class SpringPopulate {
-
+	
 	@ForgeSubscribe
 	public void populate(PopulateChunkEvent.Post event) {
 
@@ -41,11 +42,12 @@ public class SpringPopulate {
 		if(random.nextFloat() > 0.025f)
 			return;
 
-		// Do not generate water in the End or the Nether
+		// Do not generate water in the blacklisted biomes
 		BiomeGenBase biomegenbase = world.getWorldChunkManager().getBiomeGenAt(x, z);
-		if (biomegenbase.biomeID == BiomeGenBase.sky.biomeID || biomegenbase.biomeID == BiomeGenBase.hell.biomeID)
+		if (!WorldGen.generateInBiome(biomegenbase)) {
 			return;
-
+		}
+		
 		int posX = x + random.nextInt(16);
 		int posZ = z + random.nextInt(16);
 

--- a/common/buildcraft/energy/OilPopulate.java
+++ b/common/buildcraft/energy/OilPopulate.java
@@ -17,6 +17,7 @@ import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftEnergy;
+import buildcraft.api.core.WorldGen;
 
 public class OilPopulate {
 
@@ -39,12 +40,12 @@ public class OilPopulate {
 	public static void doPopulate(World world, Random rand, int x, int z) {
 		BiomeGenBase biomegenbase = world.getBiomeGenForCoords(x + 16, z + 16);
 
-		// Do not generate oil in the End
-		if (biomegenbase.biomeID == BiomeGenBase.sky.biomeID || biomegenbase.biomeID == BiomeGenBase.hell.biomeID) {
+		// Do not generate oil in blacklisted biomes.
+		if (!WorldGen.generateInBiome(biomegenbase)) {
 			return;
 		}
 
-		if (biomegenbase == BiomeGenBase.desert && rand.nextFloat() > 0.97) {
+		if (WorldGen.isBiomeWhitelisted(biomegenbase) && rand.nextFloat() > 0.97) {
 			// Generate a small desert deposit
 
 			int startX = rand.nextInt(10) + 2;


### PR DESCRIPTION
With that part of the API, you can add Biomes, where Buildcraft does not generate stuff, and add biomes, where buildcraft generates the desert oil spawns.
