### PR TITLE
Remove use of .getAABBPool() for 1.7.10 compatibility

### DIFF
--- a/common/buildcraft/builders/BlockMarker.java
+++ b/common/buildcraft/builders/BlockMarker.java
@@ -43,17 +43,17 @@ public class BlockMarker extends BlockContainer {
 		ForgeDirection dir = ForgeDirection.getOrientation(meta);
 		switch (dir) {
 			case DOWN:
-				return AxisAlignedBB.getAABBPool().getAABB(0.5F - w, 1F - h, 0.5F - w, 0.5F + w, 1F, 0.5F + w);
+				return AxisAlignedBB.getBoundingBox(0.5F - w, 1F - h, 0.5F - w, 0.5F + w, 1F, 0.5F + w);
 			case UP:
-				return AxisAlignedBB.getAABBPool().getAABB(0.5F - w, 0F, 0.5F - w, 0.5F + w, h, 0.5F + w);
+				return AxisAlignedBB.getBoundingBox(0.5F - w, 0F, 0.5F - w, 0.5F + w, h, 0.5F + w);
 			case SOUTH:
-				return AxisAlignedBB.getAABBPool().getAABB(0.5F - w, 0.5F - w, 0F, 0.5F + w, 0.5F + w, h);
+				return AxisAlignedBB.getBoundingBox(0.5F - w, 0.5F - w, 0F, 0.5F + w, 0.5F + w, h);
 			case NORTH:
-				return AxisAlignedBB.getAABBPool().getAABB(0.5F - w, 0.5F - w, 1 - h, 0.5F + w, 0.5F + w, 1);
+				return AxisAlignedBB.getBoundingBox(0.5F - w, 0.5F - w, 1 - h, 0.5F + w, 0.5F + w, 1);
 			case EAST:
-				return AxisAlignedBB.getAABBPool().getAABB(0F, 0.5F - w, 0.5F - w, h, 0.5F + w, 0.5F + w);
+				return AxisAlignedBB.getBoundingBox(0F, 0.5F - w, 0.5F - w, h, 0.5F + w, 0.5F + w);
 			default:
-				return AxisAlignedBB.getAABBPool().getAABB(1 - h, 0.5F - w, 0.5F - w, 1F, 0.5F + w, 0.5F + w);
+				return AxisAlignedBB.getBoundingBox(1 - h, 0.5F - w, 0.5F - w, 1F, 0.5F + w, 0.5F + w);
 		}
 	}
 

--- a/common/buildcraft/builders/urbanism/EntityUrbanist.java
+++ b/common/buildcraft/builders/urbanism/EntityUrbanist.java
@@ -56,7 +56,7 @@ public class EntityUrbanist extends EntityLivingBase {
 	public void onUpdate() {
         Vec3 look = this.getLook(1.0F).normalize();
 
-        Vec3 worldUp = worldObj.getWorldVec3Pool().getVecFromPool(0, 1, 0);
+        Vec3 worldUp = Vec3.createVectorHelper(0, 1, 0);
         Vec3 side = worldUp.crossProduct(look).normalize();
         Vec3 forward = side.crossProduct(worldUp).normalize();
 
@@ -158,7 +158,7 @@ public class EntityUrbanist extends EntityLivingBase {
 
 		    look = this.getLook(1.0F).normalize();
 
-			Vec3 aimed = worldObj.getWorldVec3Pool().getVecFromPool(
+			Vec3 aimed = Vec3.createVectorHelper(
 					localPos.xCoord + look.xCoord * 200,
 					localPos.yCoord + look.yCoord * 200,
 					localPos.zCoord + look.zCoord * 200);

--- a/common/buildcraft/energy/BlockEngine.java
+++ b/common/buildcraft/energy/BlockEngine.java
@@ -166,7 +166,7 @@ public class BlockEngine extends BlockBuildCraft implements ICustomHighlight {
 		if (tile instanceof TileEngine) {
 			return boxes[((TileEngine) tile).orientation.ordinal()];
 		} else {
-			return new AxisAlignedBB[]{AxisAlignedBB.getAABBPool().getAABB(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)};
+			return new AxisAlignedBB[]{AxisAlignedBB.getBoundingBox(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)};
 		}
 	}
 

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -309,7 +309,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 
 		double eyeHeight = world.isRemote ? player.getEyeHeight() - player.getDefaultEyeHeight() : player.getEyeHeight();
 		Vec3 lookVec = player.getLookVec();
-		Vec3 origin = world.getWorldVec3Pool().getVecFromPool(player.posX, player.posY + eyeHeight, player.posZ);
+		Vec3 origin = Vec3.createVectorHelper(player.posX, player.posY + eyeHeight, player.posZ);
 		Vec3 direction = origin.addVector(lookVec.xCoord * reachDistance, lookVec.yCoord * reachDistance, lookVec.zCoord * reachDistance);
 
 		return doRayTrace(world, x, y, z, origin, direction);
@@ -468,7 +468,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		bounds[2][1] = max;
 
 		MatrixTranformations.transform(bounds, side);
-		return AxisAlignedBB.getAABBPool().getAABB(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
+		return AxisAlignedBB.getBoundingBox(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
 	}
 
 	private AxisAlignedBB getFacadeBoundingBox(ForgeDirection side) {
@@ -484,7 +484,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		bounds[2][1] = 1.0F;
 
 		MatrixTranformations.transform(bounds, side);
-		return AxisAlignedBB.getAABBPool().getAABB(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
+		return AxisAlignedBB.getBoundingBox(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
 	}
 
 	private AxisAlignedBB getPlugBoundingBox(ForgeDirection side) {
@@ -500,7 +500,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		bounds[2][1] = 0.75F;
 
 		MatrixTranformations.transform(bounds, side);
-		return AxisAlignedBB.getAABBPool().getAABB(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
+		return AxisAlignedBB.getBoundingBox(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
 	}
 
 	private AxisAlignedBB getRobotStationBoundingBox(ForgeDirection side) {
@@ -516,7 +516,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		bounds[2][1] = 0.75F;
 
 		MatrixTranformations.transform(bounds, side);
-		return AxisAlignedBB.getAABBPool().getAABB(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
+		return AxisAlignedBB.getBoundingBox(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
 	}
 
 	private AxisAlignedBB getPipeBoundingBox(ForgeDirection side) {
@@ -524,7 +524,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		float max = CoreConstants.PIPE_MAX_POS;
 
 		if (side == ForgeDirection.UNKNOWN) {
-			return AxisAlignedBB.getAABBPool().getAABB(min, min, min, max, max, max);
+			return AxisAlignedBB.getBoundingBox(min, min, min, max, max, max);
 		}
 
 		float[][] bounds = new float[3][2];
@@ -539,7 +539,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 		bounds[2][1] = max;
 
 		MatrixTranformations.transform(bounds, side);
-		return AxisAlignedBB.getAABBPool().getAABB(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
+		return AxisAlignedBB.getBoundingBox(bounds[0][0], bounds[1][0], bounds[2][0], bounds[0][1], bounds[1][1], bounds[2][1]);
 	}
 
 	public static void removePipe(Pipe pipe) {

--- a/common/buildcraft/transport/pipes/PipeItemsObsidian.java
+++ b/common/buildcraft/transport/pipes/PipeItemsObsidian.java
@@ -142,7 +142,7 @@ public class PipeItemsObsidian extends Pipe<PipeTransportItems> {
 		Position min = p1.min(p2);
 		Position max = p1.max(p2);
 
-		return AxisAlignedBB.getAABBPool().getAABB(min.x, min.y, min.z, max.x, max.y, max.z);
+		return AxisAlignedBB.getBoundingBox(min.x, min.y, min.z, max.x, max.y, max.z);
 	}
 
 	@Override


### PR DESCRIPTION
.getAABBPool() is no more in 1.7.10, I instead moved it to the suggested .getBoundingBox().
