### PR TITLE
Update dropItems to use custom entities

### DIFF
--- a/common/buildcraft/core/inventory/InvUtils.java
+++ b/common/buildcraft/core/inventory/InvUtils.java
@@ -116,6 +116,13 @@ public final class InvUtils {
 		double d2 = (world.rand.nextFloat() * f1) + (1.0F - f1) * 0.5D;
 		EntityItem entityitem = new EntityItem(world, i + d, j + d1, k + d2, stack);
 		entityitem.delayBeforeCanPickup = 10;
+		if(stack.getItem().hasCustomEntity(stack)) {
+			Entity entity = stack.getItem().createEntity(world, entityitem, stack);
+			if(entity != null) {
+				world.spawnEntityInWorld(entity);
+				return;
+			}
+		}
 
 		world.spawnEntityInWorld(entityitem);
 	}


### PR DESCRIPTION
According to the javadoc if an item returns true on "hasCustomEntity" the method "createEntity" should be called and if it returns a non-null entity that should be spawned in the world instead of the ItemEntity. If "createEntity" returns null the entity item should be spawned normally.
