### PR TITLE
fix NPE when using combustion engine with empty tank

### DIFF
--- a/common/buildcraft/energy/TileEngineIron.java
+++ b/common/buildcraft/energy/TileEngineIron.java
@@ -117,7 +117,7 @@ public class TileEngineIron extends TileEngine implements IFluidHandler {
 	@Override
 	public void burn() {
 		FluidStack fuel = this.fuelTank.getFluid();
-		if (currentFuel == null) {
+		if (currentFuel == null && fuel != null) {
 			currentFuel = IronEngineFuel.getFuelForFluid(fuel.getFluid());
 		}
 


### PR DESCRIPTION
When new Combustion engine was placed a NullPointerException was thrown. This will prevent it.
