### PR TITLE
Allow for more advanced delivery conditions

### DIFF
--- a/common/buildcraft/api/transport/IPipedItem.java
+++ b/common/buildcraft/api/transport/IPipedItem.java
@@ -80,4 +80,11 @@ public interface IPipedItem {
 
 	public abstract boolean hasContributions();
 
+	
+	/**
+	 * @return the can this item be moved into this specific entity type.
+	 * (basic BuildCraft PipedItems always return true)
+	 */
+	public abstract boolean canSinkTo(TileEntity entity);
+
 }

--- a/common/buildcraft/core/EntityPassiveItem.java
+++ b/common/buildcraft/core/EntityPassiveItem.java
@@ -359,4 +359,9 @@ public class EntityPassiveItem implements IPipedItem {
 	public boolean hasContributions() {
 		return contributions.size() > 0;
 	}
+
+	@Override
+	public boolean canSinkTo(TileEntity entity) {
+		return true; // a passive item can sink anywhere
+	}
 }

--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -243,7 +243,7 @@ public class PipeTransportItems extends PipeTransport {
 			TileGenericPipe pipe = (TileGenericPipe) entity;
 
 			return pipe.pipe.transport instanceof PipeTransportItems;
-		} else if (entity instanceof IInventory)
+		} else if (entity instanceof IInventory && item.canSinkTo(entity))
 			if (Transactor.getTransactorFor(entity).add(item.getItemStack(), o.getOpposite(), false).stackSize > 0)
 				return true;
 


### PR DESCRIPTION
This doesn't control items passing between pipes, only a condition for a
PipedItem to prevent itself exiting the network in specific places.

This modification allows BC to have more advanced sinking conditions
(eg: the discussion about coloured pipes/items)

Logistics pipes currently modifies something via reflection to prevent
it's liquid packets from being sunk to standard IInventories.
