### PR TITLE
Fix Forge ore dictionary support for the Assembly Table

### DIFF
--- a/common/buildcraft/api/recipes/AssemblyRecipe.java
+++ b/common/buildcraft/api/recipes/AssemblyRecipe.java
@@ -32,7 +32,7 @@ public class AssemblyRecipe {
 					continue;
 				}
 
-				if (item.isItemEqual(in)) {
+				if (StackHelper.instance().isCraftingEquivalent(in, item, true)) {
 					found += item.stackSize; // Adds quantity of stack to amount
 												// found
 				}


### PR DESCRIPTION
Fixes https://github.com/BuildCraft/BuildCraft/issues/531.
Don't worry, I checked it and it has no errors and works as intended :D
