### PR TITLE
More Ore Dictionary support all around

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -523,7 +523,7 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	public static void loadRecipes() {
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(templateItem, 1), "ppp", "pip", "ppp", 'i',
-			new ItemStack(Items.dye, 1, 0), 'p', Items.paper);
+			"dyeBlack", 'p', Items.paper);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(blueprintItem, 1), "ppp", "pip", "ppp", 'i',
 			new ItemStack(Items.dye, 1, 4), 'p', Items.paper);
@@ -532,19 +532,19 @@ public class BuildCraftBuilders extends BuildCraftMod {
 			new ItemStack(Items.dye, 1, 4), 'r', Blocks.redstone_torch);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(pathMarkerBlock, 1), "l ", "r ", 'l',
-			new ItemStack(Items.dye, 1, 2), 'r', Blocks.redstone_torch);
+			"dyeGreen", 'r', Blocks.redstone_torch);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(fillerBlock, 1), "btb", "ycy", "gCg", 'b',
-			new ItemStack(Items.dye, 1, 0), 't', markerBlock, 'y', new ItemStack(Items.dye, 1, 11),
-			'c', Blocks.crafting_table, 'g', BuildCraftCore.goldGearItem, 'C', Blocks.chest);
+			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
+			'c', Blocks.crafting_table, 'g', "gearGold", 'C', Blocks.chest);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(builderBlock, 1), "btb", "ycy", "gCg", 'b',
-			new ItemStack(Items.dye, 1, 0), 't', markerBlock, 'y', new ItemStack(Items.dye, 1, 11),
-			'c', Blocks.crafting_table, 'g', BuildCraftCore.diamondGearItem, 'C', Blocks.chest);
+			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
+			'c', Blocks.crafting_table, 'g', "gearDiamond", 'C', Blocks.chest);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(architectBlock, 1), "btb", "ycy", "gCg", 'b',
-			new ItemStack(Items.dye, 1, 0), 't', markerBlock, 'y', new ItemStack(Items.dye, 1, 11),
-			'c', Blocks.crafting_table, 'g', BuildCraftCore.diamondGearItem, 'C',
+			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
+			'c', Blocks.crafting_table, 'g', "gearDiamond", 'C',
 			new ItemStack(blueprintItem, 1));
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(libraryBlock, 1), "bbb", "bBb", "bbb", 'b',

--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -443,25 +443,25 @@ public class BuildCraftCore extends BuildCraftMod {
 	}
 
 	public void loadRecipes() {
-		CoreProxy.proxy.addCraftingRecipe(new ItemStack(wrenchItem), "I I", " G ", " I ", 'I', Items.iron_ingot, 'G', stoneGearItem);
+		CoreProxy.proxy.addCraftingRecipe(new ItemStack(wrenchItem), "I I", " G ", " I ", 'I', "ingotIron", 'G', "gearStone");
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(woodenGearItem), " S ", "S S",
 				" S ", 'S',
 				"stickWood");
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(stoneGearItem), " I ", "IGI",
 				" I ", 'I',
 				"cobblestone", 'G',
-				woodenGearItem);
+				"gearWood");
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(ironGearItem), " I ", "IGI",
 				" I ", 'I',
-				Items.iron_ingot, 'G', stoneGearItem);
+				"ingotIron", 'G', "gearStone");
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(goldGearItem), " I ", "IGI",
 				" I ", 'I',
-				Items.gold_ingot, 'G', ironGearItem);
+				"ingotGold", 'G', "gearIron");
 		CoreProxy.proxy.addCraftingRecipe(
-				new ItemStack(diamondGearItem), " I ", "IGI", " I ", 'I', Items.diamond, 'G', goldGearItem);
-		CoreProxy.proxy.addCraftingRecipe(new ItemStack(mapLocationItem), "ppp", "pYp", "ppp", 'p', Items.paper, 'Y', new ItemStack(Items.dye, 1, 11));
+				new ItemStack(diamondGearItem), " I ", "IGI", " I ", 'I', "gemDiamond", 'G', "gearGold");
+		CoreProxy.proxy.addCraftingRecipe(new ItemStack(mapLocationItem), "ppp", "pYp", "ppp", 'p', Items.paper, 'Y', "dyeYellow");
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(listItem), "ppp", "pYp", "ppp", 'p', Items.paper, 'Y',
-				new ItemStack(Items.dye, 1, 2));
+				"dyeGreen");
 	}
 
 	@Mod.EventHandler

--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -354,14 +354,14 @@ public class BuildCraftEnergy extends BuildCraftMod {
 
 	public static void loadRecipes() {
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(engineBlock, 1, 0),
-				"www", " g ", "GpG", 'w', "plankWood", 'g', Blocks.glass, 'G',
-				BuildCraftCore.woodenGearItem, 'p', Blocks.piston);
+				"www", " g ", "GpG", 'w', "plankWood", 'g', "blockGlass", 'G',
+				"gearWood", 'p', Blocks.piston);
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(engineBlock, 1, 1),
 				"www", " g ", "GpG", 'w', "cobblestone",
-				'g', Blocks.glass, 'G', BuildCraftCore.stoneGearItem, 'p', Blocks.piston);
+				'g', "blockGlass", 'G', "gearStone", 'p', Blocks.piston);
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(engineBlock, 1, 2),
-				"www", " g ", "GpG", 'w', Items.iron_ingot,
-				'g', Blocks.glass, 'G', BuildCraftCore.ironGearItem, 'p', Blocks.piston);
+				"www", " g ", "GpG", 'w', "ingotIron",
+				'g', "blockGlass", 'G', "gearIron", 'p', Blocks.piston);
 	}
 
 	private int findUnusedBiomeID(String biomeName) {

--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -226,9 +226,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 						"ipi",
 						"igi",
 						"iPi",
-						'p', Items.redstone,
-						'i', Items.iron_ingot,
-						'g', BuildCraftCore.ironGearItem,
+						'p', "dustRedstone",
+						'i', "ingotIron",
+						'g', "gearIron",
 						'P', Items.iron_pickaxe);
 			}
 
@@ -238,10 +238,10 @@ public class BuildCraftFactory extends BuildCraftMod {
 						"ipi",
 						"gig",
 						"dDd",
-						'i', BuildCraftCore.ironGearItem,
-						'p', Items.redstone,
-						'g', BuildCraftCore.goldGearItem,
-						'd', BuildCraftCore.diamondGearItem,
+						'i', "gearIron",
+						'p', "dustRedstone",
+						'g', "gearGold",
+						'd', "gearDiamond",
 						'D', Items.diamond_pickaxe);
 			}
 
@@ -249,7 +249,7 @@ public class BuildCraftFactory extends BuildCraftMod {
 				CoreProxy.proxy.addCraftingRecipe(new ItemStack(pumpBlock),
 						"T",
 						"W",
-						'T', tankBlock != null ? tankBlock : Blocks.glass,
+						'T', tankBlock != null ? tankBlock : "blockGlass",
 						'W', miningWellBlock);
 			}
 		}
@@ -260,10 +260,10 @@ public class BuildCraftFactory extends BuildCraftMod {
 						"iri",
 						"iTi",
 						"gpg",
-						'r', Items.redstone,
-						'i', Items.iron_ingot,
-						'T', tankBlock != null ? tankBlock : Blocks.glass,
-						'g', BuildCraftCore.ironGearItem,
+						'r', "dustRedstone",
+						'i', "ingotIron",
+						'T', tankBlock != null ? tankBlock : "blockGlass",
+						'g', "gearIron",
 						'p', BuildCraftTransport.pipeFluidsGold);
 			}
 		}
@@ -274,7 +274,7 @@ public class BuildCraftFactory extends BuildCraftMod {
 					"gwg",
 					" g ",
 					'w', Blocks.crafting_table,
-					'g', BuildCraftCore.woodenGearItem);
+					'g', "gearWood");
 		}
 
 
@@ -283,15 +283,15 @@ public class BuildCraftFactory extends BuildCraftMod {
 					"ggg",
 					"g g",
 					"ggg",
-					'g', Blocks.glass);
+					'g', "blockGlass");
 		}
 
 		if (refineryBlock != null) {
 			CoreProxy.proxy.addCraftingRecipe(new ItemStack(refineryBlock),
 					"RTR",
 					"TGT",
-					'T', tankBlock != null ? tankBlock : Blocks.glass,
-					'G', BuildCraftCore.diamondGearItem,
+					'T', tankBlock != null ? tankBlock : "blockGlass",
+					'G', "gearDiamond",
 					'R', Blocks.redstone_torch);
 		}
 
@@ -300,9 +300,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 					"ICI",
 					"IGI",
 					" I ",
-					'I', Items.iron_ingot,
+					'I', "ingotIron",
 					'C', Blocks.chest,
-					'G', BuildCraftCore.stoneGearItem);
+					'G', "gearStone");
 		}
 
 		if (floodGateBlock != null) {
@@ -310,9 +310,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 					"IGI",
 					"FTF",
 					"IFI",
-					'I', Items.iron_ingot,
-					'T', tankBlock != null ? tankBlock : Blocks.glass,
-					'G', BuildCraftCore.ironGearItem,
+					'I', "ingotIron",
+					'T', tankBlock != null ? tankBlock : "blockGlass",
+					'G', "gearIron",
 					'F', new ItemStack(Blocks.iron_bars));
 		}
 	}

--- a/common/buildcraft/BuildCraftSilicon.java
+++ b/common/buildcraft/BuildCraftSilicon.java
@@ -216,17 +216,17 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"DDR",
 				"ORR",
 				'O', Blocks.obsidian,
-				'R', Items.redstone,
-				'D', Items.diamond);
+				'R', "dustRedstone",
+				'D', "gemDiamond");
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(assemblyTableBlock, 1, 0),
 				"ORO",
 				"ODO",
 				"OGO",
 				'O', Blocks.obsidian,
-				'R', Items.redstone,
-				'D', Items.diamond,
-				'G', BuildCraftCore.diamondGearItem);
+				'R', "dustRedstone",
+				'D', "gemDiamond",
+				'G', "gearDiamond");
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(assemblyTableBlock, 1, 1),
 				"OWO",
@@ -242,9 +242,9 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"OCO",
 				"OGO",
 				'O', Blocks.obsidian,
-				'R', Items.redstone,
+				'R', "dustRedstone",
 				'C', new ItemStack(redstoneChipset, 1, 0),
-				'G', BuildCraftCore.diamondGearItem);
+				'G', "gearDiamond");
 
 		// COMMANDER BLOCKS
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(zonePlanBlock, 1, 0),
@@ -252,38 +252,38 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"GMG",
 				"IDI",
 				'M', Items.map,
-				'R', Items.redstone,
-				'G', BuildCraftCore.goldGearItem,
-				'D', BuildCraftCore.diamondGearItem,
-				'I', Items.iron_ingot);
+				'R', "dustRedstone",
+				'G', "gearGold",
+				'D', "gearDiamond",
+				'I', "ingotIron");
 		
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(requesterBlock, 1, 0),
 				"IPI",
 				"GCG",
 				"IRI",
 				'C', Blocks.chest,
-				'R', Items.redstone,
+				'R', "dustRedstone",
 				'P', Blocks.piston,
-				'G', BuildCraftCore.ironGearItem,
-				'I', Items.iron_ingot);
+				'G', "gearIron",
+				'I', "ingotIron");
 		
 		// CHIPSETS
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:redstoneChipset", 100000, Chipset.RED.getStack(),
-				Items.redstone);
+				"dustRedstone");
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:ironChipset", 200000, Chipset.IRON.getStack(),
-				Items.redstone, Items.iron_ingot);
+				"dustRedstone", "ingotIron");
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:goldChipset", 400000, Chipset.GOLD.getStack(),
-				Items.redstone, Items.gold_ingot);
+				"dustRedstone", "ingotGold");
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:diamondChipset", 800000,
-				Chipset.DIAMOND.getStack(), Items.redstone, Items.diamond);
+				Chipset.DIAMOND.getStack(), "dustRedstone", "gemDiamond");
         BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:emeraldChipset", 1200000,
-                Chipset.EMERALD.getStack(), Items.redstone, Items.emerald);
+                Chipset.EMERALD.getStack(), "dustRedstone", "gemEmerald");
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:pulsatingChipset", 400000,
-				Chipset.PULSATING.getStack(2), Items.redstone, Items.ender_pearl);
+				Chipset.PULSATING.getStack(2), "dustRedstone", Items.ender_pearl);
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:quartzChipset", 600000, Chipset.QUARTZ.getStack(),
-				Items.redstone, Items.quartz);
+				"dustRedstone", "gemQuartz");
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:compChipset", 600000, Chipset.COMP.getStack(),
-				Items.redstone, Items.comparator);
+				"dustRedstone", Items.comparator);
 
 		// ROBOTS AND BOARDS
 		BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:redstoneCrystal", 10000000, new ItemStack(
@@ -294,14 +294,14 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"PPP",
 				"PRP",
 				"PPP",
-				'R', Items.redstone,
+				'R', "dustRedstone",
 				'P', Items.paper);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(robotItem),
 				"PPP",
 				"PRP",
 				"C C",
-				'P', Items.iron_ingot,
+				'P', "ingotIron",
 				'R', redstoneCrystal,
 				'C', Chipset.DIAMOND.getStack());
 

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -371,20 +371,20 @@ public class BuildCraftTransport extends BuildCraftMod {
 			CoreProxy.proxy.registerBlock(genericPipeBlock.setBlockName("pipeBlock"), ItemBlock.class);
 
 			pipeItemsWood = buildPipe(PipeItemsWood.class, "Wooden Transport Pipe", CreativeTabBuildCraft.PIPES, "plankWood", Blocks.glass, "plankWood");
-			pipeItemsEmerald = buildPipe(PipeItemsEmerald.class, "Emerald Transport Pipe", CreativeTabBuildCraft.PIPES, Items.emerald, Blocks.glass, Items.emerald);
+			pipeItemsEmerald = buildPipe(PipeItemsEmerald.class, "Emerald Transport Pipe", CreativeTabBuildCraft.PIPES, "gemEmerald", Blocks.glass, "gemEmerald");
 			pipeItemsCobblestone = buildPipe(PipeItemsCobblestone.class, "Cobblestone Transport Pipe", CreativeTabBuildCraft.PIPES, "cobblestone", Blocks.glass, "cobblestone");
 			pipeItemsStone = buildPipe(PipeItemsStone.class, "Stone Transport Pipe", CreativeTabBuildCraft.PIPES, "stone", Blocks.glass, "stone");
-			pipeItemsQuartz = buildPipe(PipeItemsQuartz.class, "Quartz Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.quartz_block, Blocks.glass, Blocks.quartz_block);
-			pipeItemsIron = buildPipe(PipeItemsIron.class, "Iron Transport Pipe", CreativeTabBuildCraft.PIPES, Items.iron_ingot, Blocks.glass, Items.iron_ingot);
-			pipeItemsGold = buildPipe(PipeItemsGold.class, "Golden Transport Pipe", CreativeTabBuildCraft.PIPES, Items.gold_ingot, Blocks.glass, Items.gold_ingot);
-			pipeItemsDiamond = buildPipe(PipeItemsDiamond.class, "Diamond Transport Pipe", CreativeTabBuildCraft.PIPES, Items.diamond, Blocks.glass, Items.diamond);
+			pipeItemsQuartz = buildPipe(PipeItemsQuartz.class, "Quartz Transport Pipe", CreativeTabBuildCraft.PIPES, "blockQuartz", Blocks.glass, "blockQuartz");
+			pipeItemsIron = buildPipe(PipeItemsIron.class, "Iron Transport Pipe", CreativeTabBuildCraft.PIPES, "ingotIron", Blocks.glass, "ingotIron");
+			pipeItemsGold = buildPipe(PipeItemsGold.class, "Golden Transport Pipe", CreativeTabBuildCraft.PIPES, "ingotGold", Blocks.glass, "ingotGold");
+			pipeItemsDiamond = buildPipe(PipeItemsDiamond.class, "Diamond Transport Pipe", CreativeTabBuildCraft.PIPES, "gemDiamond", Blocks.glass, "gemDiamond");
 			pipeItemsObsidian = buildPipe(PipeItemsObsidian.class, "Obsidian Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.obsidian, Blocks.glass, Blocks.obsidian);
-			pipeItemsLapis = buildPipe(PipeItemsLapis.class, "Lapis Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.lapis_block, Blocks.glass, Blocks.lapis_block);
-			pipeItemsDaizuli = buildPipe(PipeItemsDaizuli.class, "Daizuli Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.lapis_block, Blocks.glass, Items.diamond);
+			pipeItemsLapis = buildPipe(PipeItemsLapis.class, "Lapis Transport Pipe", CreativeTabBuildCraft.PIPES, "blockLapis", Blocks.glass, "blockLapis");
+			pipeItemsDaizuli = buildPipe(PipeItemsDaizuli.class, "Daizuli Transport Pipe", CreativeTabBuildCraft.PIPES, "blockLapis", Blocks.glass, "gemDiamond");
 			pipeItemsSandstone = buildPipe(PipeItemsSandstone.class, "Sandstone Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.sandstone, Blocks.glass, Blocks.sandstone);
-			pipeItemsVoid = buildPipe(PipeItemsVoid.class, "Void Transport Pipe", CreativeTabBuildCraft.PIPES, "dyeBlack", Blocks.glass, Items.redstone);
-			pipeItemsEmzuli = buildPipe(PipeItemsEmzuli.class, "Emzuli Transport Pipe", CreativeTabBuildCraft.PIPES, Blocks.lapis_block, Blocks.glass, Items.emerald);
-			pipeItemsStripes = buildPipe(PipeItemsStripes.class, "Stripes Transport Pipe", CreativeTabBuildCraft.PIPES, BuildCraftCore.goldGearItem, Blocks.glass, BuildCraftCore.goldGearItem);
+			pipeItemsVoid = buildPipe(PipeItemsVoid.class, "Void Transport Pipe", CreativeTabBuildCraft.PIPES, "dyeBlack", Blocks.glass, "dustRedstone");
+			pipeItemsEmzuli = buildPipe(PipeItemsEmzuli.class, "Emzuli Transport Pipe", CreativeTabBuildCraft.PIPES, "blockLapis", Blocks.glass, "gemEmerald");
+			pipeItemsStripes = buildPipe(PipeItemsStripes.class, "Stripes Transport Pipe", CreativeTabBuildCraft.PIPES, "gearGold", Blocks.glass, "gearGold");
 
 			pipeFluidsWood = buildPipe(PipeFluidsWood.class, "Wooden Waterproof Pipe", CreativeTabBuildCraft.PIPES, pipeWaterproof, pipeItemsWood);
 			pipeFluidsCobblestone = buildPipe(PipeFluidsCobblestone.class, "Cobblestone Waterproof Pipe", CreativeTabBuildCraft.PIPES, pipeWaterproof, pipeItemsCobblestone);
@@ -396,14 +396,14 @@ public class BuildCraftTransport extends BuildCraftMod {
 			pipeFluidsSandstone = buildPipe(PipeFluidsSandstone.class, "Sandstone Waterproof Pipe", CreativeTabBuildCraft.PIPES, pipeWaterproof, pipeItemsSandstone);
 			pipeFluidsVoid = buildPipe(PipeFluidsVoid.class, "Void Waterproof Pipe", CreativeTabBuildCraft.PIPES, pipeWaterproof, pipeItemsVoid);
 
-			pipePowerWood = buildPipe(PipePowerWood.class, "Wooden Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsWood);
-			pipePowerCobblestone = buildPipe(PipePowerCobblestone.class, "Cobblestone Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsCobblestone);
-			pipePowerStone = buildPipe(PipePowerStone.class, "Stone Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsStone);
-			pipePowerQuartz = buildPipe(PipePowerQuartz.class, "Quartz Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsQuartz);
-			pipePowerIron = buildPipe(PipePowerIron.class, "Iron Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsIron);
-			pipePowerGold = buildPipe(PipePowerGold.class, "Golden Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsGold);
-			pipePowerDiamond = buildPipe(PipePowerDiamond.class, "Diamond Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsDiamond);
-			pipePowerEmerald = buildPipe(PipePowerEmerald.class, "Emerald Kinesis Pipe", CreativeTabBuildCraft.PIPES, Items.redstone, pipeItemsEmerald);
+			pipePowerWood = buildPipe(PipePowerWood.class, "Wooden Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsWood);
+			pipePowerCobblestone = buildPipe(PipePowerCobblestone.class, "Cobblestone Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsCobblestone);
+			pipePowerStone = buildPipe(PipePowerStone.class, "Stone Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsStone);
+			pipePowerQuartz = buildPipe(PipePowerQuartz.class, "Quartz Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsQuartz);
+			pipePowerIron = buildPipe(PipePowerIron.class, "Iron Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsIron);
+			pipePowerGold = buildPipe(PipePowerGold.class, "Golden Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsGold);
+			pipePowerDiamond = buildPipe(PipePowerDiamond.class, "Diamond Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsDiamond);
+			pipePowerEmerald = buildPipe(PipePowerEmerald.class, "Emerald Kinesis Pipe", CreativeTabBuildCraft.PIPES, "dustRedstone", pipeItemsEmerald);
 			
 			pipeStructureCobblestone = buildPipe(PipeStructureCobblestone.class, "Cobblestone Structure Pipe", CreativeTabBuildCraft.PIPES, Blocks.gravel, pipeItemsCobblestone);
 
@@ -555,7 +555,7 @@ public class BuildCraftTransport extends BuildCraftMod {
 				new ItemStack(pipeStructureCobblestone));
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(robotStationItem), "   ", " I ", "ICI",
-				'I', Items.iron_ingot,
+				'I', "ingotIron",
 				'C', Chipset.GOLD.getStack());
 
 		if (Loader.isModLoaded("BuildCraft|Silicon")) {
@@ -563,13 +563,13 @@ public class BuildCraftTransport extends BuildCraftMod {
 					
 			// PIPE WIRE
 			BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:redWire", 5000, PipeWire.RED.getStack(8),
-					OreDictionary.getOres("dyeRed"), Items.redstone, Items.iron_ingot);
+					"dyeRed", "dustRedstone", "ingotIron");
 			BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:blueWire", 5000, PipeWire.BLUE.getStack(8),
-					OreDictionary.getOres("dyeBlue"), Items.redstone, Items.iron_ingot);
+					"dyeBlue", "dustRedstone", "ingotIron");
 			BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:greenWire", 5000, PipeWire.GREEN.getStack(8),
-					OreDictionary.getOres("dyeGreen"), Items.redstone, Items.iron_ingot);
+					"dyeGreen", "dustRedstone", "ingotIron");
 			BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:yellowWire", 5000, PipeWire.YELLOW.getStack(8),
-					OreDictionary.getOres("dyeYellow"), Items.redstone, Items.iron_ingot);			
+					"dyeYellow", "dustRedstone", "ingotIron");			
 
 			// GATES
 			BuildcraftRecipeRegistry.assemblyTable.addRecipe("buildcraft:simpleGate", 100000,

--- a/common/buildcraft/core/recipes/FlexibleRecipe.java
+++ b/common/buildcraft/core/recipes/FlexibleRecipe.java
@@ -16,6 +16,7 @@ import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.oredict.OreDictionary;
 import buildcraft.api.recipes.CraftingResult;
 import buildcraft.api.recipes.IFlexibleCrafter;
 import buildcraft.api.recipes.IFlexibleRecipe;
@@ -77,6 +78,8 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 				inputFluids.add((FluidStack) i);
 			} else if (i instanceof List) {
 				inputItemsWithAlternatives.add((List) i);
+			} else if (i instanceof String) {
+				inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
 			} else {
 				throw new IllegalArgumentException("An unknown object passed to recipe " + iid + " as input! (" + i.getClass() + ")");
 			}


### PR DESCRIPTION
Replaced several items with their ore dictionary names:
-Iron and Gold ingots
-Diamond, Emerald and Quartz
-Yellow, Green and Black dyes (left lapis out since I didn't know if I should replace it with gemLapis or dyeBlue)
-Redstone
-All gears
-Glass (Only in some instances, for pipes for example I didn't replace it)

Also made a slight change to FlexibleRecipe.java to allow string parameters to be passed to it directly.
