### PR TITLE
Fixed a crash on dedicated servers with EnumColor

### DIFF
--- a/api/buildcraft/api/core/EnumColor.java
+++ b/api/buildcraft/api/core/EnumColor.java
@@ -107,7 +107,7 @@ public enum EnumColor {
 		0xe4e4e4};
 
 	@SideOnly(Side.CLIENT)
-	private static IIcon[] brushIcons = new IIcon[16];
+	private static IIcon[] brushIcons;
 
 	public int getDarkHex() {
 		return DARK_HEX[ordinal()];
@@ -193,6 +193,7 @@ public enum EnumColor {
 
 	@SideOnly(Side.CLIENT)
 	public static void registerIcons(IIconRegister iconRegister) {
+		brushIcons = new IIcon[16];
 		for (EnumColor c : values()) {
 			brushIcons[c.ordinal()] = iconRegister.registerIcon("buildcraft:triggers/color_"
 					+ c.name().toLowerCase(Locale.ENGLISH));


### PR DESCRIPTION
You can see the crash here https://gist.github.com/darkevilmac/f9587498216118ebf49a if you run the server with this change the crash no longer occurs.
