### PR TITLE
Tweak blueprint and template recipe

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -477,10 +477,10 @@ public class BuildCraftBuilders extends BuildCraftMod {
 	}
 
 	public static void loadRecipes() {
-		CoreProxy.proxy.addCraftingRecipe(new ItemStack(templateItem, 1), "ppp", "pip", "ppp", 'i',
+		CoreProxy.proxy.addCraftingRecipe(new ItemStack(templateItem, 4), "ppp", "pip", "ppp", 'i',
 			new ItemStack(Items.dye, 1, 0), 'p', Items.paper);
 
-		CoreProxy.proxy.addCraftingRecipe(new ItemStack(blueprintItem, 1), "ppp", "pip", "ppp", 'i',
+		CoreProxy.proxy.addCraftingRecipe(new ItemStack(blueprintItem, 4), "ppp", "pip", "ppp", 'i',
 			new ItemStack(Items.dye, 1, 4), 'p', Items.paper);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(markerBlock, 1), "l ", "r ", 'l',


### PR DESCRIPTION
It's a bit unfair that they only give one, especially since 8 paper is used in the recipe. It would be nice for them to give, maybe, 4.
