### PR TITLE
Fix for duplication bug.

### DIFF
--- a/common/buildcraft/core/gui/slots/SlotPhantom.java
+++ b/common/buildcraft/core/gui/slots/SlotPhantom.java
@@ -7,6 +7,7 @@
  */
 package buildcraft.core.gui.slots;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 
 /**
@@ -23,4 +24,10 @@ public class SlotPhantom extends SlotBase implements IPhantomSlot {
 	public boolean canAdjust() {
 		return true;
 	}
+	
+	@Override
+    public boolean canTakeStack(EntityPlayer par1EntityPlayer)
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
It was possible to get the item in a phantom slot with the new inventory management features. This fix prevents for example the item double click feature (make stack of many small?) to take items from the ghosted inventory.

I think I've isolated the problem in the right place, but I'm very new to the BuildCraft code so I hope you do a serious sanity check. There might be a better way.
