### PR TITLE
Fixed potential rage

### DIFF
--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -217,7 +217,7 @@ public class TileAutoWorkbench extends TileEntity implements ISpecialInventory {
 		for (int slot = 0; slot < this.getSizeInventory(); slot++){
 			ItemStack stack = this.getStackInSlot(slot);
 			
-			if (stack != null && (stack.getItem().hasContainerItem() ? stack.stackSize > 1 && stack.getItem().getContainerItem() != stack.getItem() : stack.stackSize <= 1)){
+			if (stack != null && (stack.getItem().hasContainerItem() ? stack.stackSize > 1 && !stack.getItem().getContainerItemStack(stack).isItemEqual(stack) : stack.stackSize <= 1)){
 				return false;
 			}
 		}


### PR DESCRIPTION
Incase an item that has a container item which stack size is more then one will fix a potential screwup. Has some intelligent code so it will bypass this rule in some cases.
