### PR TITLE
Updated Liquid Pipe Connection Logic

### DIFF
--- a/common/buildcraft/transport/PipeTransportLiquids.java
+++ b/common/buildcraft/transport/PipeTransportLiquids.java
@@ -507,7 +507,7 @@ public class PipeTransportLiquids extends PipeTransport implements ITankContaine
 		if (tile instanceof ITankContainer) {
 			ITankContainer liq = (ITankContainer) tile;
 
-			if (liq.getTanks(side) != null && liq.getTanks(side).length > 0)
+			if (liq.getTanks(side.getOpposite()) != null && liq.getTanks(side.getOpposite()).length > 0)
 				return true;
 		}
 


### PR DESCRIPTION
Due to a change in base pipe connection logic, liquid pipes are querying the wrong side. This fixes that.

Yes, I wrote the original connection check. At the time, it was infact correct due to how getOpposite() was handled earlier in the chain.

Signed-off-by: King Lemming kinglemming@gmail.com
