### PR TITLE
Changing  serverSideRequired to false

### DIFF
--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -81,7 +81,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
 @Mod(name = "BuildCraft", version = Version.VERSION, useMetadata = false, modid = "BuildCraft|Core", acceptedMinecraftVersions = "[1.6,1.7)", dependencies = "required-after:Forge@[9.10.0.800,)")
-@NetworkMod(channels = { DefaultProps.NET_CHANNEL_NAME }, packetHandler = PacketHandler.class, clientSideRequired = true, serverSideRequired = true)
+@NetworkMod(channels = { DefaultProps.NET_CHANNEL_NAME }, packetHandler = PacketHandler.class, clientSideRequired = true, serverSideRequired = false)
 public class BuildCraftCore {
 	public static enum RenderMode {
 		Full, NoDynamic


### PR DESCRIPTION
If you have it to true, The Client isn't able to connect to a server without the mod ("
Tells Forge how to handle what happens when the client xor the server has the client installed. Takes two parameters.
clientSideRequired 
Asks if you need this on the client to use this mod. This should be true.
serverSideRequired 
Asks if you need this on the server for the client to be able to connect. This should always be false, else you can't join a server if the server doesn't have the mod installed, but you do. It is false by default anyway."
from http://www.minecraftforge.net/wiki/Basic_Modding
