### PR TITLE
Update ReflectMjAPI.java to remove potential NPE

### DIFF
--- a/common/buildcraft/core/ReflectMjAPI.java
+++ b/common/buildcraft/core/ReflectMjAPI.java
@@ -84,6 +84,8 @@ public class ReflectMjAPI {
 	}
 
 	public static BatteryObject getMjBattery (Object o) {
+		if (o == null)
+			return null;
 		BatteryField f = getMjBattery (o.getClass());
 
 		if (f == null) {


### PR DESCRIPTION
Removed a potential NPE (this can occur when a class contains a null mjBattery object)
While I have not encountered this in vanilla buildcraft, this has been a problem for my own block extender (offer the mjBattery field down the line, this has to be null if there is no tile entity down the line)
