### PR TITLE
Dont' break other mods' gui s when holding a pipe

### DIFF
--- a/common/buildcraft/transport/render/PipeItemRenderer.java
+++ b/common/buildcraft/transport/render/PipeItemRenderer.java
@@ -12,7 +12,6 @@ import org.lwjgl.opengl.GL11;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -27,8 +26,10 @@ import buildcraft.core.CoreConstants;
 public class PipeItemRenderer implements IItemRenderer {
 
 	private void renderPipeItem(RenderBlocks render, ItemStack item, float translateX, float translateY, float translateZ) {
-		// Simply force transparency
-		OpenGlHelper.glBlendFunc(770, 771, 0, 1);
+		
+		GL11.glPushAttrib(GL11.GL_COLOR_BUFFER_BIT); //don't break other mods' guis when holding a pipe
+		//force transparency
+		GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 		GL11.glEnable(GL11.GL_BLEND);
 
 		// GL11.glBindTexture(GL11.GL_TEXTURE_2D, 10);
@@ -73,8 +74,8 @@ public class PipeItemRenderer implements IItemRenderer {
 		GL11.glTranslatef(0.5F, 0.5F, 0.5F);
 		block.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
 
-		// Cleanup
-		GL11.glDisable(GL11.GL_BLEND);
+		GL11.glPopAttrib(); //nicely leave the rendering how it was
+		
 	}
 
 	/**


### PR DESCRIPTION
Restore the OpenGl to the state we found it,
instead of forcing the transparency to be turned off.

If you force the transparency off, we break other things' transparency.
