### PR TITLE
Better handling for ISidedInventory tile entities

### DIFF
--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -572,7 +572,9 @@ public class PipeTransportItems extends PipeTransport {
 			if (BlockGenericPipe.isValid(pipe2) && !(pipe2.transport instanceof PipeTransportItems))
 				return false;
 		}
-
+		
+		if(tile instanceof ISidedInventory)
+			return ((ISidedInventory)tile).getAccessibleSlotsFromSide(side.getOpposite().ordinal()).length > 0;
 		return tile instanceof TileGenericPipe || tile instanceof ISpecialInventory || (tile instanceof IInventory && ((IInventory) tile).getSizeInventory() > 0)
 				|| (tile instanceof IMachine && ((IMachine) tile).manageSolids());
 	}


### PR DESCRIPTION
The pipe shouldn't connect to an inventory that isn't available from a certain side. With this it would be easier to manage what sides the pipe connects to without having to implement IPipeConnection. And also get rid of unnecessary connections.
