### PR TITLE
Add call to onInventoryChanged to extraction pipes

### DIFF
--- a/common/buildcraft/transport/pipes/PipeItemsWood.java
+++ b/common/buildcraft/transport/pipes/PipeItemsWood.java
@@ -129,6 +129,8 @@ public class PipeItemsWood extends Pipe<PipeTransportItems> implements IPowerRec
 			if (extracted == null)
 				return;
 
+			tile.onInventoryChanged();
+
 			for (ItemStack stack : extracted) {
 				if (stack == null || stack.stackSize == 0) {
 					powerHandler.useEnergy(1, 1, true);


### PR DESCRIPTION
I noticed an issue while using extraction pipes on a tile entity.  Presently the onInventoryChanged method of a tile is only being called when an item is being added by any pipe, but not when it is extracted.

This is noticeable on barrel type mods that display a count of their contents.  Using a wood/emerald/emzuli pipe would not cause the tile entity to update it's displayed count.  Adding of items via pipes would trigger this method and the tile would update it's count.
