### PR TITLE
Fixed ghost facades from pre-6.0.x worlds

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -168,8 +168,14 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, IFlui
 				if (nbt.hasKey("facadeBlocks[" + i + "]")) {
 					// In this case, we're on legacy pre-6.0 facade loading
 					// mode.
-					facadeBlocks[i][0] = (Block) Block.blockRegistry.getObjectById
-							(nbt.getInteger("facadeBlocks[" + i + "]"));
+					int blockId = nbt.getInteger("facadeBlocks[" + i + "]");
+
+					if (blockId != 0) {
+						facadeBlocks[i][0] = (Block) Block.blockRegistry.getObjectById(blockId);
+					} else {
+						facadeBlocks[i][0] = null;
+					}
+
 					facadeBlocks[i][1] = null;
 
 					facadeMeta[i][0] = nbt.getInteger("facadeMeta[" + i + "]");


### PR DESCRIPTION
It put ghost facades on all sides, because it wasn't checking if there even was a facade there (if there was, the facade loaded properly).
Probably quite critical, since after you upgrade your world to 6.0.x and didn't backup your world, there's gonna be ghost facades on all pipes, that you can't seem remove, without replacing pipes.
This might also fix ghost facades from removed mods (or when their IDs changed), when migrating from pre-6.0.x to 6.0.x.

Should be also put into 6.1.x (some people will probably skip 6.0.x).
