### PR TITLE
Don't crash when I create new PipeTypes

### DIFF
--- a/common/buildcraft/transport/render/PipeRendererTESR.java
+++ b/common/buildcraft/transport/render/PipeRendererTESR.java
@@ -39,6 +39,7 @@ import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftCore.RenderMode;
 import buildcraft.BuildCraftTransport;
 import buildcraft.api.gates.IGateExpansion;
+import buildcraft.api.transport.IPipeTile.PipeType;
 import buildcraft.api.transport.PipeWire;
 import buildcraft.core.CoreConstants;
 import buildcraft.core.DefaultProps;


### PR DESCRIPTION
I am using reflection to "hack in" new PipeTypes for myself.
(Yes, that IS possible, but very "aggressive")

Don't cause an ArrayIndexOutOfBounds exception when I do that.
(at least when rendering, just don't place a gate on my pipes)

This is also another step towards
the ability to create new PipeTypes.
