### PR TITLE
Fix builder fluid support

### DIFF
--- a/api/buildcraft/api/blueprints/Schematic.java
+++ b/api/buildcraft/api/blueprints/Schematic.java
@@ -187,8 +187,10 @@ public abstract class Schematic {
 	public double getEnergyRequirement(LinkedList<ItemStack> stacksUsed) {
 		double result = 0;
 
-		for (ItemStack s : stacksUsed) {
-			result += s.stackSize * SchematicRegistry.BUILD_ENERGY;
+		if (stacksUsed != null) {
+			for (ItemStack s : stacksUsed) {
+				result += s.stackSize * SchematicRegistry.BUILD_ENERGY;
+			}
 		}
 
 		return result;

--- a/api/buildcraft/api/blueprints/SchematicFluid.java
+++ b/api/buildcraft/api/blueprints/SchematicFluid.java
@@ -70,12 +70,13 @@ public class SchematicFluid extends SchematicBlock {
 	@Override
 	public LinkedList<ItemStack> getStacksToDisplay(
 			LinkedList<ItemStack> stackConsumed) {
-
 		LinkedList<ItemStack> result = new LinkedList<ItemStack>();
-
 		result.add(fluidItem);
-
 		return result;
 	}
 
+	@Override
+	public double getEnergyRequirement(LinkedList<ItemStack> stacksUsed) {
+		return 1 * SchematicRegistry.BUILD_ENERGY;
+	}
 }

--- a/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
+++ b/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
@@ -51,7 +51,6 @@ import buildcraft.core.utils.BlockUtil;
 public class BptBuilderBlueprint extends BptBuilderBase {
 
 	public LinkedList<ItemStack> neededItems = new LinkedList<ItemStack>();
-	public LinkedList<FluidStack> neededFluids = new LinkedList<FluidStack>();
 
 	protected TreeSet<Integer> builtEntities = new TreeSet<Integer>();
 
@@ -551,14 +550,11 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 			}
 		}
 
-		builder.consumeEnergy(slot.getEnergyRequirement ());
-
-		return;
+		builder.consumeEnergy(slot.getEnergyRequirement());
 	}
 
 	public void recomputeNeededItems() {
 		neededItems.clear();
-		neededFluids.clear();
 
 		HashMap<StackKey, Integer> computeStacks = new HashMap<StackKey, Integer>();
 


### PR DESCRIPTION
Builder won't build fluids if it's already present in tank in blueprint push time.

Some cleanup.
