### PR TITLE
Fix blueprints not being uploaded when shift-clicked in blueprint library

### DIFF
--- a/common/buildcraft/builders/gui/ContainerBlueprintLibrary.java
+++ b/common/buildcraft/builders/gui/ContainerBlueprintLibrary.java
@@ -16,6 +16,7 @@ import net.minecraft.item.ItemStack;
 
 import buildcraft.builders.TileBlueprintLibrary;
 import buildcraft.core.gui.BuildCraftContainer;
+import buildcraft.core.gui.slots.SlotBlueprintLibrary;
 import buildcraft.core.gui.slots.SlotOutput;
 
 public class ContainerBlueprintLibrary extends BuildCraftContainer {
@@ -30,10 +31,10 @@ public class ContainerBlueprintLibrary extends BuildCraftContainer {
 		this.playerInventory = player.inventory;
 		this.library = library;
 
-		addSlotToContainer(new Slot(library, 0, 211, 61));
+		addSlotToContainer(new SlotBlueprintLibrary(library, player, 0, 211, 61));
 		addSlotToContainer(new SlotOutput(library, 1, 167, 61));
 
-		addSlotToContainer(new Slot(library, 2, 167, 79));
+		addSlotToContainer(new SlotBlueprintLibrary(library, player, 2, 167, 79));
 		addSlotToContainer(new SlotOutput(library, 3, 211, 79));
 
 		// Player inventory

--- a/common/buildcraft/core/gui/slots/SlotBlueprintLibrary.java
+++ b/common/buildcraft/core/gui/slots/SlotBlueprintLibrary.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.core.gui.slots;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+
+import buildcraft.builders.TileBlueprintLibrary;
+
+public class SlotBlueprintLibrary extends SlotBase {
+	private TileBlueprintLibrary library;
+	private EntityPlayer player;
+	private int slot;
+
+	public SlotBlueprintLibrary(IInventory iinventory, EntityPlayer player, int slotIndex, int posX, int posY) {
+		super(iinventory, slotIndex, posX, posY);
+		this.library = (TileBlueprintLibrary) iinventory;
+		this.slot = slotIndex;
+		this.player = player;
+	}
+
+	public void onSlotChanged() {
+		if (slot == 0) {
+			library.uploadingPlayer = player;
+		} else if (slot == 2) {
+			library.downloadingPlayer = player;
+		}
+
+		this.inventory.markDirty();
+	}
+}


### PR DESCRIPTION
Was trying to put some blueprints in blueprint library, but they well wouldn't simply appear in the list.
Came out the uploading and downloading player is only set when the slot is clicked, but not when shift clicked.
Also since the onSlotChanged is triggered always, slotClick doesn't seem to be needed anymore?
