### PR TITLE
Fixes wire flicker when changing redstone output of gates v3

### DIFF
--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -565,6 +565,9 @@ public class BlockGenericPipe extends BlockBuildCraft {
 
 		pipeRemoved.put(new BlockIndex(x, y, z), pipe);
 		world.removeTileEntity(x, y, z);
+		
+		updateNeighbourSignalState(pipe);
+		
 	}
 
 	@Override
@@ -860,6 +863,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 				pipe.gate.dropGate();
 			}
 			pipe.resetGate();
+			
 			return true;
 		}
 		return false;
@@ -894,17 +898,15 @@ public class BlockGenericPipe extends BlockBuildCraft {
 			}
 			pipe.wireSet[color.ordinal()] = false;
 			
-			TileBuffer neighbours[] = pipe.container.getTileCache();
+			pipe.updateSignalState();
 			
-			if(neighbours != null) {
-				for(int i = 0; i < 6; i++) {
-					if (neighbours[i] != null && neighbours[i].getTile() instanceof TileGenericPipe && !neighbours[i].getTile().isInvalid()) {
-						((TileGenericPipe) neighbours[i].getTile()).pipe.updateSignalState();
-					}
-				}
+			updateNeighbourSignalState(pipe);
+			
+			if (isFullyDefined(pipe) && pipe.hasGate()) {
+//				pipe.gate.resolveActions();
 			}
-			pipe.container.scheduleRenderUpdate();
 			
+			pipe.container.scheduleRenderUpdate();			
 			
 			return true;
 		}
@@ -1328,5 +1330,18 @@ public class BlockGenericPipe extends BlockBuildCraft {
 			return facadeRenderColor;
 		}
 		return super.colorMultiplier(world, x, y, z);
+	}
+	
+	public static void updateNeighbourSignalState(Pipe pipe) {
+		TileBuffer neighbours[] = pipe.container.getTileCache();
+		
+		if(neighbours != null) {
+			for(int i = 0; i < 6; i++) {
+				if (neighbours[i] != null && neighbours[i].getTile() instanceof TileGenericPipe && !neighbours[i].getTile().isInvalid()) {
+					((TileGenericPipe) neighbours[i].getTile()).pipe.updateSignalState();
+
+				}
+			}
+		}
 	}
 }

--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -459,6 +459,7 @@ public abstract class Pipe<T extends PipeTransport> implements IDropControlInven
 	}
 
 	public void onBlockRemoval() {
+		
 		if (getWorld().getWorldInfo().getGameType() != GameType.CREATIVE) {
 			for (ItemStack stack : computeItemDrop()) {
 				dropItem(stack);
@@ -513,6 +514,8 @@ public abstract class Pipe<T extends PipeTransport> implements IDropControlInven
 	public void resetGate() {
 		gate.resetGate();
 		gate = null;
+		
+		internalUpdateScheduled = true;
 		container.scheduleRenderUpdate();
 	}
 


### PR DESCRIPTION
A much simpler fix to issue https://github.com/BuildCraft/BuildCraft/issues/1357 than PR https://github.com/BuildCraft/BuildCraft/pull/1774

Test world: https://dl.dropboxusercontent.com/u/48472211/New%20World2_2.zip
