### PR TITLE
Fix builder/filler not rendering if player is too far away

### DIFF
--- a/common/buildcraft/builders/TileAbstractBuilder.java
+++ b/common/buildcraft/builders/TileAbstractBuilder.java
@@ -151,4 +151,9 @@ public abstract class TileAbstractBuilder extends TileBuildCraft implements ITil
 		mjPrev = mjStored;
 		mjUnchangedCycles = 0;
 	}
+	
+	@Override
+        public double getMaxRenderDistanceSquared() {
+        	return Double.MAX_VALUE;
+    	}
 }


### PR DESCRIPTION
If the player is standing further than 64 blocks away (which is far enough for most blocks but not for the builder/filler since the area where they render can get quite big) tile entities aren't rendered.

This is fixed by overriding that method.
