### PR TITLE
Use rotationYaw to set quarry orientation.

### DIFF
--- a/common/buildcraft/factory/BlockQuarry.java
+++ b/common/buildcraft/factory/BlockQuarry.java
@@ -19,6 +19,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Icon;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import buildcraft.BuildCraftFactory;
@@ -48,7 +49,10 @@ public class BlockQuarry extends BlockMachineRoot {
 	public void onBlockPlacedBy(World world, int i, int j, int k, EntityLiving entityliving, ItemStack stack) {
 		super.onBlockPlacedBy(world, i, j, k, entityliving, stack);
 
-		ForgeDirection orientation = Utils.get2dOrientation(new Position(entityliving.posX, entityliving.posY, entityliving.posZ), new Position(i, j, k));
+                // Convert entityLiving.rotationYaw into a cardinal direction.
+                ForgeDirection [] orientationTable = {ForgeDirection.SOUTH, ForgeDirection.WEST, ForgeDirection.NORTH, ForgeDirection.EAST};
+                int orientationIndex = MathHelper.floor_double((entityliving.rotationYaw + 45.0) / 90.0) & 3;
+                ForgeDirection orientation = orientationTable[orientationIndex];
 
 		world.setBlockMetadataWithNotify(i, j, k, orientation.getOpposite().ordinal(),1);
 		if (entityliving instanceof EntityPlayer) {


### PR DESCRIPTION
This patch is intended to allow computercraft turtles to place buildcraft quarries. The base code computes the quarry orientation metadata from entityliving posX, posY, and posZ. When a turtle places a quarry, this technique seems to always return north regardless of the direction the turtle is facing. By using the entityliving rotationYaw instead, the quarry orientation will match the turtle orientation. The behavior when a real player places a quarry is preserved as well.

I'm new to buildcraft and minecraft, so I apologize if I've overlooked an important issue with this patch.
