### PR TITLE
Assembly Table isInvalid() Crash Fix

### DIFF
--- a/common/buildcraft/silicon/ILaserTarget.java
+++ b/common/buildcraft/silicon/ILaserTarget.java
@@ -5,7 +5,7 @@ public interface ILaserTarget {
 
 	void receiveLaserEnergy(float energy);
 
-	boolean isInvalid();
+	boolean isInvalidTarget();
 
 	int getXCoord();
 

--- a/common/buildcraft/silicon/TileAdvancedCraftingTable.java
+++ b/common/buildcraft/silicon/TileAdvancedCraftingTable.java
@@ -525,4 +525,9 @@ public class TileAdvancedCraftingTable extends TileEntity implements IInventory,
 			lastMode = ActionMachineControl.Mode.Off;
 		}
 	}
+
+	@Override
+	public boolean isInvalidTarget() {
+		return isInvalid();
+	}
 }

--- a/common/buildcraft/silicon/TileAssemblyTable.java
+++ b/common/buildcraft/silicon/TileAssemblyTable.java
@@ -485,4 +485,9 @@ public class TileAssemblyTable extends TileEntity implements IMachine, IInventor
 		// TODO Auto-generated method stub
 		return true;
 	}
+
+	@Override
+	public boolean isInvalidTarget() {
+		return isInvalid();
+	}
 }

--- a/common/buildcraft/silicon/TileLaser.java
+++ b/common/buildcraft/silicon/TileLaser.java
@@ -114,7 +114,7 @@ public class TileLaser extends TileBuildCraft implements IPowerReceptor, IAction
 
 	protected boolean isValidTable() {
 
-		if (laserTarget == null || laserTarget.isInvalid() || !laserTarget.hasCurrentWork())
+		if (laserTarget == null || laserTarget.isInvalidTarget() || !laserTarget.hasCurrentWork())
 			return false;
 
 		return true;


### PR DESCRIPTION
Solution for #1054.  Avoids crash from name conflict with .isInvalid()
between ILaserTarget interface and TileEntity class, in relation to
TileAssemblyTable and TileAdvancedCraftingTable.
