### PR TITLE
5.0.x Forge deprecation fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ archivesBaseName = "buildcraft" // the name that all artifacts will use as a bas
 minecraft {
     version = "1.7.10-10.13.0.1179" // McVersion-ForgeVersion     this variable is later changed to contain only the MC version, while the apiVersion variable is used for the forge version.  Yeah its stupid, and will be changed eentually.
 
-    assetDir = "run/assets" // the place for ForgeGradle to download the assets. The assets that the launcher gets and stuff
+    runDir = "run" // the directory for ForgeGradle to run Minecraft in
 
     // replacing stuff in the source
     replace '@VERSION@', project.version

--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -107,7 +107,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 		int oilOceanBiomeId = BuildCraftCore.mainConfiguration.get("biomes", "biomeOilOcean", DefaultProps.BIOME_OIL_OCEAN).getInt(DefaultProps.BIOME_OIL_OCEAN);
 		canOilBurn = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "burnOil", true, "Can oil burn?").getBoolean(true);
 		oilWellScalar = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "oilWellGenerationRate", 1.0, "Probability of oil well generation").getDouble(1.0);
-		for (String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "oilBiomeIDs", BiomeDictionary.Type.DESERT.toString() +","+BiomeGenBase.taiga.biomeID, "IDs or Biome Types (e.g. DESERT,OCEAN) of biomes that should have increased oil generation rates.").getString().trim().split(",")){
+		for (String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "oilBiomeIDs", BiomeDictionary.Type.SANDY.toString() +","+BiomeGenBase.taiga.biomeID, "IDs or Biome Types (e.g. SANDY,OCEAN) of biomes that should have increased oil generation rates.").getString().trim().split(",")){
 			id = id.trim();
 			if(id.length() > 0){ 
 				try{oilBiomeIDs.add(Integer.parseInt(id));}
@@ -123,7 +123,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 				}
 			}
 		}
-		for(String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "excessiveOilBiomeIDs", "", "IDs or Biome Types (e.g. DESERT,OCEAN) of biomes that should have GREATLY increased oil generation rates.").getString().trim().split(",")) {
+		for(String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "excessiveOilBiomeIDs", "", "IDs or Biome Types (e.g. SANDY,OCEAN) of biomes that should have GREATLY increased oil generation rates.").getString().trim().split(",")) {
 			id = id.trim();
 			if(id.length() > 0){ 
 				try{excessiveOilBiomeIDs.add(Integer.parseInt(id));}
@@ -139,7 +139,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 				}
 			}
 		}
-		for(String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "excludeOilBiomeIDs", BiomeGenBase.sky.biomeID +","+BiomeGenBase.hell.biomeID, "IDs or Biome Types (e.g. DESERT,OCEAN) of biomes that are excluded from generating oil.").getString().trim().split(",")){
+		for(String id : BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "excludeOilBiomeIDs", BiomeGenBase.sky.biomeID +","+BiomeGenBase.hell.biomeID, "IDs or Biome Types (e.g. SANDY,OCEAN) of biomes that are excluded from generating oil.").getString().trim().split(",")){
 			id = id.trim();
 			if(id.length() > 0){ 
 				try{excludeOilBiomeIDs.add(Integer.parseInt(id));}

--- a/common/buildcraft/core/fluids/Tank.java
+++ b/common/buildcraft/core/fluids/Tank.java
@@ -72,7 +72,7 @@ public class Tank extends FluidTank {
 		toolTip.clear();
 		int amount = 0;
 		if (getFluid() != null && getFluid().amount > 0) {
-			ToolTipLine fluidName = new ToolTipLine(getFluid().getFluid().getLocalizedName());
+			ToolTipLine fluidName = new ToolTipLine(getFluid().getFluid().getLocalizedName(getFluid()));
 			fluidName.setSpacing(2);
 			toolTip.add(fluidName);
 			amount = getFluid().amount;


### PR DESCRIPTION
Changed build.gradle to use RunDir, changed deprecated fluid localized name functionality, changed deprecated biome type desert to sandy.
