### PR TITLE
Make the Advanced Crafting Table respect wildcards

### DIFF
--- a/common/buildcraft/silicon/TileAdvancedCraftingTable.java
+++ b/common/buildcraft/silicon/TileAdvancedCraftingTable.java
@@ -36,6 +36,7 @@ import buildcraft.core.utils.Utils;
 import com.google.common.collect.Lists;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraftforge.common.ForgeDirection;
+import net.minecraftforge.oredict.OreDictionary;
 
 public class TileAdvancedCraftingTable extends TileEntity implements IInventory, ILaserTarget, IMachine, IActionReceptor, ISidedInventory {
 
@@ -292,7 +293,9 @@ public class TileAdvancedCraftingTable extends TileEntity implements IInventory,
 			}
 			boolean matchedStorage = false;
 			for (int i = 0; i < tempStorage.length; i++) {
-				if (tempStorage[i] != null && craftingSlots.getStackInSlot(j).isItemEqual(tempStorage[i])
+				if (tempStorage[i] != null && craftingSlots.getStackInSlot(j).itemID == tempStorage[i].itemID
+						&& (craftingSlots.getStackInSlot(j).getItemDamage() == OreDictionary.WILDCARD_VALUE
+							|| craftingSlots.getStackInSlot(j).getItemDamage() == tempStorage[i].getItemDamage())
 						&& internalInventoryCrafting.hitCount[i] < tempStorage[i].stackSize
 						&& internalInventoryCrafting.hitCount[i] < tempStorage[i].getMaxStackSize()) {
 					internalInventoryCrafting.bindings[j] = i;


### PR DESCRIPTION
This will make it work with different types of wood and that kind of stuff, and also support EE3 damaged minium stones.

PS: I don't know why the file looks like it's completely changed, it's just 1 import and 3 lines from line 296. Git doesn't seem to like me.
