### PR TITLE
Workaround for scala compiler derp

### DIFF
--- a/common/buildcraft/api/power/IPowerReceptor.java
+++ b/common/buildcraft/api/power/IPowerReceptor.java
@@ -7,7 +7,6 @@
  */
 package buildcraft.api.power;
 
-import buildcraft.api.power.PowerHandler.PowerReceiver;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 
@@ -31,7 +30,7 @@ public interface IPowerReceptor {
 	 * @param side
 	 * @return
 	 */
-	public PowerReceiver getPowerReceiver(ForgeDirection side);
+	public PowerHandler.PowerReceiver getPowerReceiver(ForgeDirection side);
 
 	/**
 	 * Call back from the PowerHandler that is called when the stored power


### PR DESCRIPTION
There's a problem with the compiler getting confused about imports when trying to use BC API from a scala mod and giving an error - "value PowerReceiver is not a member of object buildcraft.api.power.PowerHandler"

This should (hopefully) fix that without breaking anything else :P
