### PR TITLE
Add density-based functionality to the Tank

### DIFF
--- a/common/buildcraft/factory/TileTank.java
+++ b/common/buildcraft/factory/TileTank.java
@@ -49,8 +49,8 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 		}
 
 		// Have liquid flow down into tanks below if any.
-		if (tank.getFluid() != null) {
-			moveFluidBelow();
+		if (!tank.isEmpty()) {
+			moveFluid();
 		}
 	}
 
@@ -92,10 +92,26 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 	public TileTank getBottomTank() {
 
 		TileTank lastTank = this;
-
+		
+		if (tank.getFluid() == null) {
+			while (true) {
+				TileTank below = getTankBelow(lastTank);
+				if (below != null && below.tank.getFluid() == null) {
+					lastTank = below;
+				}
+				else if (below != null) {
+					return below.getBottomTank();
+				}
+				else {
+					return lastTank;
+				}
+			}
+		}
+		
 		while (true) {
 			TileTank below = getTankBelow(lastTank);
-			if (below != null) {
+			if (below != null && below.tank.getFluid() != null &&
+					below.tank.getFluid().isFluidEqual(tank.getFluid())) {
 				lastTank = below;
 			} else {
 				break;
@@ -108,10 +124,26 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 	public TileTank getTopTank() {
 
 		TileTank lastTank = this;
-
+		
+		if (tank.getFluid() == null) {
+			while (true) {
+				TileTank above = getTankBelow(lastTank);
+				if (above != null && above.tank.getFluid() == null) {
+					lastTank = above;
+				}
+				else if (above != null) {
+					return above.getTopTank();
+				}
+				else {
+					return lastTank;
+				}
+			}
+		}
+		
 		while (true) {
 			TileTank above = getTankAbove(lastTank);
-			if (above != null) {
+			if (above != null && (above.tank.getFluid() != null &&
+					above.tank.getFluid().isFluidEqual(tank.getFluid()))) {
 				lastTank = above;
 			} else {
 				break;
@@ -138,19 +170,73 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 			return null;
 		}
 	}
-
-	public void moveFluidBelow() {
+	
+	public void moveFluid() {
+		moveFluidBelow();
+		moveFluidAbove();
+	}
+	
+	private void moveFluidBelow() {
 		TileTank below = getTankBelow(this);
-		if (below == null) {
+		if (below == null ||
+				(below.tank.getFluid() != null && 
+					below.tank.getFluid().getFluid().getDensity(below.tank.getFluid()) >=
+						tank.getFluid().getFluid().getDensity(tank.getFluid())) ||
+				(below.tank.getFluid() == null &&
+					tank.getFluid().getFluid().getDensity(tank.getFluid()) <= 0)) {
+			return;
+		}
+		
+		if (below.tank.isEmpty() || below.tank.getFluid().isFluidEqual(tank.getFluid())) {
+			int used = below.tank.fill(tank.getFluid(), true);
+			if (used > 0) {
+				hasUpdate = true; // not redundant because tank.drain operates on an IFluidTank, not a tile
+				below.hasUpdate = true; // redundant because below.fill sets hasUpdate
+
+				tank.drain(used, true);
+			}
+		}
+		else
+		{
+			FluidStack temp = below.tank.getFluid().copy();
+			below.tank.setFluid(tank.getFluid().copy());
+			
+			hasUpdate = true;
+			below.hasUpdate = true;
+			
+			tank.setFluid(temp);
+		}
+	}
+
+	private void moveFluidAbove() {
+		TileTank above = getTankAbove(this);
+		if (above == null ||
+				(above.tank.getFluid() != null && 
+					above.tank.getFluid().getFluid().getDensity(above.tank.getFluid()) <=
+					tank.getFluid().getFluid().getDensity(tank.getFluid())) ||
+				(above.tank.getFluid() == null &&
+					tank.getFluid().getFluid().getDensity(tank.getFluid()) >= 0)) {
 			return;
 		}
 
-		int used = below.tank.fill(tank.getFluid(), true);
-		if (used > 0) {
-			hasUpdate = true; // not redundant because tank.drain operates on an IFluidTank, not a tile
-			below.hasUpdate = true; // redundant because below.fill sets hasUpdate
+		if (above.tank.isEmpty() || above.tank.getFluid().isFluidEqual(tank.getFluid())) {
+			int used = above.tank.fill(tank.getFluid(), true);
+			if (used > 0) {
+				hasUpdate = true; // not redundant because tank.drain operates on an IFluidTank, not a tile
+				above.hasUpdate = true; // redundant because below.fill sets hasUpdate
 
-			tank.drain(used, true);
+				tank.drain(used, true);
+			}
+		}
+		else
+		{
+			FluidStack temp = above.tank.getFluid().copy();
+			above.tank.setFluid(tank.getFluid());
+			
+			hasUpdate = true;
+			above.hasUpdate = true;
+			
+			tank.setFluid(temp);
 		}
 	}
 
@@ -163,7 +249,8 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 
 		resource = resource.copy();
 		int totalUsed = 0;
-		TileTank tankToFill = getBottomTank();
+		boolean fluidFalls = resource.getFluid().getDensity(resource) > 0;
+		TileTank tankToFill = fluidFalls ? getBottomTank() : getTopTank();
 
 		FluidStack liquid = tankToFill.tank.getFluid();
 		if (liquid != null && liquid.amount > 0 && !liquid.isFluidEqual(resource)) {
@@ -178,7 +265,7 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 			}
 
 			totalUsed += used;
-			tankToFill = getTankAbove(tankToFill);
+			tankToFill = fluidFalls ? getTankAbove(tankToFill) : getTankBelow(tankToFill);
 		}
 		return totalUsed;
 	}

--- a/common/buildcraft/factory/render/RenderTank.java
+++ b/common/buildcraft/factory/render/RenderTank.java
@@ -42,7 +42,14 @@ public class RenderTank extends TileEntitySpecialRenderer {
 
 		GL11.glTranslatef((float) x + 0.125F, (float) y, (float) z + 0.125F);
 		GL11.glScalef(0.75F, 0.999F, 0.75F);
-
+		
+		if (liquid.getFluid().getDensity(liquid) < 0) {
+			GL11.glTranslatef(0, 1F - ((float) liquid.amount / (float) (tank.tank.getCapacity())), 0);
+		}
+		else if (liquid.getFluid().getDensity(liquid) == 0) {
+			GL11.glTranslatef(0, 0.5F - ((float) liquid.amount / (float) (tank.tank.getCapacity())) / 2, 0);
+		}
+		
 		GL11.glCallList(displayList[(int) ((float) liquid.amount / (float) (tank.tank.getCapacity()) * (FluidRenderer.DISPLAY_STAGES - 1))]);
 
 		GL11.glPopAttrib();


### PR DESCRIPTION
The Tank now sorts fluids by density, like it would in real life. Lava
is below water is below oil.
It also renders nagative-density fluids upside-down, and fluids with 0
density in the middle.
The getBottomTank() and getTopTank() methods now only go to the last
tank with the same fluid as the tank preforming the search, or if the
tank is empty, to the last tank with the same fluid as the first tank
with some fluid.
