### PR TITLE
Energy display helper

### DIFF
--- a/common/buildcraft/transport/pipes/PipePowerWood.java
+++ b/common/buildcraft/transport/pipes/PipePowerWood.java
@@ -109,7 +109,7 @@ public class PipePowerWood extends Pipe<PipeTransportPower> implements IPowerRec
 			return;
 		}
 
-		int energyToRemove = requestedEnergy;
+		int energyToRemove = Math.min(battery.getEnergyStored(), requestedEnergy);
 
 		// TODO: Have energyToRemove be precalculated
 		// and used in receiveEnergy and extractEnergy.
@@ -133,12 +133,8 @@ public class PipePowerWood extends Pipe<PipeTransportPower> implements IPowerRec
 				}
 
 				System.out.println("Sent " + energyToRemove + " energy to " + o.name());
-	
-				int energyUsable = Math.min(battery.getEnergyStored(), energyToRemove);
-	
-				if (energyUsable > 0) {
-					battery.setEnergy(battery.getEnergyStored() - transport.receiveEnergy(o, energyUsable));
-				}
+
+				battery.setEnergy(battery.getEnergyStored() - transport.receiveEnergy(o, energyToRemove));
 			}
 		}
 


### PR DESCRIPTION
This fixes the fixable portion of the wooden pipe energy display bug. The problem was happening because when the power query was above the energy in the internal buffer it would split the query up into equal parts and then use the entire internal buffer on one source, thus causing the wooden pipe to render as if one engine was outputting all the energy. Now it minimizes between the internal buffer and the query, thus splitting only the energy it could actually use into equal parts and rendering correctly. (Although it will still treat sinks as sources, but that's unavoidable until the RF api update.)
