### PR TITLE
BuildCraft tanks always return false on "canDrain"

### DIFF
--- a/common/buildcraft/factory/TileTank.java
+++ b/common/buildcraft/factory/TileTank.java
@@ -253,7 +253,7 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 
 	@Override
 	public boolean canDrain(ForgeDirection from, Fluid fluid) {
-		return false;
+		return true;
 	}
 
 	public int getFluidLightLevel() {


### PR DESCRIPTION
This should be obviously changed, because you can actually drain(...) from them.

Another issue would be, if those "can"-methods should actually look, if the tank is empty and if the requested fluid is the correct fluid, but that is not topic of this issue.
