### PR TITLE
Auto workbench no longer pulls from adjacent inventories if not needed

### DIFF
--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -160,7 +160,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 							ItemStack item1 = this.getStackInSlot(slot1);
 							if (item1 != null && item1.stackSize == 1 && item.isItemEqual(item1)){
 								item1.stackSize++;
-								if (item.stackSize > 1){
+								if ((item = inventory.getStackInSlotOnClosing(slot)).stackSize > 1){
 									inventory.decrStackSize(slot, 1);
 								}else{
 									inventory.setInventorySlotContents(slot, null);


### PR DESCRIPTION
when extracting and doRemove is false, the crafting table will not bother to extract items from adjacent inventories
