### PR TITLE
Stopped wooden pipes from extracting from IEnergySources

### DIFF
--- a/common/buildcraft/transport/pipes/PipePowerWood.java
+++ b/common/buildcraft/transport/pipes/PipePowerWood.java
@@ -129,23 +129,6 @@ public class PipePowerWood extends Pipe<PipeTransportPower> implements IPowerRec
 
 		energyToRemove /= sources;
 
-		// Extract power from RF sources.
-		// While we send power to receivers and so does TE4,
-		// Extra Utilities generators (as an example) depend
-		// on extracting energy from them manually.
-		for (ForgeDirection o : ForgeDirection.VALID_DIRECTIONS) {
-			if (!powerSources[o.ordinal()]) {
-				continue;
-			}
-
-			TileEntity tile = container.getTile(o);
-
-			if (tile instanceof IEnergyHandler) {
-				battery.addEnergy(0, ((IEnergyHandler) tile).extractEnergy(o.getOpposite(), energyToRemove, false),
-						false);
-			}
-		}
-
 		if (battery.getEnergyStored() > 0) {
 			for (ForgeDirection o : ForgeDirection.VALID_DIRECTIONS) {
 				if (!powerSources[o.ordinal()]) {


### PR DESCRIPTION
It seems to be unnecessary. Extra utilities generators allow extraction directly, but they do not require it. And the previous code would waste energy if there wasn't enough room in the RFBattery when it was pulling from the generator, so this fixes that and removes unnecessary code.

Edit: Also discovered this helps with pipes connecting to MFR generators, as they only implement IEnergyConnection and not IEnergyHandler. (IEnergyConnection is intended for things like dynamos, all they do is output energy, there's no access to the internal storage. For engines it makes sense to use IEnergyHandler so gates can read the internal state.)
This PR doesn't actually fix the fact that wooden pipes don't connect, that's a separate PR. (Unless you want it in this one :P)

Edit edit: Never mind on MFR, it's entirely on their side: https://github.com/skyboy/MineFactoryReloaded/blob/master/src/powercrystals/minefactoryreloaded/tile/base/TileEntityFactory.java#L398

![2014-10-20_15 51 12](https://cloud.githubusercontent.com/assets/246232/4709991/7f80fc02-58a4-11e4-8876-28b96d740f98.png)
![2014-10-20_15 51 18](https://cloud.githubusercontent.com/assets/246232/4709990/7f37890a-58a4-11e4-8383-42561b2b2620.png)
![2014-10-20_15 58 00](https://cloud.githubusercontent.com/assets/246232/4709989/7f0f87fc-58a4-11e4-899e-d8b65c340755.png)
![2014-10-20_16 03 08](https://cloud.githubusercontent.com/assets/246232/4710031/e65acf84-58a4-11e4-9333-b4cd02ee43bd.png)
