### PR TITLE
Check an stack limit size for iron logic pipes

### DIFF
--- a/common/buildcraft/transport/pipes/PipeLogicIron.java
+++ b/common/buildcraft/transport/pipes/PipeLogicIron.java
@@ -12,6 +12,7 @@ import buildcraft.api.tools.IToolWrench;
 import buildcraft.core.TileBuffer;
 import buildcraft.transport.Pipe;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -58,8 +59,12 @@ public abstract class PipeLogicIron {
 			return true;
 
 		TileEntity tile = tileBuffer[side.ordinal()].getTile();
-		return isValidConnectingTile(tile);
+		return isValidOutputTile(tile);
 	}
+
+    protected boolean isValidOutputTile(TileEntity tile) {
+        return !(tile instanceof IInventory && ((IInventory) tile).getInventoryStackLimit() == 0) && isValidConnectingTile(tile);
+    }
 
 	protected abstract boolean isValidConnectingTile(TileEntity tile);
 


### PR DESCRIPTION
That means iron pipes cannot anymore setup for output in 'fake' inventories, like quarry.
Fix #1395
