### PR TITLE
Prevent a possible crash when rendering a marker

### DIFF
--- a/common/buildcraft/builders/BuildersProxy.java
+++ b/common/buildcraft/builders/BuildersProxy.java
@@ -17,7 +17,6 @@ public final class BuildersProxy {
 	 * Forbid contruction of this class
 	 */
 	private BuildersProxy() {
-
 	}
 
 	public static boolean canPlaceTorch(World world, int i, int j, int k) {

--- a/common/buildcraft/builders/blueprints/BlueprintDatabase.java
+++ b/common/buildcraft/builders/blueprints/BlueprintDatabase.java
@@ -44,7 +44,7 @@ public class BlueprintDatabase {
 	/**
 	 * Initialize the blueprint database.
 	 *
-	 * @param configDir config directory to read the blueprints from.
+	 * @param inputPaths directories to read the blueprints from.
 	 */
 	public void init(String[] inputPaths, String outputPath) {
 		outputDir = new File(outputPath);

--- a/common/buildcraft/core/render/RenderingMarkers.java
+++ b/common/buildcraft/core/render/RenderingMarkers.java
@@ -36,12 +36,13 @@ public class RenderingMarkers implements ISimpleBlockRenderingHandler {
 
 	@Override
 	public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks renderer) {
-
 		Tessellator tessellator = Tessellator.instance;
 		float f = block.getMixedBrightnessForBlock(world, x, y, z);
+
 		if (block.getLightValue() > 0) {
 			f = 1.0F;
 		}
+
 		tessellator.setColorOpaque_F(f, f, f);
 		renderMarkerWithMeta(world, block, x, y, z, world.getBlockMetadata(x, y, z));
 
@@ -94,7 +95,7 @@ public class RenderingMarkers implements ISimpleBlockRenderingHandler {
 		rotateFace(frontX[0]);
 		rotateFace(frontX[0]);
 
-		double[][] frontZBase = { {-0.5, -0.5, 0.5, 0.5}, {1, 0, 0, 1}, {0.0625, 0.0625, 0.0625, 0.0625}};
+		double[][] frontZBase = {{-0.5, -0.5, 0.5, 0.5}, {1, 0, 0, 1}, {0.0625, 0.0625, 0.0625, 0.0625}};
 
 		frontZ[5] = safeClone(frontZBase);
 
@@ -110,7 +111,7 @@ public class RenderingMarkers implements ISimpleBlockRenderingHandler {
 		rotateFace(frontZ[0]);
 		rotateFace(frontZ[0]);
 
-		double[][] frontYBase = { {-0.5, -0.5, 0.5, 0.5}, {-0.0625, -0.0625, -0.0625, -0.0625}, {0.5, -0.5, -0.5, 0.5}};
+		double[][] frontYBase = {{-0.5, -0.5, 0.5, 0.5}, {-0.0625, -0.0625, -0.0625, -0.0625}, {0.5, -0.5, -0.5, 0.5}};
 
 		frontY[4] = safeClone(frontYBase);
 		rotateFace(frontY[4]);
@@ -130,6 +131,11 @@ public class RenderingMarkers implements ISimpleBlockRenderingHandler {
 
 	public void renderMarkerWithMeta(IBlockAccess iblockaccess, Block block, double xi, double yi, double zi, int meta) {
 		Tessellator tessellator = Tessellator.instance;
+		int metadata = meta;
+
+		if (metadata > 5 || metadata < 0) {
+			metadata = 1;
+		}
 
 		double x = xi;
 		double y = yi;
@@ -141,7 +147,7 @@ public class RenderingMarkers implements ISimpleBlockRenderingHandler {
 
 		IIcon i = block.getIcon(iblockaccess, xCoord, yCoord, zCoord, 1);
 
-		int m = metaToOld[meta];
+		int m = metaToOld[metadata];
 		x += 0.5D;
 		z += 0.5D;
 


### PR DESCRIPTION
Prevents a possible crash when rendering a marker:
http://openeye.openmods.info/crashes/4e94260c23958a0c6e5d3ba81c2bd8f3

Also a mini cleanup.
