### PR TITLE
Fixed Engines not using continuous power when their initial rotation is valid

### DIFF
--- a/common/buildcraft/energy/TileEngine.java
+++ b/common/buildcraft/energy/TileEngine.java
@@ -228,6 +228,16 @@ public abstract class TileEngine extends TileBuildCraft implements IPowerRecepto
 
 			if (!isOrientationValid()) {
 				switchOrientation(true);
+			}else{
+				TileEntity tile = getTileBuffer(orientation).getTile();
+
+				if(isPoweredTile(tile, orientation)){
+					if((tile instanceof IPipeTile) && (((IPipeTile) tile).getPipeType() != PipeType.POWER)){
+						constantPower = false;
+					}else{
+						constantPower = true;
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/BuildCraft/BuildCraft/issues/2053
