### PR TITLE
Pipe Connections for Mod Blocks without IInventory

### DIFF
--- a/common/buildcraft/api/transport/IPipeConnectedTile.java
+++ b/common/buildcraft/api/transport/IPipeConnectedTile.java
@@ -1,0 +1,14 @@
+package buildcraft.api.transport;
+
+import net.minecraftforge.common.ForgeDirection;
+
+/**
+ * Implementors can connect to pipes even without inventory/tank implementations.
+ *
+ * Valid for Item and Fluid Pipe Connections only.
+ */
+public interface IPipeConnectedTile {
+	
+	boolean canPipeConnect( IPipeTile.PipeType type, ForgeDirection direction );
+	
+}

--- a/common/buildcraft/transport/PipeTransportFluids.java
+++ b/common/buildcraft/transport/PipeTransportFluids.java
@@ -10,6 +10,7 @@ package buildcraft.transport;
 import buildcraft.BuildCraftCore;
 import buildcraft.api.core.SafeTimeTracker;
 import buildcraft.api.gates.ITrigger;
+import buildcraft.api.transport.IPipeConnectedTile;
 import buildcraft.api.transport.IPipeTile.PipeType;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.IMachine;
@@ -505,7 +506,7 @@ public class PipeTransportFluids extends PipeTransport implements IFluidHandler 
 				return true;
 		}
 
-		return tile instanceof TileGenericPipe || (tile instanceof IMachine && ((IMachine) tile).manageFluids());
+		return tile instanceof TileGenericPipe || ( tile instanceof IPipeConnectedTile && ((IPipeConnectedTile) tile).canPipeConnect( PipeType.FLUID, side.getOpposite()) ) || (tile instanceof IMachine && ((IMachine) tile).manageFluids());
 	}
 
 	public boolean isTriggerActive(ITrigger trigger) {

--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -12,6 +12,7 @@ import buildcraft.BuildCraftTransport;
 import buildcraft.api.core.Position;
 import buildcraft.api.gates.ITrigger;
 import buildcraft.api.inventory.ISpecialInventory;
+import buildcraft.api.transport.IPipeConnectedTile;
 import buildcraft.api.transport.IPipeTile.PipeType;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.IMachine;
@@ -575,7 +576,8 @@ public class PipeTransportItems extends PipeTransport {
 		}
 
 		return tile instanceof TileGenericPipe || tile instanceof ISpecialInventory || (tile instanceof IInventory && ((IInventory) tile).getSizeInventory() > 0)
-				|| (tile instanceof IMachine && ((IMachine) tile).manageSolids());
+				 || ( tile instanceof IPipeConnectedTile && ((IPipeConnectedTile) tile).canPipeConnect( PipeType.ITEM, side.getOpposite()) ) 
+				 || (tile instanceof IMachine && ((IMachine) tile).manageSolids());
 	}
 
 	public boolean isTriggerActive(ITrigger trigger) {


### PR DESCRIPTION
With the BC API changes for 1.6, its now impossible to inject items into pipes without them connecting, but in order to a pipe to connect, you must be a pipe, or you must be an inventory.

This is problematic, internally BC supports IMachine to allow non inventories to connect  to pipes, but there is no public facing interface that accomplishes a similar goal.
