### PR TITLE
Temporary solution to fluids eating other fluids

### DIFF
--- a/common/buildcraft/energy/BlockBuildcraftFluid.java
+++ b/common/buildcraft/energy/BlockBuildcraftFluid.java
@@ -103,4 +103,16 @@ public class BlockBuildcraftFluid extends BlockFluidClassic {
 			FMLClientHandler.instance().getClient().effectRenderer.addEffect(fx);
 		}
 	}
+	
+	@Override
+	public boolean canDisplace(IBlockAccess world, int x, int y, int z) {
+		if (world.getBlockMaterial(x,  y,  z).isLiquid()) return false;
+		return super.canDisplace(world, x, y, z);
+	}
+	
+	@Override
+	public boolean displaceIfPossible(World world, int x, int y, int z) {
+		if (world.getBlockMaterial(x,  y,  z).isLiquid()) return false;
+		return super.displaceIfPossible(world, x, y, z);
+	}
 }


### PR DESCRIPTION
This will work for BC, untill the Forge devs decide what would be the best universal approach. For now this is a solution to prevent the issue for Oil and Fuel, using the rule "first fluid wins".
