### PR TITLE
Make the assembly recipe properly parse ore IDs

### DIFF
--- a/common/buildcraft/core/recipes/AssemblyRecipeManager.java
+++ b/common/buildcraft/core/recipes/AssemblyRecipeManager.java
@@ -71,7 +71,7 @@ public class AssemblyRecipeManager implements IAssemblyRecipeManager {
 				} else if (inputs[i] instanceof Block) {
 					processedInput[i] = new ItemStack((Block) inputs[i], 1, OreDictionary.WILDCARD_VALUE);
 				} else if (inputs[i] instanceof Integer) {
-					processedInput[i] = inputs[i];
+					processedInput[i] = OreDictionary.getOres((Integer) inputs[i]);
 				} else {
 					throw new IllegalArgumentException("Unknown Object passed to recipe!");
 				}


### PR DESCRIPTION
Before it would just store the numeric value, and then never check for it, because in canBeDone() it only checks if the processed input is an ItemStack, or a List.
