### PR TITLE
Fixes #2253, array contains null elements

### DIFF
--- a/common/buildcraft/core/statements/TriggerFluidContainerLevel.java
+++ b/common/buildcraft/core/statements/TriggerFluidContainerLevel.java
@@ -74,6 +74,10 @@ public class TriggerFluidContainerLevel extends BCStatement implements ITriggerE
 			}
 
 			for (FluidTankInfo c : liquids) {
+				if (c == null) {
+					continue;
+				}
+				
 				if (c.fluid == null) {
 					if (searchedFluid == null) {
 						return true;


### PR DESCRIPTION
As I suggested in issue #2253, there might be null elements in the array that is iterated over. By skipping over these elements, the server crash I reported no longer occurs.
