### PR TITLE
Added pumping.controlList option.

### DIFF
--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -42,6 +42,7 @@ import buildcraft.factory.BptBlockTank;
 import buildcraft.factory.FactoryProxy;
 import buildcraft.factory.FactoryProxyClient;
 import buildcraft.factory.GuiHandler;
+import buildcraft.factory.PumpDimensionList;
 import buildcraft.factory.TileAutoWorkbench;
 import buildcraft.factory.TileHopper;
 import buildcraft.factory.TileMiningWell;
@@ -82,6 +83,8 @@ public class BuildCraftFactory {
 	public static boolean hopperDisabled;
 
 	public static boolean allowMining = true;
+	
+	public static PumpDimensionList pumpDimensionList;
 
 	@Instance("BuildCraft|Factory")
 	public static BuildCraftFactory instance;
@@ -155,6 +158,8 @@ public class BuildCraftFactory {
 	@PreInit
 	public void initialize(FMLPreInitializationEvent evt) {
 		allowMining = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "mining.enabled", true).getBoolean(true);
+		
+		pumpDimensionList = new PumpDimensionList(BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "pumping.controlList", DefaultProps.PUMP_DIMENSION_LIST).getString());
 
 		Property miningWellId = BuildCraftCore.mainConfiguration.getBlock("miningWell.id", DefaultProps.MINING_WELL_ID);
 		Property plainPipeId = BuildCraftCore.mainConfiguration.getBlock("drill.id", DefaultProps.DRILL_ID);

--- a/common/buildcraft/core/BlockIndex.java
+++ b/common/buildcraft/core/BlockIndex.java
@@ -89,6 +89,6 @@ public class BlockIndex implements Comparable<BlockIndex> {
 
 	@Override
 	public int hashCode() {
-		return i + j << 8 + k << 16;
+		return (i * 37 + j) * 37 + k;
 	}
 }

--- a/common/buildcraft/core/DefaultProps.java
+++ b/common/buildcraft/core/DefaultProps.java
@@ -32,6 +32,8 @@ public class DefaultProps {
 
 	public static final String DEFAULT_LANGUAGE = "en_US";
 
+	public static String PUMP_DIMENSION_LIST = "+/*/*,+/-1/Lava";
+
 	public static int WOODEN_GEAR_ID = 19100;
 	public static int STONE_GEAR_ID = 19101;
 	public static int IRON_GEAR_ID = 19102;


### PR DESCRIPTION
Allows admins to whitelist or blacklist pumping of specific liquids in specific dimensions.
Eg. "-/-1/Lava" will disable lava in the nether. "-/_/Lava" will disable lava in any dimension. "+/0/_" will enable any liquid in the overworld.

Default is "+/_/_,+/-1/Lava" - the second redundant entry is there to show the format.

Also fixed BlockIndex hashcode (massively speeding up pump searches) and added a timeout for pump searches.
