### PR TITLE
Fix isFullFluidBlock -> Fix Floodgate

### DIFF
--- a/common/buildcraft/core/utils/BlockUtil.java
+++ b/common/buildcraft/core/utils/BlockUtil.java
@@ -27,7 +27,6 @@ import net.minecraft.world.WorldServer;
 import cpw.mods.fml.common.FMLCommonHandler;
 
 import net.minecraftforge.event.ForgeEventFactory;
-import net.minecraftforge.fluids.BlockFluidBase;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidRegistry;


### PR DESCRIPTION
There was a previous commit attempt that didn't solve the problem with floodgates overwriting source blocks. This should fix it.
