### PR TITLE
On opening Architect GUI focus textfield

### DIFF
--- a/common/buildcraft/builders/gui/GuiArchitect.java
+++ b/common/buildcraft/builders/gui/GuiArchitect.java
@@ -74,6 +74,7 @@ public class GuiArchitect extends GuiBuildCraft {
 		textField = new GuiTextField(this.fontRendererObj, TEXT_X, TEXT_Y, TEXT_WIDTH, TEXT_HEIGHT);
 		textField.setMaxStringLength(BuildCraftBuilders.MAX_BLUEPRINTS_NAME_SIZE);
 		textField.setText(architect.name);
+		textField.setFocused(true);
 
 		updateButtons();
 	}


### PR DESCRIPTION
Makes it more convenient. Instead of clicking on the textfield you simply can start writing right away and then put in the blueprint/template to write to.
