### PR TITLE
Fixes wire flicker when changing redstone output of gates

### DIFF
--- a/common/buildcraft/core/utils/BlockUtil.java
+++ b/common/buildcraft/core/utils/BlockUtil.java
@@ -24,8 +24,10 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S27PacketExplosion;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.ChunkPosition;
 import net.minecraft.world.Explosion;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fluids.BlockFluidBase;
@@ -185,5 +187,20 @@ public class BlockUtil {
 				((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S27PacketExplosion(x + .5, y + .5, z + .5, 3f, explosion.affectedBlockPositions, null));
 			}
 		}
+	}
+	
+	
+	public static TileEntity[] getBlockNeighboursAsTileEntities(IBlockAccess blockAccess, int x, int y, int z) {
+		
+		TileEntity[] entities = new TileEntity[6];
+		
+		entities[0] = blockAccess.getTileEntity(x, y - 1, z);
+		entities[1] = blockAccess.getTileEntity(x, y + 1, z);
+		entities[2] = blockAccess.getTileEntity(x, y, z - 1);
+		entities[3] = blockAccess.getTileEntity(x, y, z + 1);
+		entities[4] = blockAccess.getTileEntity(x - 1, y, z);
+		entities[5] = blockAccess.getTileEntity(x + 1, y, z);
+		
+		return entities;
 	}
 }

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -46,6 +46,7 @@ import buildcraft.core.BlockBuildCraft;
 import buildcraft.core.BlockIndex;
 import buildcraft.core.CoreConstants;
 import buildcraft.core.utils.BCLog;
+import buildcraft.core.utils.BlockUtil;
 import buildcraft.core.utils.MatrixTranformations;
 import buildcraft.core.utils.Utils;
 import buildcraft.transport.gates.GateDefinition;
@@ -1037,6 +1038,20 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		}
 
 		return ((TileGenericPipe) tile).pipe;
+	}
+	
+	public static Pipe[] getBlockNeighboursAsPipes(IBlockAccess blockAccess, int x, int y, int z) {
+		TileEntity entities[] = BlockUtil.getBlockNeighboursAsTileEntities(blockAccess, x, y, z);
+		Pipe pipes[] = new Pipe[6];
+		for(int i = 0; i < 6; i++) {
+			if (!(entities[i] instanceof TileGenericPipe) || entities[i].isInvalid()) {
+				pipes[i] = null;
+			} else {
+				pipes[i] = ((TileGenericPipe) entities[i]).pipe;
+			}
+		}
+		
+		return pipes;
 	}
 
 	public static boolean isFullyDefined(Pipe pipe) {

--- a/common/buildcraft/transport/Gate.java
+++ b/common/buildcraft/transport/Gate.java
@@ -193,7 +193,7 @@ public final class Gate {
 	public void resetGate() {
 		if (redstoneOutput != 0) {
 			redstoneOutput = 0;
-			pipe.updateNeighbors(true);
+			pipe.updateNeighborsOnRedstoneOutput(true);
 		}
 	}
 
@@ -285,7 +285,7 @@ public final class Gate {
 		if (oldRedstoneOutput != redstoneOutput) {
 			if (redstoneOutput == 0 ^ oldRedstoneOutput == 0)
 				pipe.container.scheduleRenderUpdate();
-			pipe.updateNeighbors(true);
+			pipe.updateNeighborsOnRedstoneOutput(true);
 		}
 
 		if (!prevBroadcastSignal.equals(broadcastSignal)) {

--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -441,7 +441,64 @@ public abstract class Pipe<T extends PipeTransport> implements IDropControlInven
 			notifyBlocksOfNeighborChange(side);
 		}
 	}
+	
+	protected void notifyBlocksOfNeighborChangeOnRedstoneOutput(ForgeDirection side) {
+		World world = container.getWorldObj();
+		int x = container.xCoord + side.offsetX;
+		int y = container.yCoord + side.offsetY;
+		int z = container.zCoord + side.offsetZ;
+		Pipe pipes[] = BlockGenericPipe.getBlockNeighboursAsPipes(world, x, y, z);
+		
+		//On gate redstone output change, neighbour change scheduling on pipes leads to wire flicker
+		//So if the only scheduled neighbour changes were from redstone, don't make them.
+		boolean oldNeighbourChanges[] = new boolean[6];
+		
+		for(int i = 0; i < 6; i++) {
+			if(pipes[i] != null) {
+				oldNeighbourChanges[i] = pipes[i].container.isBlockNeighborChange();
+			}
+		}
 
+		world.notifyBlocksOfNeighborChange(x, y, z, BuildCraftTransport.genericPipeBlock);
+		
+		for(int i = 0; i < 6; i++) {
+			if(pipes[i] != null) {
+				pipes[i].container.setBlockNeighborChange(oldNeighbourChanges[i]);
+			}
+		}
+	}
+
+	protected void updateNeighborsOnRedstoneOutput(boolean needSelf) {
+		if (needSelf) {
+			World world = container.getWorldObj();
+			int x = container.xCoord;
+			int y = container.yCoord;
+			int z = container.zCoord;
+			Pipe pipes[] = BlockGenericPipe.getBlockNeighboursAsPipes(world, x, y, z);
+			
+			//On gate redstone output change, neighbour change scheduling on pipes leads to wire flicker
+			//So if the only scheduled neighbour changes were from redstone, don't make them.
+			boolean oldNeighbourChanges[] = new boolean[6];
+			
+			for(int i = 0; i < 6; i++) {
+				if(pipes[i] != null) {
+					oldNeighbourChanges[i] = pipes[i].container.isBlockNeighborChange();
+				}
+			}
+
+			world.notifyBlocksOfNeighborChange(x, y, z, BuildCraftTransport.genericPipeBlock);
+			
+			for(int i = 0; i < 6; i++) {
+				if(pipes[i] != null) {
+					pipes[i].container.setBlockNeighborChange(oldNeighbourChanges[i]);
+				}
+			}
+		}
+		for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
+			notifyBlocksOfNeighborChangeOnRedstoneOutput(side);
+		}
+	}
+	
 	public void dropItem(ItemStack stack) {
 		InvUtils.dropItems(container.getWorldObj(), stack, container.xCoord, container.yCoord, container.zCoord);
 	}

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -831,4 +831,12 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, IFlui
 		if (BlockGenericPipe.isValid(pipe) && pipe instanceof IGuiReturnHandler)
 			((IGuiReturnHandler) pipe).readGuiData(data, sender);
 	}
+	
+	protected boolean isBlockNeighborChange() {
+		return blockNeighborChange;
+	}
+
+	protected void setBlockNeighborChange(boolean blockNeighborChange) {
+		this.blockNeighborChange = blockNeighborChange;
+	}
 }


### PR DESCRIPTION
Mind you - this could potentially break something, but from what I've tested, it works.

Signed-off-by: Humungus
