### PR TITLE
Fixes engines storing energy for all time when unpowered

### DIFF
--- a/common/buildcraft/energy/TileEngineIron.java
+++ b/common/buildcraft/energy/TileEngineIron.java
@@ -193,6 +193,7 @@ public class TileEngineIron extends TileEngineWithInventory implements IFluidHan
 
 	@Override
 	public void engineUpdate() {
+		super.engineUpdate();
 
 		final ItemStack stack = getStackInSlot(0);
 		if (stack != null) {

--- a/common/buildcraft/energy/TileEngineStone.java
+++ b/common/buildcraft/energy/TileEngineStone.java
@@ -75,10 +75,11 @@ public class TileEngineStone extends TileEngineWithInventory {
 	public void burn() {
 		if (burnTime > 0) {
 			burnTime--;
+			if(isRedstonePowered){
+				currentOutput = calculateCurrentOutput();
 
-			currentOutput = calculateCurrentOutput();
-
-			addEnergy(currentOutput);
+				addEnergy(currentOutput);
+			}
 		} else {
 			currentOutput = 0;
 		}


### PR DESCRIPTION
Engines will now drain energy at the rate of 10RF/t when unpowered. Addresses comment on https://github.com/BuildCraft/BuildCraft/commit/593a5a5c07d989d23538a3ad2bb1d6cc39d0686f
