### PR TITLE
allow IPipe to be used in a much wider set of situations

### DIFF
--- a/common/buildcraft/api/transport/IPipe.java
+++ b/common/buildcraft/api/transport/IPipe.java
@@ -10,8 +10,10 @@
 package buildcraft.api.transport;
 
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeDirection;
 
-public interface IPipe {
+public interface IPipe{ // extends IPipeConnection
 
 	enum DrawingState {
 		DrawingPipe, DrawingRedWire, DrawingBlueWire, DrawingGreenWire, DrawingYellowWire, DrawingGate
@@ -35,11 +37,23 @@ public interface IPipe {
 	}
 
 	public boolean isWired(WireColor color);
+	public boolean isWireConnectedTo(TileEntity tile, WireColor color);
+	public int signalStrength(WireColor color);
+
+	public boolean hasGate();
 
 	public boolean hasInterface();
 
 	public TileEntity getContainer();
 
-	public boolean isWireConnectedTo(TileEntity tile, WireColor color);
+	public boolean canPipeConnect(TileEntity tile, ForgeDirection o);
+	public IPipeLogic getLogic();	// primarily used for instanceof testing
+	public IPipeTransport getTransport();
 
+	public World getWorld();
+
+	int getXPosition();
+	int getYPosition();
+	int getZPosition();
+	
 }

--- a/common/buildcraft/api/transport/IPipeLogic.java
+++ b/common/buildcraft/api/transport/IPipeLogic.java
@@ -1,0 +1,5 @@
+package buildcraft.api.transport;
+
+public interface IPipeLogic {
+
+}

--- a/common/buildcraft/api/transport/IPipeTile.java
+++ b/common/buildcraft/api/transport/IPipeTile.java
@@ -9,9 +9,25 @@
 
 package buildcraft.api.transport;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeDirection;
+
 public interface IPipeTile {
 
 	IPipe getPipe();
 
 	boolean isInitialized();
+
+	TileEntity getTile(ForgeDirection o);
+	
+	int getXCoord();
+	int getYCoord();
+	int getZCoord();
+
+	void scheduleRenderUpdate();
+
+	World getWorld();
+
+	boolean hasFacade(ForgeDirection east);
 }

--- a/common/buildcraft/api/transport/IPipeTransport.java
+++ b/common/buildcraft/api/transport/IPipeTransport.java
@@ -1,0 +1,5 @@
+package buildcraft.api.transport;
+
+public interface IPipeTransport {
+
+}

--- a/common/buildcraft/core/inventory/SimpleInventory.java
+++ b/common/buildcraft/core/inventory/SimpleInventory.java
@@ -87,7 +87,7 @@ public class SimpleInventory implements IInventory, INBTTagable {
 
 	@Override
 	public boolean isUseableByPlayer(EntityPlayer entityplayer) {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/common/buildcraft/core/utils/Utils.java
+++ b/common/buildcraft/core/utils/Utils.java
@@ -36,6 +36,7 @@ import buildcraft.api.core.LaserKind;
 import buildcraft.api.core.Position;
 import buildcraft.api.transport.IPipeConnection;
 import buildcraft.api.transport.IPipeEntry;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.api.transport.IPipedItem;
 import buildcraft.core.BlockIndex;
 import buildcraft.core.EntityBlock;
@@ -423,32 +424,38 @@ public class Utils {
 		}
 	}
 
-	public static boolean checkPipesConnections(TileEntity tile1, TileEntity tile2) {
-		if (tile1 == null || tile2 == null) {
+	public static boolean checkPipesConnections(IPipeTile container, TileEntity tile2) {
+		if (container == null || tile2 == null) {
 			return false;
 		}
 
-		if (!(tile1 instanceof IPipeConnection) && !(tile2 instanceof IPipeConnection)) {
+		if (!(container instanceof IPipeConnection) && !(tile2 instanceof IPipeConnection)) {
 			return false;
 		}
 
 		ForgeDirection o = ForgeDirection.UNKNOWN;
 
-		if (tile1.xCoord - 1 == tile2.xCoord) {
-			o = ForgeDirection.WEST;
-		} else if (tile1.xCoord + 1 == tile2.xCoord) {
-			o = ForgeDirection.EAST;
-		} else if (tile1.yCoord - 1 == tile2.yCoord) {
-			o = ForgeDirection.DOWN;
-		} else if (tile1.yCoord + 1 == tile2.yCoord) {
-			o = ForgeDirection.UP;
-		} else if (tile1.zCoord - 1 == tile2.zCoord) {
-			o = ForgeDirection.NORTH;
-		} else if (tile1.zCoord + 1 == tile2.zCoord) {
-			o = ForgeDirection.SOUTH;
+		if(container.getXCoord() != tile2.xCoord){
+			if (container.getXCoord() > tile2.xCoord) {
+				o = ForgeDirection.WEST;
+			} else {
+				o = ForgeDirection.EAST;
+			}
+		} else if((container.getYCoord() != tile2.yCoord)){
+			if (container.getYCoord() > tile2.yCoord) {
+				o = ForgeDirection.DOWN;
+			} else {
+				o = ForgeDirection.UP;
+			}
+		} else if((container.getZCoord() != tile2.zCoord)){
+			if (container.getZCoord() > tile2.zCoord) {
+				o = ForgeDirection.NORTH;
+			} else {
+				o = ForgeDirection.SOUTH;
+			}
 		}
 
-		if (tile1 instanceof IPipeConnection && !((IPipeConnection) tile1).isPipeConnected(o)) {
+		if (container instanceof IPipeConnection && !((IPipeConnection) container).isPipeConnected(o)) {
 			return false;
 		}
 
@@ -459,7 +466,7 @@ public class Utils {
 		return true;
 	}
 
-	public static boolean checkPipesConnections(IBlockAccess blockAccess, TileEntity tile1, int x2, int y2, int z2) {
+	public static boolean checkPipesConnections(IBlockAccess blockAccess, IPipeTile tile1, int x2, int y2, int z2) {
 		TileEntity tile2 = blockAccess.getBlockTileEntity(x2, y2, z2);
 
 		return checkPipesConnections(tile1, tile2);

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -39,6 +39,7 @@ import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftTransport;
 import buildcraft.api.tools.IToolWrench;
 import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.api.transport.ISolidSideTile;
 import buildcraft.core.BlockIndex;
 import buildcraft.core.proxy.CoreProxy;
@@ -119,34 +120,34 @@ public class BlockGenericPipe extends BlockContainer {
 		super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 
 		TileEntity tile1 = world.getBlockTileEntity(i, j, k);
-		TileGenericPipe tileG = (TileGenericPipe) tile1;
+		IPipeTile tileG = (IPipeTile) tile1;
 
-		if (Utils.checkPipesConnections(world, tile1, i - 1, j, k)) {
+		if (Utils.checkPipesConnections(world, tileG, i - 1, j, k)) {
 			setBlockBounds(0.0F, Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMaxPos, Utils.pipeMaxPos, Utils.pipeMaxPos);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
 
-		if (Utils.checkPipesConnections(world, tile1, i + 1, j, k)) {
+		if (Utils.checkPipesConnections(world, tileG, i + 1, j, k)) {
 			setBlockBounds(Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMinPos, 1.0F, Utils.pipeMaxPos, Utils.pipeMaxPos);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
 
-		if (Utils.checkPipesConnections(world, tile1, i, j - 1, k)) {
+		if (Utils.checkPipesConnections(world, tileG, i, j - 1, k)) {
 			setBlockBounds(Utils.pipeMinPos, 0.0F, Utils.pipeMinPos, Utils.pipeMaxPos, Utils.pipeMaxPos, Utils.pipeMaxPos);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
 
-		if (Utils.checkPipesConnections(world, tile1, i, j + 1, k)) {
+		if (Utils.checkPipesConnections(world, tileG, i, j + 1, k)) {
 			setBlockBounds(Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMaxPos, 1.0F, Utils.pipeMaxPos);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
 
-		if (Utils.checkPipesConnections(world, tile1, i, j, k - 1)) {
+		if (Utils.checkPipesConnections(world, tileG, i, j, k - 1)) {
 			setBlockBounds(Utils.pipeMinPos, Utils.pipeMinPos, 0.0F, Utils.pipeMaxPos, Utils.pipeMaxPos, Utils.pipeMaxPos);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
 
-		if (Utils.checkPipesConnections(world, tile1, i, j, k + 1)) {
+		if (Utils.checkPipesConnections(world, tileG, i, j, k + 1)) {
 			setBlockBounds(Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMinPos, Utils.pipeMaxPos, Utils.pipeMaxPos, 1.0F);
 			super.addCollisionBoxesToList(world, i, j, k, axisalignedbb, arraylist, par7Entity);
 		}
@@ -192,31 +193,30 @@ public class BlockGenericPipe extends BlockContainer {
 	public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int i, int j, int k) {
 		float xMin = Utils.pipeMinPos, xMax = Utils.pipeMaxPos, yMin = Utils.pipeMinPos, yMax = Utils.pipeMaxPos, zMin = Utils.pipeMinPos, zMax = Utils.pipeMaxPos;
 
-		TileEntity tile1 = world.getBlockTileEntity(i, j, k);
-		TileGenericPipe tileG = (TileGenericPipe) tile1;
+		IPipeTile tileG = (IPipeTile)world.getBlockTileEntity(i, j, k);
 
 		if (tileG != null) {
-			if (Utils.checkPipesConnections(world, tile1, i - 1, j, k) || tileG.hasFacade(ForgeDirection.WEST)) {
+			if (Utils.checkPipesConnections(world, tileG, i - 1, j, k) || tileG.hasFacade(ForgeDirection.WEST)) {
 				xMin = 0.0F;
 			}
 
-			if (Utils.checkPipesConnections(world, tile1, i + 1, j, k) || tileG.hasFacade(ForgeDirection.EAST)) {
+			if (Utils.checkPipesConnections(world, tileG, i + 1, j, k) || tileG.hasFacade(ForgeDirection.EAST)) {
 				xMax = 1.0F;
 			}
 
-			if (Utils.checkPipesConnections(world, tile1, i, j - 1, k) || tileG.hasFacade(ForgeDirection.DOWN)) {
+			if (Utils.checkPipesConnections(world, tileG, i, j - 1, k) || tileG.hasFacade(ForgeDirection.DOWN)) {
 				yMin = 0.0F;
 			}
 
-			if (Utils.checkPipesConnections(world, tile1, i, j + 1, k) || tileG.hasFacade(ForgeDirection.UP)) {
+			if (Utils.checkPipesConnections(world, tileG, i, j + 1, k) || tileG.hasFacade(ForgeDirection.UP)) {
 				yMax = 1.0F;
 			}
 
-			if (Utils.checkPipesConnections(world, tile1, i, j, k - 1) || tileG.hasFacade(ForgeDirection.NORTH)) {
+			if (Utils.checkPipesConnections(world, tileG, i, j, k - 1) || tileG.hasFacade(ForgeDirection.NORTH)) {
 				zMin = 0.0F;
 			}
 
-			if (Utils.checkPipesConnections(world, tile1, i, j, k + 1) || tileG.hasFacade(ForgeDirection.SOUTH)) {
+			if (Utils.checkPipesConnections(world, tileG, i, j, k + 1) || tileG.hasFacade(ForgeDirection.SOUTH)) {
 				zMax = 1.0F;
 			}
 
@@ -279,10 +279,12 @@ public class BlockGenericPipe extends BlockContainer {
 	public RaytraceResult doRayTrace(World world, int x, int y, int z, Vec3 origin, Vec3 direction) {
 		float xMin = Utils.pipeMinPos, xMax = Utils.pipeMaxPos, yMin = Utils.pipeMinPos, yMax = Utils.pipeMaxPos, zMin = Utils.pipeMinPos, zMax = Utils.pipeMaxPos;
 
-		TileEntity pipeTileEntity = world.getBlockTileEntity(x, y, z);
-		Pipe pipe = getPipe(world, x, y, z);
-
-		if (pipeTileEntity == null || !isValid(pipe)) {
+		TileEntity tileEntity = world.getBlockTileEntity(x, y, z);
+		if(tileEntity==null || !(tileEntity instanceof IPipeTile) || tileEntity.isInvalid())
+			return null;
+		IPipeTile pipeTileEntity = (IPipeTile) tileEntity;
+		IPipe pipe = pipeTileEntity.getPipe();
+		if ( !isValid(pipe)) {
 			return null;
 		}
 
@@ -887,12 +889,12 @@ public class BlockGenericPipe extends BlockContainer {
 		return ((TileGenericPipe) tile).pipe;
 	}
 
-	public static boolean isFullyDefined(Pipe pipe) {
-		return pipe != null && pipe.transport != null && pipe.logic != null;
+	public static boolean isFullyDefined(IPipe pipe2) {
+		return pipe2 != null && pipe2.getTransport() != null && pipe2.getLogic() != null;
 	}
 
-	public static boolean isValid(Pipe pipe) {
-		return isFullyDefined(pipe);
+	public static boolean isValid(IPipe pipe2) {
+		return isFullyDefined(pipe2);
 	}
 
 	@Override
@@ -951,27 +953,27 @@ public class BlockGenericPipe extends BlockContainer {
 		double pz = z + rand.nextDouble() * (block.getBlockBoundsMaxZ() - block.getBlockBoundsMinZ() - (b * 2.0F)) + b + block.getBlockBoundsMinZ();
 
 		if (sideHit == 0) {
-			py = (double) y + block.getBlockBoundsMinY() - (double) b;
+			py = y + block.getBlockBoundsMinY() - b;
 		}
 
 		if (sideHit == 1) {
-			py = (double) y + block.getBlockBoundsMaxY() + (double) b;
+			py = y + block.getBlockBoundsMaxY() + b;
 		}
 
 		if (sideHit == 2) {
-			pz = (double) z + block.getBlockBoundsMinZ() - (double) b;
+			pz = z + block.getBlockBoundsMinZ() - b;
 		}
 
 		if (sideHit == 3) {
-			pz = (double) z + block.getBlockBoundsMaxZ() + (double) b;
+			pz = z + block.getBlockBoundsMaxZ() + b;
 		}
 
 		if (sideHit == 4) {
-			px = (double) x + block.getBlockBoundsMinX() - (double) b;
+			px = x + block.getBlockBoundsMinX() - b;
 		}
 
 		if (sideHit == 5) {
-			px = (double) x + block.getBlockBoundsMaxX() + (double) b;
+			px = x + block.getBlockBoundsMaxX() + b;
 		}
 
 		EntityDiggingFX fx = new EntityDiggingFX(worldObj, px, py, pz, 0.0D, 0.0D, 0.0D, block, sideHit, worldObj.getBlockMetadata(x, y, z), Minecraft.getMinecraft().renderEngine);
@@ -1007,9 +1009,9 @@ public class BlockGenericPipe extends BlockContainer {
 		for (int i = 0; i < its; ++i) {
 			for (int j = 0; j < its; ++j) {
 				for (int k = 0; k < its; ++k) {
-					double px = x + (i + 0.5D) / (double) its;
-					double py = y + (j + 0.5D) / (double) its;
-					double pz = z + (k + 0.5D) / (double) its;
+					double px = x + (i + 0.5D) / its;
+					double py = y + (j + 0.5D) / its;
+					double pz = z + (k + 0.5D) / its;
 					int random = rand.nextInt(6);
 					EntityDiggingFX fx = new EntityDiggingFX(worldObj, px, py, pz, px - x - 0.5D, py - y - 0.5D, pz - z - 0.5D, BuildCraftTransport.genericPipeBlock, random, meta, Minecraft.getMinecraft().renderEngine);
 					fx.setParticleIcon(Minecraft.getMinecraft().renderEngine, icon);

--- a/common/buildcraft/transport/GuiHandler.java
+++ b/common/buildcraft/transport/GuiHandler.java
@@ -1,7 +1,6 @@
 package buildcraft.transport;
 
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import buildcraft.core.GuiIds;
@@ -13,6 +12,7 @@ import buildcraft.transport.gui.GuiDiamondPipe;
 import buildcraft.transport.gui.GuiEmeraldPipe;
 import buildcraft.transport.gui.GuiFilteredBuffer;
 import buildcraft.transport.gui.GuiGateInterface;
+import buildcraft.transport.pipes.PipeItemsEmerald;
 import buildcraft.transport.pipes.PipeLogicDiamond;
 import cpw.mods.fml.common.network.IGuiHandler;
 
@@ -43,7 +43,7 @@ public class GuiHandler implements IGuiHandler {
 			return new ContainerDiamondPipe(player.inventory, ((PipeLogicDiamond) pipe.pipe.logic).getFilters());
 			
 		case GuiIds.PIPE_EMERALD_ITEM:
-			return new ContainerEmeraldPipe(player.inventory, (IInventory) pipe.pipe);
+			return new ContainerEmeraldPipe(player.inventory, ((PipeItemsEmerald) pipe.pipe).getFilters());
 
 		case GuiIds.GATES:
 			return new ContainerGateInterface(player.inventory, pipe.pipe);

--- a/common/buildcraft/transport/ITriggerPipe.java
+++ b/common/buildcraft/transport/ITriggerPipe.java
@@ -10,9 +10,10 @@
 package buildcraft.transport;
 
 import buildcraft.api.gates.ITriggerParameter;
+import buildcraft.api.transport.IPipe;
 
 public interface ITriggerPipe {
 
-	public boolean isTriggerActive(Pipe pipe, ITriggerParameter parameter);
+	public boolean isTriggerActive(IPipe pipe, ITriggerParameter parameter);
 
 }

--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -34,6 +34,7 @@ import buildcraft.api.gates.ITrigger;
 import buildcraft.api.gates.ITriggerParameter;
 import buildcraft.api.gates.TriggerParameter;
 import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipe.WireColor;
 import buildcraft.core.IDropControlInventory;
 import buildcraft.core.network.TilePacketWrapper;
 import buildcraft.core.triggers.ActionRedstoneOutput;
@@ -91,6 +92,38 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 		}
 
 	}
+	
+	// IPipe Interface update
+	@Override
+	public PipeLogic getLogic() {
+		return this.logic;
+	}
+
+	@Override
+	public PipeTransport getTransport() {
+		return this.transport;
+	}
+
+	@Override
+	public World getWorld() {
+		return this.worldObj;
+	}
+
+	@Override
+	public int getXPosition() {
+		return this.xCoord;
+	}
+
+	@Override
+	public int getYPosition() {
+		return this.yCoord;
+	}
+
+	@Override
+	public int getZPosition() {
+		return this.zCoord;
+	}
+
 
 	private void setPosition(int xCoord, int yCoord, int zCoord) {
 		this.xCoord = xCoord;
@@ -666,7 +699,7 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 		ForgeDirection target_orientation = ForgeDirection.UNKNOWN;
 
 		for (ForgeDirection o : ForgeDirection.VALID_DIRECTIONS)
-			if (Utils.checkPipesConnections(container.getTile(o), container)) {
+			if (Utils.checkPipesConnections(container, container.getTile(o))) {
 
 				Connections_num++;
 
@@ -728,5 +761,9 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
         fixedTriggers = true;
 
     }
-
+    
+	@Override
+	public int signalStrength(WireColor color) {
+		return signalStrength[color.ordinal()];
+	}
 }

--- a/common/buildcraft/transport/PipeTransport.java
+++ b/common/buildcraft/transport/PipeTransport.java
@@ -13,9 +13,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
-import buildcraft.api.transport.IPipedItem;
 
-public abstract class PipeTransport {
+import buildcraft.api.transport.IPipedItem;
+import buildcraft.api.transport.IPipeTransport;
+
+public abstract class PipeTransport implements IPipeTransport{
 
 	public int xCoord;
 	public int yCoord;

--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -32,7 +32,9 @@ import buildcraft.BuildCraftTransport;
 import buildcraft.api.core.Position;
 import buildcraft.api.gates.ITrigger;
 import buildcraft.api.inventory.ISpecialInventory;
+import buildcraft.api.transport.IPipe;
 import buildcraft.api.transport.IPipeEntry;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.api.transport.IPipedItem;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.EntityPassiveItem;
@@ -212,7 +214,7 @@ public class PipeTransportItems extends PipeTransport {
 	public boolean canReceivePipeObjects(ForgeDirection o, IPipedItem item) {
 		TileEntity entity = container.getTile(o);
 
-		if (!Utils.checkPipesConnections(entity, container))
+		if (!Utils.checkPipesConnections(container, entity))
 			return false;
 
 		if (entity instanceof IPipeEntry)
@@ -527,9 +529,9 @@ public class PipeTransportItems extends PipeTransport {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		if (tile instanceof TileGenericPipe) {
-			Pipe pipe2 = ((TileGenericPipe) tile).pipe;
-			if (BlockGenericPipe.isValid(pipe2) && !(pipe2.transport instanceof PipeTransportItems))
+		if (tile instanceof IPipeTile) {
+			IPipe pipe2 = ((IPipeTile) tile).getPipe();
+			if (BlockGenericPipe.isValid(pipe2) && !(pipe2.getTransport() instanceof PipeTransportItems))
 				return false;
 		}
 

--- a/common/buildcraft/transport/PipeTransportLiquids.java
+++ b/common/buildcraft/transport/PipeTransportLiquids.java
@@ -488,7 +488,7 @@ public class PipeTransportLiquids extends PipeTransport implements ITankContaine
 		super.onNeighborBlockChange(blockId);
 
 		for (ForgeDirection direction : directions) {
-			if (!Utils.checkPipesConnections(container.getTile(orientations[direction.ordinal()]), container)) {
+			if (!Utils.checkPipesConnections(container, container.getTile(orientations[direction.ordinal()]))) {
 				internalTanks[direction.ordinal()].reset();
 				transferState[direction.ordinal()] = TransferState.None;
 				renderCache[direction.ordinal()] = null;

--- a/common/buildcraft/transport/PipeTransportPower.java
+++ b/common/buildcraft/transport/PipeTransportPower.java
@@ -84,7 +84,7 @@ public class PipeTransportPower extends PipeTransport {
 	private void updateTiles() {
 		for (int i = 0; i < 6; ++i) {
 			TileEntity tile = container.getTile(ForgeDirection.VALID_DIRECTIONS[i]);
-			if (Utils.checkPipesConnections(tile, container)) {
+			if (Utils.checkPipesConnections(container,tile)) {
 				tiles[i] = tile;
 			} else {
 				tiles[i] = null;

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -78,7 +78,7 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 	public TileBuffer[] tileBuffer;
 	public boolean[] pipeConnectionsBuffer = new boolean[6];
 	public SafeTimeTracker networkSyncTracker = new SafeTimeTracker();
-	public Pipe pipe;
+	protected Pipe pipe;
 	private boolean blockNeighborChange = false;
 	private boolean refreshRenderState = false;
 	private boolean pipeBound = false;
@@ -726,5 +726,25 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, ITank
 			return block.blockID;
 		}
 		return 0;
+	}
+
+	@Override
+	public final int getXCoord() {
+		return xCoord;
+	}
+
+	@Override
+	public final int getYCoord() {
+		return yCoord;
+	}
+
+	@Override
+	public final int getZCoord() {
+		return zCoord;
+	}
+
+	@Override
+	public World getWorld() {
+		return this.worldObj;
 	}
 }

--- a/common/buildcraft/transport/gui/ContainerGateInterface.java
+++ b/common/buildcraft/transport/gui/ContainerGateInterface.java
@@ -70,7 +70,7 @@ public class ContainerGateInterface extends BuildCraftContainer {
 			_potentialActions.addAll(pipe.getActions());
 			_potentialTriggers.addAll(ActionManager.getPipeTriggers(pipe));
 
-			TileEntity ptile = pipe.worldObj.getBlockTileEntity(pipe.xCoord, pipe.yCoord, pipe.zCoord);
+			TileEntity ptile = pipe.worldObj.getBlockTileEntity(pipe.getXPosition(), pipe.getYPosition(), pipe.getZPosition());
 			if (ptile instanceof IOverrideDefaultTriggers) {
 				_potentialTriggers.addAll(((IOverrideDefaultTriggers) ptile).getTriggers());
 			}

--- a/common/buildcraft/transport/gui/GuiDiamondPipe.java
+++ b/common/buildcraft/transport/gui/GuiDiamondPipe.java
@@ -11,10 +11,10 @@ import net.minecraft.inventory.IInventory;
 
 import org.lwjgl.opengl.GL11;
 
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.gui.GuiBuildCraft;
 import buildcraft.core.utils.StringUtils;
-import buildcraft.transport.TileGenericPipe;
 import buildcraft.transport.pipes.PipeLogicDiamond;
 
 public class GuiDiamondPipe extends GuiBuildCraft {
@@ -22,10 +22,10 @@ public class GuiDiamondPipe extends GuiBuildCraft {
 	IInventory playerInventory;
 	PipeLogicDiamond filterInventory;
 
-	public GuiDiamondPipe(IInventory playerInventory, TileGenericPipe tile) {
-		super(new ContainerDiamondPipe(playerInventory, (IInventory) tile.pipe.logic), (IInventory) tile.pipe.logic);
+	public GuiDiamondPipe(IInventory playerInventory, IPipeTile tile) {
+		super(new ContainerDiamondPipe(playerInventory, ((PipeLogicDiamond)tile.getPipe().getLogic()).getFilters()), ((PipeLogicDiamond)tile.getPipe().getLogic()).getFilters());
 		this.playerInventory = playerInventory;
-		this.filterInventory = (PipeLogicDiamond) tile.pipe.logic;
+		this.filterInventory = (PipeLogicDiamond) tile.getPipe().getLogic();
 		xSize = 175;
 		ySize = 225;
 	}

--- a/common/buildcraft/transport/gui/GuiEmeraldPipe.java
+++ b/common/buildcraft/transport/gui/GuiEmeraldPipe.java
@@ -11,10 +11,10 @@ import net.minecraft.inventory.IInventory;
 
 import org.lwjgl.opengl.GL11;
 
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.gui.GuiBuildCraft;
 import buildcraft.core.utils.StringUtils;
-import buildcraft.transport.TileGenericPipe;
 import buildcraft.transport.pipes.PipeItemsEmerald;
 
 public class GuiEmeraldPipe extends GuiBuildCraft {
@@ -22,10 +22,10 @@ public class GuiEmeraldPipe extends GuiBuildCraft {
 	IInventory playerInventory;
 	PipeItemsEmerald filterInventory;
 
-	public GuiEmeraldPipe(IInventory playerInventory, TileGenericPipe tile) {
-		super(new ContainerEmeraldPipe(playerInventory, (IInventory) tile.pipe), (IInventory) tile.pipe);
+	public GuiEmeraldPipe(IInventory playerInventory, IPipeTile tile) {
+		super(new ContainerEmeraldPipe(playerInventory, ((PipeItemsEmerald) tile.getPipe()).getFilters()), ((PipeItemsEmerald) tile.getPipe()).getFilters());
 		this.playerInventory = playerInventory;
-		this.filterInventory = (PipeItemsEmerald) tile.pipe;
+		this.filterInventory = (PipeItemsEmerald) tile.getPipe();
 		xSize = 175;
 		ySize = 132;
 	}

--- a/common/buildcraft/transport/network/PacketHandlerTransport.java
+++ b/common/buildcraft/transport/network/PacketHandlerTransport.java
@@ -10,6 +10,8 @@ import net.minecraft.network.INetworkManager;
 import net.minecraft.network.packet.Packet250CustomPayload;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.core.network.PacketCoordinates;
 import buildcraft.core.network.PacketIds;
 import buildcraft.core.network.PacketSlotChange;
@@ -160,17 +162,17 @@ public class PacketHandlerTransport implements IPacketHandler {
 	}
 
 	private void onPipeContentNBT(EntityPlayer player, PacketPipeTransportNBT packet) {
-		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		IPipeTile pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
 		if (pipe == null)
 			return;
 
-		if (pipe.pipe == null)
+		if (pipe.getPipe() == null)
 			return;
 
-		if (!(pipe.pipe.transport instanceof PipeTransportItems))
+		if (!(pipe.getPipe().getTransport() instanceof PipeTransportItems))
 			return;
 
-		((PipeTransportItems)pipe.pipe.transport).handleNBTPacket(packet);
+		((PipeTransportItems)pipe.getPipe().getTransport()).handleNBTPacket(packet);
 	}
 
 	/**
@@ -213,13 +215,13 @@ public class PacketHandlerTransport implements IPacketHandler {
 			return;
 
 		TileGenericPipe pipe = (TileGenericPipe) entity;
-		if (pipe.pipe == null)
+		if (pipe.getPipe() == null)
 			return;
 
-		if (!(pipe.pipe.transport instanceof PipeTransportItems))
+		if (!(pipe.getPipe().getTransport() instanceof PipeTransportItems))
 			return;
 
-		((PipeTransportItems) pipe.pipe.transport).handleItemPacket(packet);
+		((PipeTransportItems) pipe.getPipe().getTransport()).handleItemPacket(packet);
 	}
 
 	/**
@@ -237,13 +239,13 @@ public class PacketHandlerTransport implements IPacketHandler {
 			return;
 
 		TileGenericPipe pipe = (TileGenericPipe) entity;
-		if (pipe.pipe == null)
+		if (pipe.getPipe() == null)
 			return;
 
-		if (!(pipe.pipe.transport instanceof PipeTransportPower))
+		if (!(pipe.getPipe().getTransport() instanceof PipeTransportPower))
 			return;
 
-		((PipeTransportPower) pipe.pipe.transport).handlePowerPacket(packetPower);
+		((PipeTransportPower) pipe.getPipe().getTransport()).handlePowerPacket(packetPower);
 
 	}
 
@@ -297,7 +299,7 @@ public class PacketHandlerTransport implements IPacketHandler {
 	 * @param z
 	 * @return
 	 */
-	private TileGenericPipe getPipe(World world, int x, int y, int z) {
+	private IPipeTile getPipe(World world, int x, int y, int z) {
 		if (!world.blockExists(x, y, z))
 			return null;
 
@@ -315,14 +317,14 @@ public class PacketHandlerTransport implements IPacketHandler {
 	 * @param packet
 	 */
 	private void onDiamondPipeSelect(EntityPlayer player, PacketSlotChange packet) {
-		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		IPipeTile pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
 		if (pipe == null)
 			return;
 
-		if (!(pipe.pipe.logic instanceof PipeLogicDiamond))
+		if (!(pipe.getPipe().getLogic() instanceof PipeLogicDiamond))
 			return;
 
-		((PipeLogicDiamond) pipe.pipe.logic).getFilters().setInventorySlotContents(packet.slot, packet.stack);
+		((PipeLogicDiamond) pipe.getPipe().getLogic()).getFilters().setInventorySlotContents(packet.slot, packet.stack);
 	}
 	
 	/**
@@ -332,14 +334,14 @@ public class PacketHandlerTransport implements IPacketHandler {
 	 * @param packet
 	 */
 	private void onEmeraldPipeSelect(EntityPlayer player, PacketSlotChange packet) {
-		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		IPipeTile pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
 		if (pipe == null)
 			return;
 
-		if (!(pipe.pipe instanceof PipeItemsEmerald))
+		if (!(pipe.getPipe() instanceof PipeItemsEmerald))
 			return;
 
-		((PipeItemsEmerald) pipe.pipe).getFilters().setInventorySlotContents(packet.slot, packet.stack);
+		((PipeItemsEmerald) pipe.getPipe()).getFilters().setInventorySlotContents(packet.slot, packet.stack);
 	}
 
 	/**
@@ -348,16 +350,16 @@ public class PacketHandlerTransport implements IPacketHandler {
 	 * @param packet
 	 */
 	private void onItemNBTRequest(EntityPlayerMP player, PacketSimpleId packet) {
-		TileGenericPipe pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
+		IPipeTile pipe = getPipe(player.worldObj, packet.posX, packet.posY, packet.posZ);
 		if (pipe == null)
 			return;
 
-		if (pipe.pipe == null)
+		if (pipe.getPipe() == null)
 			return;
 
-		if (!(pipe.pipe.transport instanceof PipeTransportItems))
+		if (!(pipe.getPipe().getTransport() instanceof PipeTransportItems))
 			return;
 
-		((PipeTransportItems) pipe.pipe.transport).handleNBTRequestPacket(player, packet.entityId);
+		((PipeTransportItems) pipe.getPipe().getTransport()).handleNBTRequestPacket(player, packet.entityId);
 	}
 }

--- a/common/buildcraft/transport/network/PacketLiquidUpdate.java
+++ b/common/buildcraft/transport/network/PacketLiquidUpdate.java
@@ -9,11 +9,11 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.liquids.LiquidStack;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.core.network.PacketCoordinates;
 import buildcraft.core.network.PacketIds;
 import buildcraft.core.proxy.CoreProxy;
 import buildcraft.transport.PipeTransportLiquids;
-import buildcraft.transport.TileGenericPipe;
 
 public class PacketLiquidUpdate extends PacketCoordinates {
 
@@ -41,17 +41,17 @@ public class PacketLiquidUpdate extends PacketCoordinates {
 			return;
 
 		TileEntity entity = world.getBlockTileEntity(posX, posY, posZ);
-		if (!(entity instanceof TileGenericPipe))
+		if (!(entity instanceof IPipeTile))
 			return;
 
-		TileGenericPipe pipe = (TileGenericPipe) entity;
-		if (pipe.pipe == null)
+		IPipeTile pipe = (IPipeTile) entity;
+		if (pipe.getPipe() == null)
 			return;
 
-		if (!(pipe.pipe.transport instanceof PipeTransportLiquids))
+		if (!(pipe.getPipe().getTransport() instanceof PipeTransportLiquids))
 			return;
 
-		PipeTransportLiquids transLiq = ((PipeTransportLiquids) pipe.pipe.transport);
+		PipeTransportLiquids transLiq = ((PipeTransportLiquids) pipe.getPipe().getTransport());
 
 		renderCache = transLiq.renderCache;
 

--- a/common/buildcraft/transport/pipes/PipeLiquidsSandstone.java
+++ b/common/buildcraft/transport/pipes/PipeLiquidsSandstone.java
@@ -13,11 +13,11 @@ import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.liquids.LiquidStack;
 import buildcraft.BuildCraftTransport;
 import buildcraft.api.core.IIconProvider;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.IPipeTransportLiquidsHook;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeIconProvider;
 import buildcraft.transport.PipeTransportLiquids;
-import buildcraft.transport.TileGenericPipe;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -42,7 +42,7 @@ public class PipeLiquidsSandstone extends Pipe implements IPipeTransportLiquidsH
 		if (container.tileBuffer == null || container.tileBuffer[from.ordinal()] == null)
 			return 0;
 
-		if (!(container.tileBuffer[from.ordinal()].getTile() instanceof TileGenericPipe))
+		if (!(container.tileBuffer[from.ordinal()].getTile() instanceof IPipeTile))
 			return 0;
 
 		return ((PipeTransportLiquids) this.transport).getTanks(ForgeDirection.UNKNOWN)[from.ordinal()].fill(resource, doFill);

--- a/common/buildcraft/transport/pipes/PipeLiquidsWood.java
+++ b/common/buildcraft/transport/pipes/PipeLiquidsWood.java
@@ -155,4 +155,5 @@ public class PipeLiquidsWood extends Pipe implements IPowerReceptor {
 			return true;
 		return super.canConnectRedstone();
 	}
+
 }

--- a/common/buildcraft/transport/pipes/PipeLogic.java
+++ b/common/buildcraft/transport/pipes/PipeLogic.java
@@ -14,16 +14,17 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.api.transport.IPipeLogic;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.core.IDropControlInventory;
-import buildcraft.transport.TileGenericPipe;
 
-public class PipeLogic implements IDropControlInventory {
+public class PipeLogic implements IDropControlInventory, IPipeLogic {
 
 	public int xCoord;
 	public int yCoord;
 	public int zCoord;
 	public World worldObj;
-	public TileGenericPipe container;
+	public IPipeTile container;
 
 	public void setPosition(int xCoord, int yCoord, int zCoord) {
 		this.xCoord = xCoord;
@@ -35,7 +36,7 @@ public class PipeLogic implements IDropControlInventory {
 		this.worldObj = worldObj;
 	}
 
-	public void setTile(TileGenericPipe tile) {
+	public void setTile(IPipeTile tile) {
 		this.container = tile;
 	}
 

--- a/common/buildcraft/transport/pipes/PipeLogicCobblestone.java
+++ b/common/buildcraft/transport/pipes/PipeLogicCobblestone.java
@@ -9,25 +9,25 @@ package buildcraft.transport.pipes;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
-import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 
 public class PipeLogicCobblestone extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
-		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+		if (tile instanceof IPipeTile) {
+			pipe2 = ((IPipeTile) tile).getPipe();
 		}
 
 		if (pipe2 != null) {
-			if (pipe2.logic instanceof PipeLogicStone) {
+			if (pipe2.getLogic() instanceof PipeLogicStone) {
 				return false;
 			}
 
-			if (pipe2.logic instanceof PipeLogicQuartz) {
+			if (pipe2.getLogic() instanceof PipeLogicQuartz) {
 				return false;
 			}
 		}

--- a/common/buildcraft/transport/pipes/PipeLogicDiamond.java
+++ b/common/buildcraft/transport/pipes/PipeLogicDiamond.java
@@ -33,8 +33,8 @@ public class PipeLogicDiamond extends PipeLogic {
 			if (Block.blocksList[entityplayer.getCurrentEquippedItem().itemID] instanceof BlockGenericPipe)
 				return false;
 
-		if (!CoreProxy.proxy.isRenderWorld(container.worldObj)) {
-			entityplayer.openGui(BuildCraftTransport.instance, GuiIds.PIPE_DIAMOND, container.worldObj, container.xCoord, container.yCoord, container.zCoord);
+		if (!CoreProxy.proxy.isRenderWorld(container.getWorld())) {
+			entityplayer.openGui(BuildCraftTransport.instance, GuiIds.PIPE_DIAMOND, container.getWorld(), container.getXCoord(), container.getYCoord(), container.getZCoord());
 		}
 
 		return true;

--- a/common/buildcraft/transport/pipes/PipeLogicIron.java
+++ b/common/buildcraft/transport/pipes/PipeLogicIron.java
@@ -16,9 +16,10 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.liquids.ITankContainer;
 import buildcraft.api.tools.IToolWrench;
+import buildcraft.api.transport.IPipe;
 import buildcraft.api.transport.IPipeEntry;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicIron extends PipeLogic {
 
@@ -48,14 +49,14 @@ public class PipeLogicIron extends PipeLogic {
 
 			TileEntity tile = container.getTile(ForgeDirection.values()[nextMetadata]);
 
-			if (tile instanceof TileGenericPipe) {
-				Pipe pipe = ((TileGenericPipe) tile).pipe;
-				if (pipe.logic instanceof PipeLogicWood || pipe instanceof PipeStructureCobblestone) {
+			if (tile instanceof IPipeTile) {
+				IPipe pipe = ((IPipeTile) tile).getPipe();
+				if (pipe.getLogic() instanceof PipeLogicWood || pipe instanceof PipeStructureCobblestone) {
 					continue;
 				}
 			}
 
-			if (tile instanceof IPipeEntry || tile instanceof IInventory || tile instanceof ITankContainer || tile instanceof TileGenericPipe) {
+			if (tile instanceof IPipeEntry || tile instanceof IInventory || tile instanceof ITankContainer || tile instanceof IPipeTile) {
 
 				worldObj.setBlockMetadataWithNotify(xCoord, yCoord, zCoord, nextMetadata,0);
 				container.scheduleRenderUpdate();

--- a/common/buildcraft/transport/pipes/PipeLogicObsidian.java
+++ b/common/buildcraft/transport/pipes/PipeLogicObsidian.java
@@ -11,20 +11,21 @@ package buildcraft.transport.pipes;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicObsidian extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
-		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+		if (tile instanceof IPipeTile) {
+			pipe2 = ((IPipeTile) tile).getPipe();
 		}
 
-		return (pipe2 == null || (!(pipe2.logic instanceof PipeLogicObsidian) && !(pipe2.logic instanceof PipeLogicStripes))) && super.canPipeConnect(tile, side);
+		return (pipe2 == null || (!(pipe2.getLogic() instanceof PipeLogicObsidian) && !(pipe2.getLogic() instanceof PipeLogicStripes))) && super.canPipeConnect(tile, side);
 	}
 
 }

--- a/common/buildcraft/transport/pipes/PipeLogicQuartz.java
+++ b/common/buildcraft/transport/pipes/PipeLogicQuartz.java
@@ -11,6 +11,7 @@ package buildcraft.transport.pipes;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.api.transport.IPipe;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.TileGenericPipe;
 
@@ -18,18 +19,18 @@ public class PipeLogicQuartz extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
 		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+			pipe2 = ((TileGenericPipe) tile).getPipe();
 		}
 
 		if (pipe2 != null) {
-			if (pipe2.logic instanceof PipeLogicStone) {
+			if (pipe2.getLogic() instanceof PipeLogicStone) {
 				return false;
 			}
 
-			if (pipe2.logic instanceof PipeLogicCobblestone) {
+			if (pipe2.getLogic() instanceof PipeLogicCobblestone) {
 				return false;
 			}
 		}

--- a/common/buildcraft/transport/pipes/PipeLogicSandstone.java
+++ b/common/buildcraft/transport/pipes/PipeLogicSandstone.java
@@ -9,13 +9,13 @@
 
 package buildcraft.transport.pipes;
 
+import buildcraft.api.transport.IPipeTile;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicSandstone extends PipeLogic {
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		return (tile instanceof TileGenericPipe) && super.canPipeConnect(tile, side);
+		return (tile instanceof IPipeTile) && super.canPipeConnect(tile, side);
 	}
 }

--- a/common/buildcraft/transport/pipes/PipeLogicStone.java
+++ b/common/buildcraft/transport/pipes/PipeLogicStone.java
@@ -11,25 +11,26 @@ package buildcraft.transport.pipes;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicStone extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
-		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+		if (tile instanceof IPipeTile) {
+			pipe2 = ((IPipeTile) tile).getPipe();
 		}
 
 		if (pipe2 != null) {
-			if (pipe2.logic instanceof PipeLogicCobblestone) {
+			if (pipe2.getLogic() instanceof PipeLogicCobblestone) {
 				return false;
 			}
 
-			if (pipe2.logic instanceof PipeLogicQuartz) {
+			if (pipe2.getLogic() instanceof PipeLogicQuartz) {
 				return false;
 			}
 		}

--- a/common/buildcraft/transport/pipes/PipeLogicStripes.java
+++ b/common/buildcraft/transport/pipes/PipeLogicStripes.java
@@ -11,20 +11,21 @@ package buildcraft.transport.pipes;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicStripes extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
-		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+		if (tile instanceof IPipeTile) {
+			pipe2 = ((IPipeTile) tile).getPipe();
 		}
 
-		return (pipe2 == null || !(pipe2.logic instanceof PipeLogicStripes) && !(pipe2.logic instanceof PipeLogicObsidian)) && super.canPipeConnect(tile, side);
+		return (pipe2 == null || !(pipe2.getLogic() instanceof PipeLogicStripes) && !(pipe2.getLogic() instanceof PipeLogicObsidian)) && super.canPipeConnect(tile, side);
 	}
 
 }

--- a/common/buildcraft/transport/pipes/PipeLogicWood.java
+++ b/common/buildcraft/transport/pipes/PipeLogicWood.java
@@ -16,11 +16,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.liquids.ITankContainer;
 import buildcraft.api.tools.IToolWrench;
+import buildcraft.api.transport.IPipe;
+import buildcraft.api.transport.IPipeTile;
 import buildcraft.api.transport.PipeManager;
 import buildcraft.core.proxy.CoreProxy;
 import buildcraft.core.utils.Utils;
 import buildcraft.transport.Pipe;
-import buildcraft.transport.TileGenericPipe;
 
 public class PipeLogicWood extends PipeLogic {
 
@@ -49,7 +50,7 @@ public class PipeLogicWood extends PipeLogic {
 	}
 
 	public boolean isInput(TileEntity tile) {
-		return !(tile instanceof TileGenericPipe) && (tile instanceof IInventory || tile instanceof ITankContainer)
+		return !(tile instanceof IPipeTile) && (tile instanceof IInventory || tile instanceof ITankContainer)
 				&& Utils.checkPipesConnections(container, tile);
 	}
 
@@ -67,13 +68,13 @@ public class PipeLogicWood extends PipeLogic {
 
 	@Override
 	public boolean canPipeConnect(TileEntity tile, ForgeDirection side) {
-		Pipe pipe2 = null;
+		IPipe pipe2 = null;
 
-		if (tile instanceof TileGenericPipe) {
-			pipe2 = ((TileGenericPipe) tile).pipe;
+		if (tile instanceof IPipeTile) {
+			pipe2 = ((IPipeTile) tile).getPipe();
 		}
 
-		return (pipe2 == null || !(pipe2.logic instanceof PipeLogicWood)) && super.canPipeConnect(tile, side);
+		return (pipe2 == null || !(pipe2.getLogic() instanceof PipeLogicWood)) && super.canPipeConnect(tile, side);
 	}
 
 	@Override
@@ -110,7 +111,7 @@ public class PipeLogicWood extends PipeLogic {
 
 	@Override
 	public boolean outputOpen(ForgeDirection to) {
-		if (this.container.pipe instanceof PipeLiquidsWood) {
+		if (this.container.getPipe() instanceof PipeLiquidsWood) {
 			int meta = worldObj.getBlockMetadata(xCoord, yCoord, zCoord);
 			return meta != to.ordinal();
 		}

--- a/common/buildcraft/transport/triggers/TriggerPipeContents.java
+++ b/common/buildcraft/transport/triggers/TriggerPipeContents.java
@@ -12,12 +12,12 @@ import net.minecraftforge.liquids.ILiquidTank;
 import net.minecraftforge.liquids.LiquidContainerRegistry;
 import net.minecraftforge.liquids.LiquidStack;
 import buildcraft.api.gates.ITriggerParameter;
+import buildcraft.api.transport.IPipe;
 import buildcraft.core.triggers.ActionTriggerIconProvider;
 import buildcraft.core.triggers.BCTrigger;
 import buildcraft.core.utils.StringUtils;
 import buildcraft.transport.EntityData;
 import buildcraft.transport.ITriggerPipe;
-import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeTransportItems;
 import buildcraft.transport.PipeTransportLiquids;
 import buildcraft.transport.PipeTransportPower;
@@ -69,9 +69,9 @@ public class TriggerPipeContents extends BCTrigger implements ITriggerPipe {
 	}
 
 	@Override
-	public boolean isTriggerActive(Pipe pipe, ITriggerParameter parameter) {
-		if (pipe.transport instanceof PipeTransportItems) {
-			PipeTransportItems transportItems = (PipeTransportItems) pipe.transport;
+	public boolean isTriggerActive(IPipe pipe, ITriggerParameter parameter) {
+		if (pipe.getTransport() instanceof PipeTransportItems) {
+			PipeTransportItems transportItems = (PipeTransportItems) pipe.getTransport();
 
 			if (kind == Kind.Empty)
 				return transportItems.travelingEntities.isEmpty();
@@ -84,8 +84,8 @@ public class TriggerPipeContents extends BCTrigger implements ITriggerPipe {
 					}
 				} else
 					return !transportItems.travelingEntities.isEmpty();
-		} else if (pipe.transport instanceof PipeTransportLiquids) {
-			PipeTransportLiquids transportLiquids = (PipeTransportLiquids) pipe.transport;
+		} else if (pipe.getTransport() instanceof PipeTransportLiquids) {
+			PipeTransportLiquids transportLiquids = (PipeTransportLiquids) pipe.getTransport();
 
 			LiquidStack searchedLiquid = null;
 
@@ -109,8 +109,8 @@ public class TriggerPipeContents extends BCTrigger implements ITriggerPipe {
 
 				return false;
 			}
-		} else if (pipe.transport instanceof PipeTransportPower) {
-			PipeTransportPower transportPower = (PipeTransportPower) pipe.transport;
+		} else if (pipe.getTransport() instanceof PipeTransportPower) {
+			PipeTransportPower transportPower = (PipeTransportPower) pipe.getTransport();
 
 			switch (kind) {
 				case Empty:

--- a/common/buildcraft/transport/triggers/TriggerPipeSignal.java
+++ b/common/buildcraft/transport/triggers/TriggerPipeSignal.java
@@ -14,7 +14,6 @@ import buildcraft.api.transport.IPipe;
 import buildcraft.core.triggers.ActionTriggerIconProvider;
 import buildcraft.core.triggers.BCTrigger;
 import buildcraft.transport.ITriggerPipe;
-import buildcraft.transport.Pipe;
 
 public class TriggerPipeSignal extends BCTrigger implements ITriggerPipe {
 
@@ -63,11 +62,11 @@ public class TriggerPipeSignal extends BCTrigger implements ITriggerPipe {
 	}
 
 	@Override
-	public boolean isTriggerActive(Pipe pipe, ITriggerParameter parameter) {
+	public boolean isTriggerActive(IPipe pipe, ITriggerParameter parameter) {
 		if (active)
-			return pipe.signalStrength[color.ordinal()] > 0;
+			return pipe.signalStrength(color) > 0;
 		else
-			return pipe.signalStrength[color.ordinal()] == 0;
+			return pipe.signalStrength(color) == 0;
 	}
 	
 	@Override

--- a/common/buildcraft/transport/triggers/TriggerRedstoneInput.java
+++ b/common/buildcraft/transport/triggers/TriggerRedstoneInput.java
@@ -10,10 +10,10 @@
 package buildcraft.transport.triggers;
 
 import buildcraft.api.gates.ITriggerParameter;
+import buildcraft.api.transport.IPipe;
 import buildcraft.core.triggers.ActionTriggerIconProvider;
 import buildcraft.core.triggers.BCTrigger;
 import buildcraft.transport.ITriggerPipe;
-import buildcraft.transport.Pipe;
 
 public class TriggerRedstoneInput extends BCTrigger implements ITriggerPipe {
 
@@ -34,11 +34,11 @@ public class TriggerRedstoneInput extends BCTrigger implements ITriggerPipe {
 	}
 
 	@Override
-	public boolean isTriggerActive(Pipe pipe, ITriggerParameter parameter) {
+	public boolean isTriggerActive(IPipe pipe, ITriggerParameter parameter) {
 		if (active)
-			return pipe.worldObj.isBlockIndirectlyGettingPowered(pipe.xCoord, pipe.yCoord, pipe.zCoord);
+			return pipe.getWorld().isBlockIndirectlyGettingPowered(pipe.getXPosition(), pipe.getYPosition(), pipe.getZPosition());
 		else
-			return !pipe.worldObj.isBlockIndirectlyGettingPowered(pipe.xCoord, pipe.yCoord, pipe.zCoord);
+			return !pipe.getWorld().isBlockIndirectlyGettingPowered(pipe.getXPosition(), pipe.getYPosition(), pipe.getZPosition());
 	}
 	
 	@Override


### PR DESCRIPTION
In many places (eg triggers) a full Pipe object is needed to be passed.
This means that you can not use an IPipeTile in many cases, because you can only get an IPipe from it. 

Adding in these functions means that a cleaner api interface/ code-base split can be achieved, with virtually all pipe types being able to drop their use of the concrete TileGenericPipe.(Pipe)pipe for use of the API IPipeTile.(IPipe)getPipe().

This PR does not break old mods using the new version, as it only adds functions.

In the long run this makes writing sub-mods for BC easier, as direct use of core BC classes can be avoided, leading to a larger immunity to BC coding refactors breaking sub-mods. I have no profiling data, but java should inline the trivial,and non-overridden, functions resulting in no performance hit from this change unless someone does something silly like override it themselves.

the x/y/z coord updates are needed as they are currently used by BlockGenericPipe, GateVanilla, ITriggerPipe.isTriggerActive, and various GUI related network code.

Most of those types of actions (triggers, gui) would be performed by mods also, so having access to the pipes coordinates via an API would be useful.
