### PR TITLE
Add support for Chisel's IFacade Connected Textures API

### DIFF
--- a/api/info/jbcs/minecraft/chisel/api/IFacade.java
+++ b/api/info/jbcs/minecraft/chisel/api/IFacade.java
@@ -1,0 +1,12 @@
+package info.jbcs.minecraft.chisel.api;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.IBlockAccess;
+
+public interface IFacade {
+
+  int getFacadeMetadata(IBlockAccess world, int x, int y, int z, int side);
+  
+  Block getFacade(IBlockAccess world, int x, int y, int z, int side);
+    
+}

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -72,8 +72,9 @@ import buildcraft.transport.gates.ItemGate;
 import buildcraft.transport.render.PipeRendererWorld;
 import buildcraft.transport.utils.FacadeMatrix;
 
+import info.jbcs.minecraft.chisel.api.IFacade;
 
-public class BlockGenericPipe extends BlockBuildCraft {
+public class BlockGenericPipe extends BlockBuildCraft implements IFacade {
 
 	public static int facadeRenderColor = -1;
 	public static Map<Item, Class<? extends Pipe>> pipes = new HashMap<Item, Class<? extends Pipe>>();
@@ -1163,6 +1164,29 @@ public class BlockGenericPipe extends BlockBuildCraft {
 
 	public static boolean isValid(Pipe<?> pipe) {
 		return isFullyDefined(pipe);
+	}
+
+	@Override
+	public int getFacadeMetadata(IBlockAccess world, int x, int y, int z, int side) {
+		Pipe<?> pipe = getPipe(world, x, y, z);
+
+		if (pipe == null) {
+			return 0;
+		}
+
+		return pipe.container.getFacadeMetadata(ForgeDirection.getOrientation(side));
+	}
+
+	@Override
+	public Block getFacade(IBlockAccess world, int x, int y, int z, int side) {
+		Pipe<?> pipe = getPipe(world, x, y, z);
+
+		if (pipe == null) {
+			return this;
+		}
+
+		Block facadeBlock = pipe.container.getFacadeBlock(ForgeDirection.getOrientation(side));
+		return facadeBlock != null ? facadeBlock : this;
 	}
 
 	@Override

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -919,6 +919,14 @@ public class TileGenericPipe extends TileEntity implements IPowerReceptor, IFlui
 				ItemFacade.getFacade(((ItemFacade.FacadePluggable) pluggable).states) : null;
 	}
 
+	public int getFacadeMetadata(ForgeDirection direction) {
+		return renderState.facadeMatrix.getFacadeMetaId(direction);
+	}
+
+	public Block getFacadeBlock(ForgeDirection direction) {
+		return renderState.facadeMatrix.getFacadeBlock(direction);
+	}
+
 	public Gate getGate(ForgeDirection direction) {
 		return pipe.gates[direction.ordinal()];
 	}

--- a/common/buildcraft/transport/render/PipeRendererWorld.java
+++ b/common/buildcraft/transport/render/PipeRendererWorld.java
@@ -83,7 +83,7 @@ public class PipeRendererWorld implements ISimpleBlockRenderingHandler {
 		renderblocks.setRenderBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
 
 		// Facade renderer handles rendering in both passes
-		pipeFacadeRenderer(renderblocks, fakeBlock, state, x, y, z);
+		pipeFacadeRenderer(renderblocks, fakeBlock, state, iblockaccess, x, y, z);
 		//block.setRenderAllSides();//Start fresh
 
 		// Force other opaque renders into pass 0
@@ -118,8 +118,8 @@ public class PipeRendererWorld implements ISimpleBlockRenderingHandler {
 		renderblocks.renderStandardBlock(stateHost, x, y, z);
 	}
 
-	private void pipeFacadeRenderer(RenderBlocks renderblocks, ITextureStates blockStateMachine, PipeRenderState state, int x, int y, int z) {
-		FacadeRenderHelper.pipeFacadeRenderer(renderblocks, blockStateMachine, state, x, y, z);
+	private void pipeFacadeRenderer(RenderBlocks renderblocks, ITextureStates blockStateMachine, PipeRenderState state, IBlockAccess blockAccess, int x, int y, int z) {
+		FacadeRenderHelper.pipeFacadeRenderer(renderblocks, blockStateMachine, state, blockAccess, x, y, z);
 	}
 
 	private void pipePlugRenderer(RenderBlocks renderblocks, ITextureStates blockStateMachine, PipeRenderState state, int x, int y, int z) {


### PR DESCRIPTION
Allows Chisel to render Facades of certain blocks with connected
textures.

@CrazyPants (author of Ender IO) recently added the IFacade API to [Chisel](https://github.com/Pokefenn/Chisel), allowing Ender IO Facades to work with Chisel's connected textures.

I maintain [ChiselFacades](https://github.com/Choonster/ChiselFacades), so I thought it would be nice if BC supported this API as well.

I've tried to make as few changes as possible, but I needed to change FacadeRenderHelper to use `Block#getIcon(iblockaccess, x, y, z, side)` instead of `Block#getIcon(side, meta)` so Chisel block facades use the connected texture icon instead of the normal one.

I also needed to add a custom IBlockAccess wrapper (like the one used in Ender IO's facade rendering code) so Chisel block facades display the correct metadata's texture. This wrapper could be moved to its own class if you feel that it doesn't belong in FacadeRenderHelper.
