### PR TITLE
Use ItemStack sensitive version of hasContainerItem()

### DIFF
--- a/common/buildcraft/core/gui/slots/SlotWorkbench.java
+++ b/common/buildcraft/core/gui/slots/SlotWorkbench.java
@@ -19,7 +19,7 @@ public class SlotWorkbench extends SlotBase {
 
 	@Override
 	public boolean isItemValid(ItemStack stack) {
-		return stack != null && stack.isStackable() && !stack.getItem().hasContainerItem();
+		return stack != null && stack.isStackable() && !stack.getItem().hasContainerItem(stack);
 	}
 
 	@Override

--- a/common/buildcraft/core/inventory/InvUtils.java
+++ b/common/buildcraft/core/inventory/InvUtils.java
@@ -211,7 +211,7 @@ public final class InvUtils {
 
 	public static ItemStack consumeItem(ItemStack stack) {
 		if (stack.stackSize == 1) {
-			if (stack.getItem().hasContainerItem()) {
+			if (stack.getItem().hasContainerItem(stack)) {
 				return stack.getItem().getContainerItem(stack);
 			} else {
 				return null;

--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -155,7 +155,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 			if (!stack.isStackable()) {
 				return null;
 			}
-			if (stack.getItem().hasContainerItem()) {
+			if (stack.getItem().hasContainerItem(stack)) {
 				return null;
 			}
 		}
@@ -278,7 +278,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 		if (!stack.isStackable()) {
 			return false;
 		}
-		if (stack.getItem().hasContainerItem()) {
+		if (stack.getItem().hasContainerItem(stack)) {
 			return false;
 		}
 		if (getStackInSlot(slot) == null) {


### PR DESCRIPTION
Use ItemStack sensitive version of hasContainerItem(), because the non-sensitive version is deprecated.
