### PR TITLE
Updated the example version under "Depending on Buildcraft" to 6.1.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ this repository will have to be rejected.
 
 ### Depending on BuildCraft
 
-add the following to your build.gradle file
+Add the following to your build.gradle file:
 ```
 dependencies {
-    compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'
+    compile 'com.mod-buildcraft:buildcraft:6.1.78:dev'
 }
 ```
-where `6.0.8` is the desired version of BuildCraft
+Where `6.1.7` is the desired version of BuildCraft.


### PR DESCRIPTION
Decided to update the version under "Depending on BuildCraft" to 6.1.7 as that's the latest Buildcraft version available, and 6.0.8 is an old release now. Also fixed some typos as well. Did the same thing for the 6.2x branch as well.
