### PR TITLE
Fix for other player pipes not being synched when placed

### DIFF
--- a/common/buildcraft/core/network/PacketIds.java
+++ b/common/buildcraft/core/network/PacketIds.java
@@ -3,7 +3,7 @@ package buildcraft.core.network;
 public class PacketIds {
 
 	public static final int TILE_UPDATE = 0;
-	// public static final int PIPE_DESCRIPTION = 1;
+	public static final int PIPE_CREATE = 1;
 	public static final int PIPE_CONTENTS = 2;
 	public static final int PIPE_LIQUID = 3;
 	public static final int PIPE_POWER = 4;

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -40,10 +40,14 @@ import buildcraft.api.transport.IPipe;
 import buildcraft.api.transport.ISolidSideTile;
 import buildcraft.core.BlockIndex;
 import buildcraft.core.CoreConstants;
+import buildcraft.core.network.PacketIds;
+import buildcraft.core.network.PacketPayloadArrays;
+import buildcraft.core.network.PacketUpdate;
 import buildcraft.core.proxy.CoreProxy;
 import buildcraft.core.utils.BCLog;
 import buildcraft.core.utils.Utils;
 import buildcraft.core.utils.MatrixTranformations;
+import cpw.mods.fml.common.network.PacketDispatcher;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -1012,6 +1016,12 @@ public class BlockGenericPipe extends BlockContainer {
 		if (placed) {
 			TileGenericPipe tile = (TileGenericPipe) world.getBlockTileEntity(i, j, k);
 			tile.initialize(pipe);
+
+			PacketPayloadArrays pipeInfo = new PacketPayloadArrays(2, 0, 0);
+			pipeInfo.intPayload[0] = blockId;
+			pipeInfo.intPayload[1] = meta;
+			PacketDispatcher.sendPacketToAllAround(tile.xCoord, tile.yCoord, tile.zCoord, 128, tile.worldObj.provider.dimensionId, new PacketUpdate(PacketIds.PIPE_CREATE, tile.xCoord, tile.yCoord, tile.zCoord, pipeInfo).getPacket());
+
 			tile.sendUpdateToClient();
 		}
 

--- a/common/buildcraft/transport/network/PacketHandlerTransport.java
+++ b/common/buildcraft/transport/network/PacketHandlerTransport.java
@@ -2,6 +2,7 @@ package buildcraft.transport.network;
 
 import buildcraft.core.network.PacketCoordinates;
 import buildcraft.core.network.PacketIds;
+import buildcraft.core.network.PacketPayloadArrays;
 import buildcraft.core.network.PacketSlotChange;
 import buildcraft.core.network.PacketUpdate;
 import buildcraft.transport.PipeTransportItems;
@@ -42,6 +43,14 @@ public class PacketHandlerTransport implements IPacketHandler {
 			case PacketIds.PIPE_LIQUID:
 				PacketFluidUpdate packetFluid = new PacketFluidUpdate();
 				packetFluid.readData(data);
+				break;
+			case PacketIds.PIPE_CREATE:
+				packet.readData(data);
+				if (player != null && player instanceof EntityPlayer) {
+					if (((EntityPlayer)player).worldObj.isAirBlock(packet.posX, packet.posY, packet.posZ)) {
+						((EntityPlayer)player).worldObj.setBlock(packet.posX, packet.posY, packet.posZ, ((PacketPayloadArrays)packet.payload).intPayload[0], ((PacketPayloadArrays)packet.payload).intPayload[1], 1);
+					}
+				}
 				break;
 			case PacketIds.PIPE_CONTENTS:
 				PacketPipeTransportContent packetC = new PacketPipeTransportContent();


### PR DESCRIPTION
Potential fix for #1334

I noticed that the packet that is eventually sent by tile.sendUpdateToClient() was failing because on other players' clients the block for the pipe did not yet exist in the world.

This workaround creates the pipe for clients that do not have it, which allows for the follow up tile update packet to succeed.

This did work with two clients started in a dev environment, one of which started a LAN game.  Both clients were able to place pipes and see their own and each others's pipes in the world.

This may not be the best solution, but it does work.  I am a little stumped as to what caused this issue as spending some time comparing current source to previous did not reveal any major changes to the pipe placement code.
