### PR TITLE
Corrects srcDir property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ minecraft {
 sourceSets {
     main {
         java {
-            srcDir 'common/buildcraft'
+            srcDir 'common'
             // exclude 'some exclusion'
             // include 'some inclusion'
         }


### PR DESCRIPTION
Please validate this change doesn't impact other workspaces. I validated 'gradle build' and 'gradle idea'

In the IDEA workspace, the "Source Root" directory was incorrectly directed to common/buildcraft. This had to be changed to common in the IDEA workspace.
