### PR TITLE
Fix for kinesis pipes content triggers

### DIFF
--- a/common/buildcraft/transport/triggers/TriggerPipeContents.java
+++ b/common/buildcraft/transport/triggers/TriggerPipeContents.java
@@ -129,14 +129,14 @@ public class TriggerPipeContents extends BCTrigger implements ITriggerPipe {
 			switch (kind) {
 				case Empty:
 					for (double s : transportPower.displayPower) {
-						if (s > 0)
+						if (s > 1e-4)
 							return false;
 					}
 
 					return true;
 				case ContainsEnergy:
 					for (double s : transportPower.displayPower) {
-						if (s > 0)
+						if (s > 1e-4)
 							return true;
 					}
 


### PR DESCRIPTION
After loading chunk if any power goes through pipe, it will always trigger "energy traversing" and never "pipe empty". It is caused by smoothing, Float.MIN_VALUE \* 9.0 / 10.0 = Float.MIN_VALUE .

Value to compare to is a matter of choice. All float values higher than 0 will work, however the lower the value, the longer the delay. Tested with 1 stirling engine powering 16 pumps connected in binary tree as a minimum reasonable energy transfer, s > 0.001 caused flickering in this case. 0.0001 works OK and is fast enough.
