### PR TITLE
Fixed laser data not existing in some cases

### DIFF
--- a/common/buildcraft/silicon/TileLaser.java
+++ b/common/buildcraft/silicon/TileLaser.java
@@ -56,8 +56,12 @@ public class TileLaser extends TileBuildCraft implements IActionReceptor, IMachi
 
 
 	@Override
-	public void initialize () {
+	public void initialize() {
 		super.initialize();
+
+		if (laser == null) {
+			laser = new LaserData();
+		}
 		
 		laser.isVisible = false;
 		laser.head = new Position(xCoord, yCoord, zCoord);


### PR DESCRIPTION
If laser data doesn't exist in some cases for an unknown reason, one should be created.

Example:
http://mod-buildcraft.com/forums/index.php?topic=748.0
