### PR TITLE
Added null check

### DIFF
--- a/common/buildcraft/core/inventory/TransactorVanillaSided.java
+++ b/common/buildcraft/core/inventory/TransactorVanillaSided.java
@@ -29,7 +29,7 @@ public class TransactorVanillaSided extends TransactorSimple {
     private int getSlotOnSideForStack(ItemStack stack, ForgeDirection orientation, int slotIndex)
     {
         int[] sideSlots = sided.getAccessibleSlotsFromSide(orientation.ordinal());
-        if (slotIndex >= sideSlots.length)
+        if (sideSlots == null || slotIndex >= sideSlots.length)
             return -1;
         int targetSlot = sideSlots[slotIndex];
         return sided.isStackValidForSlot(targetSlot, stack) && sided.canInsertItem(targetSlot, stack, orientation.ordinal()) ? targetSlot : -1;


### PR DESCRIPTION
Fixes https://github.com/BuildCraft/BuildCraft/issues/885
It should always return an empty array for an invalid side, but it seems Tinkers Construct returns null.
