### PR TITLE
Pipe wires persistence between runs

### DIFF
--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -210,8 +210,11 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 
 		for (int i = 0; i < 4; ++i) {
 			nbttagcompound.setBoolean("wireSet[" + i + "]", wireSet[i]);
+			nbttagcompound.setBoolean("wireState[" + i + "]", broadcastSignal[i]);
 		}
 
+		nbttagcompound.setBoolean("redstoneState", broadcastRedstone);
+		
 		for (int i = 0; i < 8; ++i) {
 			nbttagcompound.setInteger("action[" + i + "]", activatedActions[i] != null ? activatedActions[i].getId() : 0);
 			nbttagcompound.setInteger("trigger[" + i + "]", activatedTriggers[i] != null ? activatedTriggers[i].getId() : 0);
@@ -245,8 +248,11 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 
 		for (int i = 0; i < 4; ++i) {
 			wireSet[i] = nbttagcompound.getBoolean("wireSet[" + i + "]");
+			broadcastSignal[i] = nbttagcompound.getBoolean("wireState[" + i + "]");
 		}
 
+		broadcastRedstone = nbttagcompound.getBoolean("redstoneState");
+		
 		for (int i = 0; i < 8; ++i) {
 			activatedActions[i] = ActionManager.actions[nbttagcompound.getInteger("action[" + i + "]")];
 			activatedTriggers[i] = ActionManager.triggers[nbttagcompound.getInteger("trigger[" + i + "]")];


### PR DESCRIPTION
At this point, wires lose their state upon Minecraft restart. Would be logical to make them store states via NBT and then restore on load.
PROS: Allows memory circuits, at example RS latch

EXAMPLE: We're having a couple of engines and a TE's redstone energy cell. linked to them. As engines need some time to boot, it's ineffective to use them as IC2 generators. So we place diamond OR gate adjacent to redstone cell, then put a couple of iron gates adjacent to engines and connect all of them with red pipe wires. Diamond gate's config:
1. Energy full: Blue wire on
2. Red wire off: Blue wire on
3. Energy empty: Red wire on
4. Blue wire off: Red wire on
5. Red wire on: Redstone on
Redstone energy cell: requires low redstone to output
Iron gate config: Red wire on: Redstone on
In this setup, 2. and 4. lines from diamond gate effectively create RS latch with one flaw - all wires will be reset to "off" on restart, so a latch will break and begin to pulse. With wire persistence, it will continue operate as expected.
