### PR TITLE
Prevent crash when - is removed from blueprints

### DIFF
--- a/common/buildcraft/builders/blueprints/BlueprintDatabase.java
+++ b/common/buildcraft/builders/blueprints/BlueprintDatabase.java
@@ -166,6 +166,10 @@ public class BlueprintDatabase {
 			for (File blueprintFile : directory.listFiles(filter)) {
 				String fileName = blueprintFile.getName();
 
+				if (fileName.indexOf(BuildCraftBuilders.BPT_SEP_CHARACTER) < 0) {
+					return;
+				}
+
 				int cutIndex = fileName.lastIndexOf(BuildCraftBuilders.BPT_SEP_CHARACTER);
 
 				String prefix = fileName.substring(0, cutIndex);


### PR DESCRIPTION
Apparently when someone decides it's good idea to remove - from file name of a blueprint, then don't crash - just simply don't load it. It might be in future a good idea to warn people about it...
