### PR TITLE
isActive method can give NullPointerException

### DIFF
--- a/common/buildcraft/factory/TilePump.java
+++ b/common/buildcraft/factory/TilePump.java
@@ -315,7 +315,12 @@ public class TilePump extends TileBuildCraft implements IMachine, IPowerReceptor
 	@Override
 	public boolean isActive() {
 		BlockIndex next = getNextIndexToPump(false);
-		return isPumpableFluid(next.x, next.y, next.z);
+		
+		if (next != null) {
+			return isPumpableFluid(next.x, next.y, next.z);
+		}
+		
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
A pump with an empty "block list" would cause NullPointerException if isActive was called.
