### PR TITLE
ClassCastException in PowerHandler (IBatteryObject vs BatteryObject)

### DIFF
--- a/api/buildcraft/api/power/PowerHandler.java
+++ b/api/buildcraft/api/power/PowerHandler.java
@@ -13,7 +13,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import buildcraft.api.core.SafeTimeTracker;
-import buildcraft.api.mj.BatteryObject;
 import buildcraft.api.mj.IBatteryObject;
 import buildcraft.api.mj.IBatteryProvider;
 import buildcraft.api.mj.IOMode;
@@ -150,7 +149,7 @@ public final class PowerHandler implements IBatteryProvider {
 
 		boolean created = false;
 		if (battery instanceof IBatteryObject) {
-			this.battery = (BatteryObject) battery;
+			this.battery = (IBatteryObject) battery;
 		} else if (battery != null) {
 			this.battery = MjAPI.createBattery(battery, MjAPI.DEFAULT_POWER_FRAMEWORK, ForgeDirection.UNKNOWN);
 			created = true;


### PR DESCRIPTION
The problem is [HERE](https://github.com/BuildCraft/BuildCraft/blob/6.1.x/api/buildcraft/api/power/PowerHandler.java#L153).

Besides being obviously type-unsafe, this makes no sense to me whatsoever. I'm under the impression that IBatteryObject is there to allow custom battery objects to be implemented, why is it forced to use the default BatteryObject implementation?

Added: I changed the cast to use the interface and it seems to not break anything. I can PR this if wanted but it's literally a 1-character change.
