### PR TITLE
fix floodgate

### DIFF
--- a/common/buildcraft/factory/TileFloodGate.java
+++ b/common/buildcraft/factory/TileFloodGate.java
@@ -214,7 +214,7 @@ public class TileFloodGate extends TileBuildCraft implements IFluidHandler {
 	}
 
 	private boolean canPlaceFluidAt(Block block, int x, int y, int z) {
-		return BuildCraftAPI.isSoftBlock(block, worldObj, x, y, z) && !BlockUtil.isFullFluidBlock(block, worldObj, x, y, z);
+		return (block == null || BuildCraftAPI.softBlocks.contains(block) || block.isAir(this.worldObj, x, y, z)) && !BlockUtil.isFullFluidBlock(block, worldObj, x, y, z);
 	}
 
 	public void onNeighborBlockChange(Block block) {


### PR DESCRIPTION
in the api softblock check it checks if the block is replacable, fluids are replacable so the floodgate thought it was overwriting sourceblocks with another sourseblock
