### PR TITLE
Disable/enable page buttons in blueprint library

### DIFF
--- a/common/buildcraft/builders/TileBlueprintLibrary.java
+++ b/common/buildcraft/builders/TileBlueprintLibrary.java
@@ -51,7 +51,7 @@ public class TileBlueprintLibrary extends TileBuildCraft implements IInventory {
 	public EntityPlayer uploadingPlayer = null;
 	public EntityPlayer downloadingPlayer = null;
 
-	private int pageId = 0;
+	public int pageId = 0;
 
 	public TileBlueprintLibrary() {
 

--- a/common/buildcraft/builders/gui/GuiBlueprintLibrary.java
+++ b/common/buildcraft/builders/gui/GuiBlueprintLibrary.java
@@ -61,6 +61,7 @@ public class GuiBlueprintLibrary extends GuiBuildCraft {
 		buttonList.add(deleteButton);
 
 		checkDelete();
+		checkPages();
 	}
 
 	@Override
@@ -145,14 +146,28 @@ public class GuiBlueprintLibrary extends GuiBuildCraft {
 		}
 
 		checkDelete();
+		checkPages();
 	}
 
 	protected void checkDelete() {
 		if (library.selected != -1) {
 			deleteButton.enabled = true;
-		
 		} else {
 			deleteButton.enabled = false;
+		}
+	}
+
+	protected void checkPages() {
+		if (library.pageId != 0) {
+			prevPageButton.enabled = true;
+		} else {
+			prevPageButton.enabled = false;
+		}
+
+		if (library.pageId < BuildCraftBuilders.clientDB.getPageNumber() - 1) {
+			nextPageButton.enabled = true;
+		} else {
+			nextPageButton.enabled = false;
 		}
 	}
 }


### PR DESCRIPTION
If there are no pages to go back to or to, according buttons will be disabled.
If there are pages, then the button will be enabled.
