### PR TITLE
Prevent facade rendering crashes from a null IIcon

### DIFF
--- a/common/buildcraft/transport/render/FacadeItemRenderer.java
+++ b/common/buildcraft/transport/render/FacadeItemRenderer.java
@@ -11,6 +11,7 @@ package buildcraft.transport.render;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;


### PR DESCRIPTION
Adds a check to make sure the IIcon is not null, and if it is, grabs the missing texture icon from the TextureMap.
