### PR TITLE
Fix typo.

### DIFF
--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -176,7 +176,7 @@ public class BuildCraftEnergy {
 				fluidFuel.setBlockID(blockFuel);
 			}
 		} else {
-			blockFuel = Block.blocksList[fluidOil.getBlockID()];
+			blockFuel = Block.blocksList[fluidFuel.getBlockID()];
 		}
 
 		// Buckets


### PR DESCRIPTION
In case another mod adds a fuel fluid, and it's loaded before BC, without this fix the fuel buckets would place oil blocks.
