### PR TITLE
Build for latest 1.6.4 Forge version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,12 +19,13 @@
 	<property name="mcpsrc.dir" value="${mcp.dir}/src"/>
 
 	<property name="mc.version" value="1.6.4"/>
-	<property name="forge.version" value="9.11.1.949"/>
+	<property name="forge.version" value="9.11.1.965"/>
 	<!--	<property name="project.version" value="0.0.0"/>-->
 
 	<property name="buildcraft.name" value="buildcraft"/>
 
-	<property name="forge.name" value="minecraftforge-src-${mc.version}-${forge.version}.zip"/>
+	<property name="forge.name" value="forge-${mc.version}-${forge.version}-src.zip"/>
+	<property name="forge.url" value="maven/net/minecraftforge/forge/${mc.version}-${forge.version}"/>
 
 	<available property="forge-exists" file="${download.dir}/${forge.name}"/>
 	<available file="${src.dir}/.git" type="dir" property="git.present"/>
@@ -99,7 +100,7 @@
 
 	<!-- Download forge (if it doesn't exist) -->
 	<target name="download-forge" unless="forge-exists">
-		<get src="http://files.minecraftforge.net/${forge.name}" dest="${download.dir}" usetimestamp="True"/>
+		<get src="http://files.minecraftforge.net/${forge.url}/${forge.name}" dest="${download.dir}" usetimestamp="True"/>
 	</target>
 
 	<!-- Setup mcp and forge -->


### PR DESCRIPTION
Fixes building of BuildCraft, because the old version of Forge is not able to download the assets anymore.
