### PR TITLE
Changed the version file link to the original.

### DIFF
--- a/common/buildcraft/core/Version.java
+++ b/common/buildcraft/core/Version.java
@@ -20,7 +20,7 @@ public class Version implements Runnable {
 
 	public static final String VERSION = "@VERSION@";
 	public static final String BUILD_NUMBER = "@BUILD_NUMBER@";
-	private static final String REMOTE_VERSION_FILE = "http://bit.ly/buildcraftver";
+	private static final String REMOTE_VERSION_FILE = "https://dl.dropboxusercontent.com/u/44760587/buildcraft/version.txt";
 	private static final String REMOTE_CHANGELOG_ROOT = "https://dl.dropbox.com/u/44760587/buildcraft/changelog/";
 
 	public static EnumUpdateState currentVersion = EnumUpdateState.CURRENT;


### PR DESCRIPTION
Use the original link instead of the short to solve the problem that someone cant visit the bit.ly from some countries(especially China & some other countries which have the Great Fire Wall).And this lead to a long delay when loading the game.And Maybe we should consider adding a config to disable the version check.
