### PR TITLE
Adjusted FluidContainerTrigger to pass through the side being checked

### DIFF
--- a/common/buildcraft/core/triggers/TriggerFluidContainer.java
+++ b/common/buildcraft/core/triggers/TriggerFluidContainer.java
@@ -66,7 +66,7 @@ public class TriggerFluidContainer extends BCTrigger {
 				searchedFluid.amount = 1;
 			}
 
-			FluidTankInfo[] liquids = container.getTankInfo(ForgeDirection.UNKNOWN);
+			FluidTankInfo[] liquids = container.getTankInfo(side);
 			if (liquids == null || liquids.length == 0)
 				return false;
 


### PR DESCRIPTION
I've been working on a mod that can handle individual Fluids per side of the block and I noticed that this trigger by default applies to the whole block.  This was causing some problems for me.

Quick example: I set my block to output fuel on the west, oil on the east, and lava on the north.  From any side using the FluidContainerTrigger Contains option for oil, fuel, or lava would all return true.  Also if testing for a fluid tank on the south side it would also return true.  This change allowed the tests to work as expected: Tank contains fuel only worked on the west side, etc...

This should be a non-breaking change to BuildCraft as the IFluidHandlers in BC appear to all ignore the specific side passed in.
