### PR TITLE
Updated the example version to 6.2.0 for the 6.2x branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ this repository will have to be rejected.
 
 ### Depending on BuildCraft
 
-add the following to your build.gradle file
+Add the following to your build.gradle file:
 ```
 dependencies {
-    compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    compile 'com.mod-buildcraft:buildcraft:6.2.0:dev'
 }
 ```
-where `6.0.8` is the desired version of BuildCraft
+Where `6.2.0` is the desired version of BuildCraft.


### PR DESCRIPTION
Did it because 6.2 is the latest BuildCraft version available in the 6.2 branch, and 6.0.8 is a old version.
