### PR TITLE
Fix drain method causing dupe glitches...

### DIFF
--- a/common/buildcraft/factory/TileTank.java
+++ b/common/buildcraft/factory/TileTank.java
@@ -204,7 +204,8 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 		if (resource == null) {
 			return null;
 		}
-		if (!resource.isFluidEqual(tank.getFluid())) {
+		TileTank bottom = getBottomTank();
+		if (!resource.isFluidEqual(bottom.tank.getFluid())) {
 			return null;
 		}
 		return drain(from, resource.amount, doDrain);


### PR DESCRIPTION
...if using them mixed

Before the one accepting a FluidStack always returned null if the targeted tank was empty, but the one under it wasnt, the one w/ int doesnt have the problem.

fixes: https://github.com/BuildCraft/BuildCraft/issues/1798
