### PR TITLE
Unfinalizing classes that are needed for the creation of dummies

### DIFF
--- a/api/buildcraft/api/power/PowerHandler.java
+++ b/api/buildcraft/api/power/PowerHandler.java
@@ -35,7 +35,7 @@ import buildcraft.api.mj.MjBattery;
  * @see IPowerReceptor
  * @see IPowerEmitter
  */
-public final class PowerHandler implements IBatteryProvider {
+public class PowerHandler implements IBatteryProvider {
 
 	public static enum Type {
 
@@ -381,7 +381,7 @@ public final class PowerHandler implements IBatteryProvider {
 		data.setTag(tag, nbt);
 	}
 
-	public final class PowerReceiver {
+	public class PowerReceiver {
 
 		private PowerReceiver() {
 		}


### PR DESCRIPTION
Hello.

First of all im a UE-Team dev, this PR is mostly meant so that we can support BC in 1.7

our main use for this is that we need a dummy, with having this class final we can't extend it
and apply the code for our mod items and blocks.
this dummy is needed to forward the BC Methods calls on a block to the UE interfaces and that way we simply allow UE Mods to support BC.

I Also fail to see the reason for making these classes final in this case, if there is a proper reason and maybe we can work around it otherwise that would work aswell, but as of now we definitely need to be able to override these to allow UE Functionality.

-tgame14
