### PR TITLE
Fix crash in BiomeInitializer when used in non standard WorldTypes

### DIFF
--- a/common/buildcraft/energy/worldgen/BiomeInitializer.java
+++ b/common/buildcraft/energy/worldgen/BiomeInitializer.java
@@ -19,29 +19,16 @@ public class BiomeInitializer {
 
 	@SubscribeEvent
 	public void initBiomes(WorldTypeEvent.InitBiomeGens event) {
+		int i;
 		if (BuildCraftEnergy.biomeOilDesert != null) {
-			event.newBiomeGens[0] = new GenLayerAddOilDesert(event.seed, 1500L, event.newBiomeGens[0]);
-			event.newBiomeGens[1] = new GenLayerAddOilDesert(event.seed, 1500L, event.newBiomeGens[1]);
-			event.newBiomeGens[2] = new GenLayerAddOilDesert(event.seed, 1500L, event.newBiomeGens[2]);
+			for (i=0; i<event.newBiomeGens.length; i++) {
+				event.newBiomeGens[i] = new GenLayerAddOilDesert(event.seed, 1500L, event.newBiomeGens[i]);
+			}
 		}
 		if (BuildCraftEnergy.biomeOilOcean != null) {
-			event.newBiomeGens[0] = new GenLayerAddOilOcean(event.seed, 1500L, event.newBiomeGens[0]);
-			event.newBiomeGens[1] = new GenLayerAddOilOcean(event.seed, 1500L, event.newBiomeGens[1]);
-			event.newBiomeGens[2] = new GenLayerAddOilOcean(event.seed, 1500L, event.newBiomeGens[2]);
+			for (i=0; i<event.newBiomeGens.length; i++) {
+				event.newBiomeGens[i] = new GenLayerAddOilOcean(event.seed, 1500L, event.newBiomeGens[i]);
+			}
 		}
-
-//		int range = GenLayerBiomeReplacer.OFFSET_RANGE;
-//		Random rand = new Random(event.seed);
-//		double xOffset = rand.nextInt(range) - (range / 2);
-//		double zOffset = rand.nextInt(range) - (range / 2);
-//		double noiseScale = GenLayerAddOilOcean.NOISE_FIELD_SCALE;
-//		double noiseThreshold = GenLayerAddOilOcean.NOISE_FIELD_THRESHOLD;
-//		for (int x = -5000; x < 5000; x += 128) {
-//			for (int z = -5000; z < 5000; z += 128) {
-//				if (SimplexNoise.noise((x + xOffset) * noiseScale, (z + zOffset) * noiseScale) > noiseThreshold) {
-//					System.out.printf("Oil Biome: %d, %d\n", x, z);
-//				}
-//			}
-//		}
 	}
 }


### PR DESCRIPTION
Fixes crash when BiomeInitializer runs in WorldTypes with less that three GenLayers. For example a world without river gen only has 2 Layers, the river is the 3rd.

Also remove redundant old code.
