### PR TITLE
Set toolClass of ItemWrench to "wrench"

### DIFF
--- a/common/buildcraft/core/ItemWrench.java
+++ b/common/buildcraft/core/ItemWrench.java
@@ -35,6 +35,7 @@ public class ItemWrench extends ItemBuildCraft implements IToolWrench {
 		shiftRotations.add(BlockLever.class);
 		shiftRotations.add(BlockButton.class);
 		shiftRotations.add(BlockChest.class);
+		setHarvestLevel("wrench", 0);
 	}
 
 	private boolean isShiftRotation(Class<? extends Block> cls) {


### PR DESCRIPTION
Allows other mods to use the BuildCraft wrench (for things other then rotation) without needing to know the itemstack or implementing the API.
