### PR TITLE
Add Pipe Content ItemStack NBT sync.

### DIFF
--- a/common/buildcraft/core/network/PacketIds.java
+++ b/common/buildcraft/core/network/PacketIds.java
@@ -7,6 +7,8 @@ public class PacketIds {
 	public static final int PIPE_CONTENTS = 2;
 	public static final int PIPE_LIQUID = 3;
 	public static final int PIPE_POWER = 4;
+	public static final int REQUEST_ITEM_NBT = 5;
+	public static final int PIPE_ITEM_NBT = 6;
 	public static final int SELECTION_ASSEMBLY_GET = 20;
 	public static final int SELECTION_ASSEMBLY = 21;
 	public static final int SELECTION_ASSEMBLY_SEND = 22;

--- a/common/buildcraft/transport/network/PacketHandlerTransport.java
+++ b/common/buildcraft/transport/network/PacketHandlerTransport.java
@@ -66,6 +66,11 @@ public class PacketHandlerTransport implements IPacketHandler {
 				packet.readData(data);
 				onGateSelection((EntityPlayer) player, packet);
 				break;
+			case PacketIds.PIPE_ITEM_NBT:
+				PacketPipeTransportNBT packetD = new PacketPipeTransportNBT();
+				packetD.readData(data);
+				onPipeContentNBT((EntityPlayer) player, packetD);
+				break;
 
 			/** SERVER SIDE **/
 			case PacketIds.DIAMOND_PIPE_SELECT: {
@@ -98,6 +103,12 @@ public class PacketHandlerTransport implements IPacketHandler {
 				PacketUpdate packet3 = new PacketUpdate();
 				packet3.readData(data);
 				onGateSelectionChange((EntityPlayerMP) player, packet3);
+				break;
+				
+			case PacketIds.REQUEST_ITEM_NBT:
+				PacketSimpleId packet4 = new PacketSimpleId();
+				packet4.readData(data);
+				onItemNBTRequest((EntityPlayerMP) player, packet4);
 				break;
 			}
 
@@ -146,6 +157,20 @@ public class PacketHandlerTransport implements IPacketHandler {
 			return;
 
 		((ContainerGateInterface) container).setSelection(packet);
+	}
+
+	private void onPipeContentNBT(EntityPlayer player, PacketPipeTransportNBT packet) {
+		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		if (pipe == null)
+			return;
+
+		if (pipe.pipe == null)
+			return;
+
+		if (!(pipe.pipe.transport instanceof PipeTransportItems))
+			return;
+
+		((PipeTransportItems)pipe.pipe.transport).handleNBTPacket(packet);
 	}
 
 	/**
@@ -317,4 +342,22 @@ public class PacketHandlerTransport implements IPacketHandler {
 		((PipeItemsEmerald) pipe.pipe).setInventorySlotContents(packet.slot, packet.stack);
 	}
 
+	/**
+	 * Handles the client request for tag data
+	 * @param player
+	 * @param packet
+	 */
+	private void onItemNBTRequest(EntityPlayerMP player, PacketSimpleId packet) {
+		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		if (pipe == null)
+			return;
+
+		if (pipe.pipe == null)
+			return;
+
+		if (!(pipe.pipe.transport instanceof PipeTransportItems))
+			return;
+
+		((PipeTransportItems) pipe.pipe.transport).handleNBTRequestPacket(player, packet.entityId);
+	}
 }

--- a/common/buildcraft/transport/network/PacketPipeTransportContent.java
+++ b/common/buildcraft/transport/network/PacketPipeTransportContent.java
@@ -23,6 +23,7 @@ public class PacketPipeTransportContent extends BuildCraftPacket {
 	private float itemY;
 	private float itemZ;
 	private float speed;
+	private boolean hasNBT;
 	public int posX;
 	public int posY;
 	public int posZ;
@@ -50,6 +51,7 @@ public class PacketPipeTransportContent extends BuildCraftPacket {
 		data.writeShort(entityData.item.getItemStack().getItemDamage());
 
 		data.writeFloat(entityData.item.getSpeed());
+		data.writeBoolean(entityData.item.getItemStack().hasTagCompound());
 	}
 
 	@Override
@@ -72,6 +74,7 @@ public class PacketPipeTransportContent extends BuildCraftPacket {
 		this.itemDamage = data.readShort();
 
 		this.speed = data.readFloat();
+		this.hasNBT = data.readBoolean();
 	}
 
 	public int getEntityId() {
@@ -114,6 +117,10 @@ public class PacketPipeTransportContent extends BuildCraftPacket {
 		return speed;
 	}
 
+	public boolean hasNBT() {
+		return hasNBT;
+	}
+	
 	@Override
 	public int getID() {
 		return PacketIds.PIPE_CONTENTS;

--- a/common/buildcraft/transport/network/PacketPipeTransportNBT.java
+++ b/common/buildcraft/transport/network/PacketPipeTransportNBT.java
@@ -1,0 +1,53 @@
+package buildcraft.transport.network;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import net.minecraft.nbt.CompressedStreamTools;
+import net.minecraft.nbt.NBTTagCompound;
+import buildcraft.core.network.PacketCoordinates;
+
+public class PacketPipeTransportNBT extends PacketCoordinates {
+
+	private NBTTagCompound tag;
+	private int entityId;
+
+	public PacketPipeTransportNBT() {
+	}
+
+	public PacketPipeTransportNBT(int id, int x, int y, int z, int entityId, NBTTagCompound tag) {
+		super(id, x, y, z);
+		this.entityId = entityId;
+		this.tag = tag;
+	}
+
+	@Override
+	public void writeData(DataOutputStream data) throws IOException {
+		super.writeData(data);
+
+		data.writeInt(entityId);
+		byte[] compressed = CompressedStreamTools.compress(tag);
+		data.writeShort(compressed.length);
+		data.write(compressed);
+	}
+
+	@Override
+	public void readData(DataInputStream data) throws IOException {
+		super.readData(data);
+
+		this.entityId = data.readInt();
+		short length = data.readShort();
+		byte[] compressed = new byte[length];
+		data.readFully(compressed);
+		this.tag = CompressedStreamTools.decompress(compressed);
+	}
+
+	public int getEntityId() {
+		return entityId;
+	}
+
+	public NBTTagCompound getTagCompound() {
+		return tag;
+	}
+}

--- a/common/buildcraft/transport/network/PacketSimpleId.java
+++ b/common/buildcraft/transport/network/PacketSimpleId.java
@@ -1,0 +1,32 @@
+package buildcraft.transport.network;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import buildcraft.core.network.PacketCoordinates;
+
+public class PacketSimpleId extends PacketCoordinates {
+
+	public int entityId;
+	public PacketSimpleId() {
+		super();
+	}
+
+	public PacketSimpleId(int id, int x, int y, int z, int entityId) {
+		super(id, x, y, z);
+		this.entityId = entityId;
+	}
+	
+	@Override
+	public void writeData(DataOutputStream data) throws IOException {
+		super.writeData(data);
+		data.writeInt(entityId);
+	}
+
+	@Override
+	public void readData(DataInputStream data) throws IOException {
+		super.readData(data);
+		entityId = data.readInt();
+	}
+}


### PR DESCRIPTION
This allows to sync the NBT tag information stored inside the ItemStack. Should fix some rendering bugs where the renderer depends on data stored inside the NBTTagCompound tag of an ItemStack.
Through the handshake Packet way this shouldn't increase the bandwide usage and ensure the NBT tag information where needed.
