### PR TITLE
fix game crashing when placing robot without a redstone board installed

### DIFF
--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -783,8 +783,9 @@ public class BlockGenericPipe extends BlockBuildCraft {
 						DockingStation station = pipe.container.getStation(rayTraceResult.sideHit);
 
 						if (!station.isTaken()) {
-							if (((ItemRobot) currentItem.getItem()).getRobotNBT(currentItem) == null )
+							if (((ItemRobot) currentItem.getItem()).getRobotNBT(currentItem) == null) {
 								return true;
+							}
 							EntityRobot robot = ((ItemRobot) currentItem.getItem())
 									.createRobot(currentItem, world);
 							robot.setUniqueRobotId(robot.getRegistry().getNextRobotId());


### PR DESCRIPTION
placed a robot without a board on a station and game crashed, this prevents it (tested it and this fixes it)
