### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ jdk:
   - openjdk7
 
 before_install: git clone https://github.com/BuildCraft/BuildCraft-Localization.git ../BuildCraft-Localization
-install: ./gradlew setupCIWorkspace --quiet
-script: ./gradlew build --quiet
+install: ./gradlew setupCIWorkspace -S
+script: ./gradlew build -S
 
 env:
   global:


### PR DESCRIPTION
Don't build buildcraft in the install stage
The 'build' task contains the 'check' task and 'assemble', so it assembles a jar and runs the tests. This is the intended behaviour for travis. Before, everything was ran in the install stage, and once again in the normal stage, which is bad
