### PR TITLE
make blockMultiTexture available for other mods

### DIFF
--- a/common/buildcraft/core/BlockMultiTexture.java
+++ b/common/buildcraft/core/BlockMultiTexture.java
@@ -27,6 +27,7 @@ import buildcraft.core.render.RenderBlockMultiTexture;
 public abstract class BlockMultiTexture extends BlockBuildCraft {
 
 	private static Map<String, IIcon> iconMap = new HashMap<String, IIcon>();
+	public String modId = "buildcraft";
 
 	public BlockMultiTexture(Material material, CreativeTabBuildCraft tab) {
 		super(material, tab);
@@ -116,7 +117,7 @@ public abstract class BlockMultiTexture extends BlockBuildCraft {
 	public void registerBlockIcons(IIconRegister register) {
 		for (int i = 0; i < ForgeDirection.VALID_DIRECTIONS.length; i++) {
 			String name = getIconName(i);
-			iconMap.put(name, register.registerIcon("buildcraft:" + name));
+			iconMap.put(name, register.registerIcon(modid + ":" + name));
 		}
 	}
 


### PR DESCRIPTION
With this the blockMultiTexture should be usable for other mods (like mine). With this i can just extend this class and override the modId variable so it loads from my folder and not the buildcraft one

i didn't test this localy yet cause my buildcraft dev setup got screwed up but this change is minor so should work without any problems
