### PR TITLE
Update EntityRobotPicker.java

### DIFF
--- a/common/buildcraft/core/robots/EntityRobotPicker.java
+++ b/common/buildcraft/core/robots/EntityRobotPicker.java
@@ -96,7 +96,7 @@ public class EntityRobotPicker extends EntityRobot implements IInventory {
 						.getTileEntity(dockingStation.x, dockingStation.y,
 								dockingStation.z);
 
-				if (pipe.pipe.transport instanceof PipeTransportItems) {
+				if (pipe != null && pipe.pipe.transport instanceof PipeTransportItems) {
 					if (unloadTracker.markTimeIfDelay(worldObj)) {
 						for (int i = 0; i < inv.length; ++i) {
 							if (inv[i] != null) {


### PR DESCRIPTION
Prevents a [crash](http://paste.ee/p/P8b5W) if the pipe a robot is docked onto is broken.
