### PR TITLE
Fixed more cases where engines would decide not to use continuous power

### DIFF
--- a/common/buildcraft/energy/TileEngine.java
+++ b/common/buildcraft/energy/TileEngine.java
@@ -596,6 +596,8 @@ public abstract class TileEngine extends TileBuildCraft implements IPowerRecepto
 
 	public void checkRedstonePower() {
 		isRedstonePowered = worldObj.isBlockIndirectlyGettingPowered(xCoord, yCoord, zCoord);
+		tileCache = null;
+		checkOrienation = true;
 	}
 
 	// RF support


### PR DESCRIPTION
This also changes mechanics so engines orient towards the closest energy acceptor when they recieve a block update and are not already pointing at an energy acceptor.
I could remove that change, but it would require a bit more code.

The reason the engines would fail to use continuous power is 1. they weren't resetting their tile cache when they received a block update, so it would continue to think that there was nothing there when there really was, and 2. it wouldn't re-evaluate whether or not to use continuous power on block update, so you could do things like place an engine next to a power pipe, break the power pipe and place an item pipe and it would use continuous power mode. Or if you place down the engine then place an energy accepting block on top without wrenching the engine it would stay in non-continuous mode.
