### PR TITLE
Fix strange npe in facade item renderer

### DIFF
--- a/common/buildcraft/transport/render/FacadeItemRenderer.java
+++ b/common/buildcraft/transport/render/FacadeItemRenderer.java
@@ -156,21 +156,20 @@ public class FacadeItemRenderer implements IItemRenderer {
 	}
 
 	private IIcon tryGetBlockIcon(Block block, int side, int decodedMeta) {
+		IIcon icon = null;
 		try {
-			IIcon icon = block.getIcon(side, decodedMeta);
-
-			if (icon != null) {
-				return icon;
-			} else {
-				return Blocks.cobblestone.getIcon(0, 0);
-			}
+			icon = block.getIcon(side, decodedMeta);
 		} catch (Throwable t) {
 			try {
-				return block.getBlockTextureFromSide(side);
-			} catch (Throwable t2) {
-				return Blocks.cobblestone.getIcon(0, 0);
+				icon = block.getBlockTextureFromSide(side);
+			} catch (Throwable ignored) {
+			}
+		} finally {
+			if (icon == null) {
+				icon = Blocks.cobblestone.getIcon(0, 0);
 			}
 		}
+		return icon;
 	}
 
 	@Override


### PR DESCRIPTION
In short: `block.getBlockTextureFromSide(int side)` can return null and this situation is not handled by renderer correctly. Probably fix #1996.
