### PR TITLE
Update Pipe.java

### DIFF
--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -405,8 +405,8 @@ public abstract class Pipe implements IPipe, IDropControlInventory {
 		}
 
 		if (hasGate()) {
-			resetGate();
 			gate.dropGate();
+			resetGate();
 		}
 
 		for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {


### PR DESCRIPTION
Fixes https://github.com/BuildCraft/BuildCraft/issues/1035 .
resetGate() set's the gate to null which causes a NPE.
