### PR TITLE
Made filler item lifespan configurable, and...

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -107,6 +107,8 @@ public class BuildCraftBuilders {
 	public static ItemBptTemplate templateItem;
 	public static ItemBptBluePrint blueprintItem;
 	public static boolean fillerDestroy;
+	public static int fillerLifespanTough;
+	public static int fillerLifespanNormal;
 
 	private static BptRootIndex rootBptIndex;
 
@@ -236,6 +238,14 @@ public class BuildCraftBuilders {
 		Property fillerDestroyProp = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "filler.destroy", DefaultProps.FILLER_DESTROY);
 		fillerDestroyProp.comment = "If true, Filler will destroy blocks instead of breaking them.";
 		fillerDestroy = fillerDestroyProp.getBoolean(DefaultProps.FILLER_DESTROY);
+		
+		Property fillerLifespanToughProp = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "filler.lifespan.tough", DefaultProps.FILLER_LIFESPAN_TOUGH);
+		fillerLifespanToughProp.comment = "Lifespan in ticks of items dropped by the filler from 'tough' blocks (those that can't be broken by hand)";
+		fillerLifespanTough = fillerLifespanToughProp.getInt(DefaultProps.FILLER_LIFESPAN_TOUGH);
+		
+		Property fillerLifespanNormalProp = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "filler.lifespan.other", DefaultProps.FILLER_LIFESPAN_NORMAL);
+		fillerLifespanNormalProp.comment = "Lifespan in ticks of items dropped by the filler from non-tough blocks (those that can be broken by hand)";
+		fillerLifespanNormal = fillerLifespanNormalProp.getInt(DefaultProps.FILLER_LIFESPAN_NORMAL);
 
 		templateItem = new ItemBptTemplate(templateItemId.getInt());
 		templateItem.setUnlocalizedName("templateItem");

--- a/common/buildcraft/builders/FillerPattern.java
+++ b/common/buildcraft/builders/FillerPattern.java
@@ -114,7 +114,10 @@ public abstract class FillerPattern implements IFillerPattern {
 			if (BuildCraftBuilders.fillerDestroy) {
 				world.setBlock(lastX, lastY, lastZ, 0);
 			} else {
-				BlockUtil.breakBlock(world, lastX, lastY, lastZ, 20);
+				if(BlockUtil.isToughBlock(world, lastX, lastY, lastZ))
+					BlockUtil.breakBlock(world, lastX, lastY, lastZ, BuildCraftBuilders.fillerLifespanTough);
+				else
+					BlockUtil.breakBlock(world, lastX, lastY, lastZ, BuildCraftBuilders.fillerLifespanNormal);
 			}
 			return true;
 		}

--- a/common/buildcraft/core/DefaultProps.java
+++ b/common/buildcraft/core/DefaultProps.java
@@ -115,6 +115,9 @@ public class DefaultProps {
 	public static double PIPES_DURABILITY = 0.25D;
 	public static boolean FILLER_DESTROY = false;
 	public static boolean USE_PIPELOSS = true;
+	
+	public static final int FILLER_LIFESPAN_TOUGH = 20;
+	public static final int FILLER_LIFESPAN_NORMAL = 6000;
 
 	public static int TRIGGER_REDSTONE_ACTIVE = 1;
 	public static int TRIGGER_REDSTONE_INACTIVE = 2;

--- a/common/buildcraft/core/utils/BlockUtil.java
+++ b/common/buildcraft/core/utils/BlockUtil.java
@@ -97,6 +97,13 @@ public class BlockUtil {
 
 		return blockID == 0 || block == null || BuildCraftAPI.softBlocks[blockID] || block.isAirBlock(world, x, y, z);
 	}
+	
+	/**
+	 * Returns true if a block cannot be harvested without a tool.
+	 */
+	public static boolean isToughBlock(World world, int x, int y, int z) {
+		return !world.getBlockMaterial(x, y, z).isToolNotRequired();
+	}
 
 	/**
 	 * Create an explosion which only affects a single block.


### PR DESCRIPTION
Differentiated "tough" blocks (which require a tool to harvest) and "non-tough" blocks (which don't).
By default dropped items from tough blocks last for 20 ticks, and dropped items from other blocks last for 6000 ticks (the normal lifespan for items dropped by a player).
This makes fillers useful for chopping down large trees again, but doesn't make them cheap quarries - if you use them for mining you'll only get the dirt and gravel.
