### PR TITLE
removed BuildNumber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,6 @@ buildscript {
 apply plugin: 'forge' // adds the forge dependency
 apply plugin: 'maven' // for uploading to a maven repo
 
-// grab buildNumber
-ext.buildnumber = 0 // this will be referenced as simply project.buildnumber from now on.
-
-if (System.getenv().BUILD_NUMBER)
-    project.buildnumber = System.getenv().BUILD_NUMBER
-else
-    logger.lifecycle "SETTING BUILDNUMBER TO 0"
-
 version = "5.0.4"
 group= "com.mod-buildcraft"
 archivesBaseName = "buildcraft" // the name that all artifacts will use as a base. artifacts names follow this pattern: [baseName]-[appendix]-[version]-[classifier].[extension]
@@ -41,7 +33,6 @@ minecraft {
     // replacing stuff in the source
     replace '@VERSION@', project.version
     replace '@MC_VERSION@', version
-    replace '@BUILD_NUMBER@', project.buildnumber
 }
 
 // configure  the source folders
@@ -70,7 +61,7 @@ processResources
                 
         // replace version and mcversion
         // ${version}   and    ${mcversion}    are the exact strings being replaced
-        expand 'version':project.version, 'mcversion':project.minecraft.version, 'buildnumber':project.buildnumber
+        expand 'version':project.version, 'mcversion':project.minecraft.version
     }
         
     // copy everything else, that's not the mcmod.info
@@ -82,9 +73,6 @@ processResources
 // --------------------
 // extra jar section
 // -------------------
-
-// for the benefit of the jars, we will now now add the buildnumber to the jars
-project.version += '.' + project.buildnumber
 
 // add a source jar
 task sourceJar(type: Jar) {


### PR DESCRIPTION
From what I have seen, mainly in CJ's quest to properly use BuildCraft as a dependency.. the BuildNumber has been a pain. People have to remember it, or have to be told by someone who has access to the jenkins what the buildnumber of a given version of BC has. The only real advantage of a build number imho is for in-dev builds that are released as betas or such. Since buildcraft does not release in this fassion, I think the build number should be removed entirely, and perhaps replaced by a commit-hash and branchName for the development builds.

Apperantly the buildnumbers were used before as an update checker, however that has not been updated.. and thats something else we would need to tackle.. in a different way...
I am leaving this versionChecker code intact for the time bieng..

TLDR:
- build numbers arnt needed, im removing them.
- lemme know if I should implement a branch name and commit hash appendage for builds not coming from the master branch.

This PR was lazily made from the github web UI, lemme know if you want me to squash it.
