### PR TITLE
Extract GL.color(int color) for unpacking hex RGB

### DIFF
--- a/common/buildcraft/core/gui/GuiAdvancedInterface.java
+++ b/common/buildcraft/core/gui/GuiAdvancedInterface.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fluids.Fluid;
 
 import org.lwjgl.opengl.GL11;
 
+import buildcraft.core.utils.GL;
 import buildcraft.core.render.FluidRenderer;
 
 public abstract class GuiAdvancedInterface extends GuiBuildCraft {
@@ -187,10 +188,7 @@ public abstract class GuiAdvancedInterface extends GuiBuildCraft {
 		@Override
 		public void drawSprite(int cornerX, int cornerY) {
 			if (fluid != null) {
-				float red = (float) (colorRenderCache >> 16 & 255) / 255.0F;
-				float green = (float) (colorRenderCache >> 8 & 255) / 255.0F;
-				float blue = (float) (colorRenderCache & 255) / 255.0F;
-				GL11.glColor4f(red, green, blue, 1);
+				GL.color(colorRenderCache);
 			}
 			super.drawSprite(cornerX, cornerY);
 		}

--- a/common/buildcraft/core/gui/GuiBuildCraft.java
+++ b/common/buildcraft/core/gui/GuiBuildCraft.java
@@ -6,6 +6,7 @@ import buildcraft.core.gui.tooltips.IToolTipProvider;
 import buildcraft.core.gui.tooltips.ToolTip;
 import buildcraft.core.gui.tooltips.ToolTipLine;
 import buildcraft.core.gui.widgets.Widget;
+import buildcraft.core.utils.GL;
 import buildcraft.core.utils.SessionVars;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -437,11 +438,7 @@ public abstract class GuiBuildCraft extends GuiContainer {
 
 		protected void drawBackground(int x, int y) {
 
-			float colorR = (overlayColor >> 16 & 255) / 255.0F;
-			float colorG = (overlayColor >> 8 & 255) / 255.0F;
-			float colorB = (overlayColor & 255) / 255.0F;
-
-			GL11.glColor4f(colorR, colorG, colorB, 1.0F);
+			GL.color(overlayColor);
 
 			mc.renderEngine.bindTexture(LEDGER_TEXTURE);
 			drawTexturedModalRect(x, y, 0, 256 - currentHeight, 4, currentHeight);

--- a/common/buildcraft/core/render/FluidRenderer.java
+++ b/common/buildcraft/core/render/FluidRenderer.java
@@ -8,6 +8,7 @@
 package buildcraft.core.render;
 
 import buildcraft.core.render.RenderEntityBlock.RenderInfo;
+import buildcraft.core.utils.GL;
 import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.block.Block;
@@ -66,10 +67,7 @@ public class FluidRenderer {
 			return;
 
 		int color = fluidstack.getFluid().getColor(fluidstack);
-		float red = (float) (color >> 16 & 255) / 255.0F;
-		float green = (float) (color >> 8 & 255) / 255.0F;
-		float blue = (float) (color & 255) / 255.0F;
-		GL11.glColor4f(red, green, blue, 1);
+		GL.color(color);
 	}
 
 	public static int[] getFluidDisplayLists(FluidStack fluidStack, World world, boolean flowing) {

--- a/common/buildcraft/core/utils/GL.java
+++ b/common/buildcraft/core/utils/GL.java
@@ -1,0 +1,12 @@
+package buildcraft.core.utils;
+
+import org.lwjgl.opengl.GL11;
+
+public class GL {
+	public static void color(int color) {
+		float red = (float) (color >> 16 & 255) / 255.0F;
+		float green = (float) (color >> 8 & 255) / 255.0F;
+		float blue = (float) (color & 255) / 255.0F;
+		GL11.glColor4f(red, green, blue, 1.0F);
+	}
+}

--- a/common/buildcraft/energy/gui/GuiCombustionEngine.java
+++ b/common/buildcraft/energy/gui/GuiCombustionEngine.java
@@ -17,6 +17,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.fluids.Tank;
+import buildcraft.core.utils.GL;
 import buildcraft.core.utils.StringUtils;
 import buildcraft.energy.TileEngineIron;
 import buildcraft.energy.TileEngineWithInventory;
@@ -63,16 +64,12 @@ public class GuiCombustionEngine extends GuiEngine {
 
 		Icon liquidIcon = null;
 		Fluid fluid = liquid.getFluid();
-		int color = tank.colorRenderCache;
 		if (fluid != null && fluid.getStillIcon() != null) {
 			liquidIcon = fluid.getStillIcon();
 		}
 		mc.renderEngine.bindTexture(BLOCK_TEXTURE);
-		float red = (float) (color >> 16 & 255) / 255.0F;
-		float green = (float) (color >> 8 & 255) / 255.0F;
-		float blue = (float) (color & 255) / 255.0F;
-		GL11.glColor4f(red, green, blue, 1.0F);
-		
+		GL.color(tank.colorRenderCache);
+
 		if (liquidIcon != null) {
 			while (true) {
 				int x;

--- a/common/buildcraft/factory/render/RenderRefinery.java
+++ b/common/buildcraft/factory/render/RenderRefinery.java
@@ -11,6 +11,7 @@ import buildcraft.core.DefaultProps;
 import buildcraft.core.IInventoryRenderer;
 import buildcraft.core.fluids.Tank;
 import buildcraft.core.render.FluidRenderer;
+import buildcraft.core.utils.GL;
 import buildcraft.factory.TileRefinery;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
@@ -187,10 +188,7 @@ public class RenderRefinery extends TileEntitySpecialRenderer implements IInvent
 
 				if (list1 != null) {
 					bindTexture(FluidRenderer.getFluidSheet(liquid1));
-					float red = (float) (color1 >> 16 & 255) / 255.0F;
-					float green = (float) (color1 >> 8 & 255) / 255.0F;
-					float blue = (float) (color1 & 255) / 255.0F;
-					GL11.glColor4f(red, green, blue, 1.0F);
+					GL.color(color1);
 					GL11.glCallList(list1[getDisplayListIndex(tile.tank1)]);
 				}
 			}
@@ -202,10 +200,7 @@ public class RenderRefinery extends TileEntitySpecialRenderer implements IInvent
 					GL11.glPushMatrix();
 					GL11.glTranslatef(0, 0, 1);
 					bindTexture(FluidRenderer.getFluidSheet(liquid2));
-					float red = (float) (color2 >> 16 & 255) / 255.0F;
-					float green = (float) (color2 >> 8 & 255) / 255.0F;
-					float blue = (float) (color2 & 255) / 255.0F;
-					GL11.glColor4f(red, green, blue, 1.0F);
+					GL.color(color2);
 					GL11.glCallList(list2[getDisplayListIndex(tile.tank2)]);
 					GL11.glPopMatrix();
 				}
@@ -219,10 +214,7 @@ public class RenderRefinery extends TileEntitySpecialRenderer implements IInvent
 					GL11.glPushMatrix();
 					GL11.glTranslatef(1, 0, 0.5F);
 					bindTexture(FluidRenderer.getFluidSheet(liquidResult));
-					float red = (float) (colorResult >> 16 & 255) / 255.0F;
-					float green = (float) (colorResult >> 8 & 255) / 255.0F;
-					float blue = (float) (colorResult & 255) / 255.0F;
-					GL11.glColor4f(red, green, blue, 1.0F);
+					GL.color(colorResult);
 					GL11.glCallList(list3[getDisplayListIndex(tile.result)]);
 					GL11.glPopMatrix();
 				}

--- a/common/buildcraft/factory/render/RenderTank.java
+++ b/common/buildcraft/factory/render/RenderTank.java
@@ -8,6 +8,7 @@
 package buildcraft.factory.render;
 
 import buildcraft.core.render.FluidRenderer;
+import buildcraft.core.utils.GL;
 import buildcraft.factory.TileTank;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
@@ -40,11 +41,8 @@ public class RenderTank extends TileEntitySpecialRenderer {
 		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 
 		bindTexture(FluidRenderer.getFluidSheet(liquid));
-		float red = (float) (color >> 16 & 255) / 255.0F;
-		float green = (float) (color >> 8 & 255) / 255.0F;
-		float blue = (float) (color & 255) / 255.0F;
-		GL11.glColor4f(red, green, blue, 1.0F);
-                
+		GL.color(color);
+
 		GL11.glTranslatef((float) x + 0.125F, (float) y + 0.5F, (float) z + 0.125F);
 		GL11.glScalef(0.75F, 0.999F, 0.75F);
 		GL11.glTranslatef(0, -0.5F, 0);

--- a/common/buildcraft/transport/render/FacadeItemRenderer.java
+++ b/common/buildcraft/transport/render/FacadeItemRenderer.java
@@ -2,6 +2,7 @@ package buildcraft.transport.render;
 
 import buildcraft.BuildCraftTransport;
 import buildcraft.core.CoreConstants;
+import buildcraft.core.utils.GL;
 import buildcraft.transport.ItemFacade;
 import buildcraft.transport.PipeIconProvider;
 import net.minecraft.block.Block;
@@ -23,10 +24,7 @@ public class FacadeItemRenderer implements IItemRenderer {
 
 		try {
 			int color = Item.itemsList[decodedBlockId].getColorFromItemStack(new ItemStack(decodedBlockId, 1, decodedMeta), 0);
-			float r = (float) (color >> 16 & 0xff) / 255F;
-			float g = (float) (color >> 8 & 0xff) / 255F;
-			float b = (float) (color & 0xff) / 255F;
-			GL11.glColor4f(r, g, b, 1.0F);
+			GL.color(color);
 		} catch (Throwable error) {
 		}
 

--- a/common/buildcraft/transport/render/PipeRendererTESR.java
+++ b/common/buildcraft/transport/render/PipeRendererTESR.java
@@ -16,6 +16,7 @@ import buildcraft.core.CoreConstants;
 import buildcraft.core.render.RenderEntityBlock;
 import buildcraft.core.render.RenderEntityBlock.RenderInfo;
 import buildcraft.core.utils.EnumColor;
+import buildcraft.core.utils.GL;
 import buildcraft.core.utils.MatrixTranformations;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeIconProvider;
@@ -665,10 +666,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 				default:
 			}
 			bindTexture(TextureMap.locationBlocksTexture);
-			float red = (float) (color >> 16 & 255) / 255.0F;
-			float green = (float) (color >> 8 & 255) / 255.0F;
-			float blue = (float) (color & 255) / 255.0F;
-			GL11.glColor4f(red, green, blue, 1.0F);
+			GL.color(color);
 			GL11.glCallList(list);
 			GL11.glPopMatrix();
 		}
@@ -683,10 +681,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 				int stage = (int) ((float) fluidStack.amount / (float) (trans.getCapacity()) * (LIQUID_STAGES - 1));
 
 				bindTexture(TextureMap.locationBlocksTexture);
-				float red = (float) (color >> 16 & 255) / 255.0F;
-				float green = (float) (color >> 8 & 255) / 255.0F;
-				float blue = (float) (color & 255) / 255.0F;
-				GL11.glColor4f(red, green, blue, 1.0F);
+				GL.color(color);
 
 				if (above) {
 					GL11.glCallList(d.centerVertical[stage]);
@@ -766,11 +761,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minX = min;
 			block.maxX = max;
 
-			int cHex = color.getLightHex();
-			float r = (float) (cHex >> 16 & 0xff) / 255F;
-			float g = (float) (cHex >> 8 & 0xff) / 255F;
-			float b = (float) (cHex & 0xff) / 255F;
-			GL11.glColor4f(r, g, b, 1.0F);
+			GL.color(color.getLightHex());
 			RenderEntityBlock.INSTANCE.renderBlock(block, null, 0, 0, 0, false, true);
 		}
 		GL11.glPopMatrix();


### PR DESCRIPTION
Centralizes all the unpacking of hex RGB values from an integer to a
single call to GL11.glColor4f.
