### PR TITLE
Restore bucket handler so empty buckets fill correctly.

### DIFF
--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -186,11 +186,10 @@ public class BuildCraftEnergy extends BuildCraftMod {
 			FluidContainerRegistry.registerFluidContainer(FluidRegistry.getFluidStack("fuel", FluidContainerRegistry.BUCKET_VOLUME), new ItemStack(bucketFuel), new ItemStack(Items.bucket));
 		}
 
-		// TODO: Are these still really necessary? If not, remove the 
-		// BucketHandler class as well.
-		//BucketHandler.INSTANCE.buckets.put(blockOil, bucketOil);
-		//BucketHandler.INSTANCE.buckets.put(blockFuel, bucketFuel);
-		//MinecraftForge.EVENT_BUS.register(BucketHandler.INSTANCE);
+		// BucketHandler ensures empty buckets fill with the correct liquid.
+		BucketHandler.INSTANCE.buckets.put(blockOil, bucketOil);
+		BucketHandler.INSTANCE.buckets.put(blockFuel, bucketFuel);
+		MinecraftForge.EVENT_BUS.register(BucketHandler.INSTANCE);
 
 		BuildcraftRecipes.refinery.addRecipe(new FluidStack(fluidOil, 1), new FluidStack(fluidFuel, 1), 12, 1);
 

--- a/common/buildcraft/energy/BucketHandler.java
+++ b/common/buildcraft/energy/BucketHandler.java
@@ -46,7 +46,7 @@ public class BucketHandler {
 	private ItemStack fillCustomBucket(World world, MovingObjectPosition pos) {
 		Block block = world.getBlock(pos.blockX, pos.blockY, pos.blockZ);
 
-		Item bucket = Item.getItemFromBlock(block);
+		Item bucket = buckets.get(block);
 		
 		if (bucket != null && world.getBlockMetadata(pos.blockX, pos.blockY, pos.blockZ) == 0) {
 			world.setBlockToAir(pos.blockX, pos.blockY, pos.blockZ);


### PR DESCRIPTION
By default clicking on any fluid with an empty bucket will fill it with
water. BucketHandler matches the fluid block clicked on with the
matching fluid filled bucket (item)
