### PR TITLE
Fixed rendering of partially transparent facades

### DIFF
--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -8,14 +8,25 @@
  */
 package buildcraft.transport;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Random;
-
+import buildcraft.BuildCraftTransport;
+import buildcraft.api.gates.GateExpansions;
+import buildcraft.api.gates.IGateExpansion;
+import buildcraft.api.tools.IToolWrench;
+import buildcraft.api.transport.PipeWire;
+import buildcraft.core.BlockBuildCraft;
+import buildcraft.core.BlockIndex;
+import buildcraft.core.CoreConstants;
+import buildcraft.core.utils.BCLog;
+import buildcraft.core.utils.MatrixTranformations;
+import buildcraft.core.utils.Utils;
+import buildcraft.transport.gates.GateDefinition;
+import buildcraft.transport.gates.GateFactory;
+import buildcraft.transport.gates.ItemGate;
+import buildcraft.transport.render.PipeRendererWorld;
+import buildcraft.transport.utils.FacadeMatrix;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -37,24 +48,8 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import buildcraft.BuildCraftTransport;
-import buildcraft.api.gates.GateExpansions;
-import buildcraft.api.gates.IGateExpansion;
-import buildcraft.api.tools.IToolWrench;
-import buildcraft.api.transport.PipeWire;
-import buildcraft.core.BlockBuildCraft;
-import buildcraft.core.BlockIndex;
-import buildcraft.core.CoreConstants;
-import buildcraft.core.utils.BCLog;
-import buildcraft.core.utils.MatrixTranformations;
-import buildcraft.core.utils.Utils;
-import buildcraft.transport.gates.GateDefinition;
-import buildcraft.transport.gates.GateFactory;
-import buildcraft.transport.gates.ItemGate;
-import buildcraft.transport.utils.FacadeMatrix;
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
+
+import java.util.*;
 
 public class BlockGenericPipe extends BlockBuildCraft {
 
@@ -102,6 +97,17 @@ public class BlockGenericPipe extends BlockBuildCraft {
 	@Override
 	public int getRenderType() {
 		return TransportProxy.pipeModel;
+	}
+
+	@Override
+	public boolean canRenderInPass(int pass) {
+		PipeRendererWorld.renderPass = pass;
+		return true;
+	}
+
+	@Override
+	public int getRenderBlockPass() {
+		return 1;
 	}
 
 	@Override

--- a/common/buildcraft/transport/render/FacadeRenderHelper.java
+++ b/common/buildcraft/transport/render/FacadeRenderHelper.java
@@ -92,70 +92,72 @@ public class FacadeRenderHelper {
 			Block renderBlock = state.facadeMatrix.getFacadeBlock(direction);
 			
 			if (renderBlock != null) {
-				int renderMeta = state.facadeMatrix.getFacadeMetaId(direction);
+				if (renderBlock.canRenderInPass(PipeRendererWorld.renderPass)) {
+					int renderMeta = state.facadeMatrix.getFacadeMetaId(direction);
 
-				for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
-					state.textureArray[side.ordinal()] = renderBlock.getIcon(side.ordinal(), renderMeta);
-					if (side == direction || side == direction.getOpposite())
-						block.setRenderSide(side, true);
-					else
-						block.setRenderSide(side, state.facadeMatrix.getFacadeBlock(side) == null);
-				}
-
-				try {
-					BlockGenericPipe.facadeRenderColor = Item.getItemFromBlock(state.facadeMatrix.getFacadeBlock(direction)).getColorFromItemStack(new ItemStack(renderBlock, 1, renderMeta), 0);
-				} catch (Throwable error) {
-				}
-
-				if (renderBlock.getRenderType() == 31) {
-					if ((renderMeta & 12) == 4) {
-						renderblocks.uvRotateEast = 1;
-						renderblocks.uvRotateWest = 1;
-						renderblocks.uvRotateTop = 1;
-						renderblocks.uvRotateBottom = 1;
-					} else if ((renderMeta & 12) == 8) {
-						renderblocks.uvRotateSouth = 1;
-						renderblocks.uvRotateNorth = 1;
+					for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+						state.textureArray[side.ordinal()] = renderBlock.getIcon(side.ordinal(), renderMeta);
+						if (side == direction || side == direction.getOpposite())
+							block.setRenderSide(side, true);
+						else
+							block.setRenderSide(side, state.facadeMatrix.getFacadeBlock(side) == null);
 					}
-				}
 
-				// Hollow facade
-				if (state.pipeConnectionMatrix.isConnected(direction)) {
-					float[][] rotated = MatrixTranformations.deepClone(zeroStateFacade);
-					rotated[0][0] = CoreConstants.PIPE_MIN_POS - zFightOffset * 4;
-					rotated[0][1] = CoreConstants.PIPE_MAX_POS + zFightOffset * 4;
-					rotated[2][0] = 0.0F;
-					rotated[2][1] = CoreConstants.PIPE_MIN_POS - zFightOffset * 2;
-					MatrixTranformations.transform(rotated, direction);
-					setRenderBounds(renderblocks, rotated, direction);
-					renderblocks.renderStandardBlock(block, x, y, z);
+					try {
+						BlockGenericPipe.facadeRenderColor = Item.getItemFromBlock(state.facadeMatrix.getFacadeBlock(direction)).getColorFromItemStack(new ItemStack(renderBlock, 1, renderMeta), 0);
+					} catch (Throwable error) {
+					}
 
-					rotated = MatrixTranformations.deepClone(zeroStateFacade);
-					rotated[0][0] = CoreConstants.PIPE_MIN_POS - zFightOffset * 4;
-					rotated[0][1] = CoreConstants.PIPE_MAX_POS + zFightOffset * 4;
-					rotated[2][0] = CoreConstants.PIPE_MAX_POS + zFightOffset * 2;
-					MatrixTranformations.transform(rotated, direction);
-					setRenderBounds(renderblocks, rotated, direction);
-					renderblocks.renderStandardBlock(block, x, y, z);
+					if (renderBlock.getRenderType() == 31) {
+						if ((renderMeta & 12) == 4) {
+							renderblocks.uvRotateEast = 1;
+							renderblocks.uvRotateWest = 1;
+							renderblocks.uvRotateTop = 1;
+							renderblocks.uvRotateBottom = 1;
+						} else if ((renderMeta & 12) == 8) {
+							renderblocks.uvRotateSouth = 1;
+							renderblocks.uvRotateNorth = 1;
+						}
+					}
 
-					rotated = MatrixTranformations.deepClone(zeroStateFacade);
-					rotated[0][0] = 0.0F;
-					rotated[0][1] = CoreConstants.PIPE_MIN_POS - zFightOffset * 2;
-					MatrixTranformations.transform(rotated, direction);
-					setRenderBounds(renderblocks, rotated, direction);
-					renderblocks.renderStandardBlock(block, x, y, z);
+					// Hollow facade
+					if (state.pipeConnectionMatrix.isConnected(direction)) {
+						float[][] rotated = MatrixTranformations.deepClone(zeroStateFacade);
+						rotated[0][0] = CoreConstants.PIPE_MIN_POS - zFightOffset * 4;
+						rotated[0][1] = CoreConstants.PIPE_MAX_POS + zFightOffset * 4;
+						rotated[2][0] = 0.0F;
+						rotated[2][1] = CoreConstants.PIPE_MIN_POS - zFightOffset * 2;
+						MatrixTranformations.transform(rotated, direction);
+						setRenderBounds(renderblocks, rotated, direction);
+						renderblocks.renderStandardBlock(block, x, y, z);
 
-					rotated = MatrixTranformations.deepClone(zeroStateFacade);
-					rotated[0][0] = CoreConstants.PIPE_MAX_POS + zFightOffset * 2;
-					rotated[0][1] = 1F;
-					MatrixTranformations.transform(rotated, direction);
-					setRenderBounds(renderblocks, rotated, direction);
-					renderblocks.renderStandardBlock(block, x, y, z);
-				} else { // Solid facade
-					float[][] rotated = MatrixTranformations.deepClone(zeroStateFacade);
-					MatrixTranformations.transform(rotated, direction);
-					setRenderBounds(renderblocks, rotated, direction);
-					renderblocks.renderStandardBlock(block, x, y, z);
+						rotated = MatrixTranformations.deepClone(zeroStateFacade);
+						rotated[0][0] = CoreConstants.PIPE_MIN_POS - zFightOffset * 4;
+						rotated[0][1] = CoreConstants.PIPE_MAX_POS + zFightOffset * 4;
+						rotated[2][0] = CoreConstants.PIPE_MAX_POS + zFightOffset * 2;
+						MatrixTranformations.transform(rotated, direction);
+						setRenderBounds(renderblocks, rotated, direction);
+						renderblocks.renderStandardBlock(block, x, y, z);
+
+						rotated = MatrixTranformations.deepClone(zeroStateFacade);
+						rotated[0][0] = 0.0F;
+						rotated[0][1] = CoreConstants.PIPE_MIN_POS - zFightOffset * 2;
+						MatrixTranformations.transform(rotated, direction);
+						setRenderBounds(renderblocks, rotated, direction);
+						renderblocks.renderStandardBlock(block, x, y, z);
+
+						rotated = MatrixTranformations.deepClone(zeroStateFacade);
+						rotated[0][0] = CoreConstants.PIPE_MAX_POS + zFightOffset * 2;
+						rotated[0][1] = 1F;
+						MatrixTranformations.transform(rotated, direction);
+						setRenderBounds(renderblocks, rotated, direction);
+						renderblocks.renderStandardBlock(block, x, y, z);
+					} else { // Solid facade
+						float[][] rotated = MatrixTranformations.deepClone(zeroStateFacade);
+						MatrixTranformations.transform(rotated, direction);
+						setRenderBounds(renderblocks, rotated, direction);
+						renderblocks.renderStandardBlock(block, x, y, z);
+					}
 				}
 
 				if (renderBlock.getRenderType() == 31) {
@@ -176,13 +178,15 @@ public class FacadeRenderHelper {
 
 		state.currentTexture = BuildCraftTransport.instance.pipeIconProvider.getIcon(PipeIconProvider.TYPE.PipeStructureCobblestone.ordinal()); // Structure Pipe
 
-		for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
-			if (state.facadeMatrix.getFacadeBlock(direction) != null && !state.pipeConnectionMatrix.isConnected(direction)) {
-				float[][] rotated = MatrixTranformations.deepClone(zeroStateSupport);
-				MatrixTranformations.transform(rotated, direction);
+		if (PipeRendererWorld.renderPass == 0) {
+			for (ForgeDirection direction : ForgeDirection.VALID_DIRECTIONS) {
+				if (state.facadeMatrix.getFacadeBlock(direction) != null && !state.pipeConnectionMatrix.isConnected(direction)) {
+					float[][] rotated = MatrixTranformations.deepClone(zeroStateSupport);
+					MatrixTranformations.transform(rotated, direction);
 
-				renderblocks.setRenderBounds(rotated[0][0], rotated[1][0], rotated[2][0], rotated[0][1], rotated[1][1], rotated[2][1]);
-				renderblocks.renderStandardBlock(block, x, y, z);
+					renderblocks.setRenderBounds(rotated[0][0], rotated[1][0], rotated[2][0], rotated[0][1], rotated[1][1], rotated[2][1]);
+					renderblocks.renderStandardBlock(block, x, y, z);
+				}
 			}
 		}
 	}

--- a/common/buildcraft/transport/render/PipeRendererWorld.java
+++ b/common/buildcraft/transport/render/PipeRendererWorld.java
@@ -23,6 +23,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 public class PipeRendererWorld implements ISimpleBlockRenderingHandler {
 
+	public static int renderPass = -1;
+
 	public void renderPipe(RenderBlocks renderblocks, IBlockAccess iblockaccess, BlockGenericPipe block, TileGenericPipe tile, int x, int y, int z) {
 		PipeRenderState state = tile.renderState;
 		IIconProvider icons = tile.getPipeIcons();
@@ -31,47 +33,52 @@ public class PipeRendererWorld implements ISimpleBlockRenderingHandler {
 			return;
 		}
 
-		int connectivity = state.pipeConnectionMatrix.getMask();
-		float[] dim = new float[6];
+		if (renderPass == 0) {
+			int connectivity = state.pipeConnectionMatrix.getMask();
+			float[] dim = new float[6];
 
-		// render the unconnected pipe faces of the center block (if any)
+			// render the unconnected pipe faces of the center block (if any)
 
-		if (connectivity != 0x3f) { // note: 0x3f = 0x111111 = all sides
-			resetToCenterDimensions(dim);
+			if (connectivity != 0x3f) { // note: 0x3f = 0x111111 = all sides
+				resetToCenterDimensions(dim);
 
-			state.currentTexture = icons.getIcon(state.textureMatrix.getTextureIndex(ForgeDirection.UNKNOWN));
-			renderTwoWayBlock(renderblocks, block, x, y, z, dim, connectivity ^ 0x3f);
-		}
-
-		// render the connecting pipe faces
-
-		for (int dir = 0; dir < 6; dir++) {
-			int mask = 1 << dir;
-			
-			if ((connectivity & mask) == 0) {
-				continue; // no connection towards dir
+				state.currentTexture = icons.getIcon(state.textureMatrix.getTextureIndex(ForgeDirection.UNKNOWN));
+				renderTwoWayBlock(renderblocks, block, x, y, z, dim, connectivity ^ 0x3f);
 			}
 
-			// center piece offsets
-			resetToCenterDimensions(dim);
+			// render the connecting pipe faces
 
-			// extend block towards dir as it's connected to there
-			dim[dir / 2] = dir % 2 == 0 ? 0 : CoreConstants.PIPE_MAX_POS;
-			dim[dir / 2 + 3] = dir % 2 == 0 ? CoreConstants.PIPE_MIN_POS : 1;
+			for (int dir = 0; dir < 6; dir++) {
+				int mask = 1 << dir;
 
-			// the mask points to all faces perpendicular to dir, i.e. dirs 0+1 -> mask 111100, 1+2 -> 110011, 3+5 -> 001111
-			int renderMask = (3 << (dir / 2 * 2)) ^ 0x3f;
+				if ((connectivity & mask) == 0) {
+					continue; // no connection towards dir
+				}
 
-			// render sub block
-			state.currentTexture = icons.getIcon(state.textureMatrix.getTextureIndex(ForgeDirection.VALID_DIRECTIONS[dir]));
+				// center piece offsets
+				resetToCenterDimensions(dim);
 
-			renderTwoWayBlock(renderblocks, block, x, y, z, dim, renderMask);
+				// extend block towards dir as it's connected to there
+				dim[dir / 2] = dir % 2 == 0 ? 0 : CoreConstants.PIPE_MAX_POS;
+				dim[dir / 2 + 3] = dir % 2 == 0 ? CoreConstants.PIPE_MIN_POS : 1;
+
+				// the mask points to all faces perpendicular to dir, i.e. dirs 0+1 -> mask 111100, 1+2 -> 110011, 3+5 -> 001111
+				int renderMask = (3 << (dir / 2 * 2)) ^ 0x3f;
+
+				// render sub block
+				state.currentTexture = icons.getIcon(state.textureMatrix.getTextureIndex(ForgeDirection.VALID_DIRECTIONS[dir]));
+
+				renderTwoWayBlock(renderblocks, block, x, y, z, dim, renderMask);
+			}
 		}
 
 		renderblocks.setRenderBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
 
 		pipeFacadeRenderer(renderblocks, block, state, x, y, z);
-		pipePlugRenderer(renderblocks, block, state, x, y, z);
+
+		if (renderPass == 0) {
+			pipePlugRenderer(renderblocks, block, state, x, y, z);
+		}
 	}
 
 	private void resetToCenterDimensions(float[] dim) {


### PR DESCRIPTION
This should finally fix issue #1468

Essentially the issue with the previous attempt was that opaque blocks (pipe, the facade connectors, and opaque facades) were rendering in the pass meant for semi-transparent blocks, which caused the clipping issues. What I've done is ensure that all opaque things are only rendered in the opaque pass, and facades regulate rendering to the proper pass as needed.

![](http://puu.sh/82Uq1.png)

![](http://puu.sh/82Uqw.png)

![](http://puu.sh/82VfJ.jpg)
The facade on the right there is packed ice, demonstrating solid and opaque facades in one block space
