### PR TITLE
Added the IPipeColorable interface to the api

### DIFF
--- a/api/buildcraft/api/transport/IPipeColorable.java
+++ b/api/buildcraft/api/transport/IPipeColorable.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * The BuildCraft API is distributed under the terms of the MIT License.
+ * Please check the contents of the license, which should be located
+ * as "LICENSE.API" in the BuildCraft source code distribution.
+ */
+package buildcraft.api.transport;
+
+import buildcraft.api.core.EnumColor;
+
+public interface IPipeColorable {
+
+	void setColor(EnumColor c);
+
+	EnumColor getColor();
+}

--- a/common/buildcraft/transport/pipes/PipeItemsDaizuli.java
+++ b/common/buildcraft/transport/pipes/PipeItemsDaizuli.java
@@ -26,6 +26,7 @@ import buildcraft.api.core.EnumColor;
 import buildcraft.api.core.IIconProvider;
 import buildcraft.api.statements.IActionInternal;
 import buildcraft.api.tools.IToolWrench;
+import buildcraft.api.transport.IPipeColorable;
 import buildcraft.core.network.IClientState;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeIconProvider;
@@ -38,7 +39,7 @@ import buildcraft.transport.pipes.events.PipeEventItem;
 import buildcraft.transport.statements.ActionPipeColor;
 import buildcraft.transport.statements.ActionPipeDirection;
 
-public class PipeItemsDaizuli extends Pipe<PipeTransportItems> implements IClientState {
+public class PipeItemsDaizuli extends Pipe<PipeTransportItems> implements IClientState, IPipeColorable {
 
 	private int standardIconIndex = PipeIconProvider.TYPE.PipeItemsDaizuli_Black.ordinal();
 	private int solidIconIndex = PipeIconProvider.TYPE.PipeAllDaizuli_Solid.ordinal();
@@ -69,10 +70,12 @@ public class PipeItemsDaizuli extends Pipe<PipeTransportItems> implements IClien
 		transport.allowBouncing = true;
 	}
 
+	@Override
 	public EnumColor getColor() {
 		return EnumColor.fromId(color);
 	}
 
+	@Override
 	public void setColor(EnumColor c) {
 		if (color != c.ordinal()) {
 			this.color = c.ordinal();

--- a/common/buildcraft/transport/pipes/PipeItemsLapis.java
+++ b/common/buildcraft/transport/pipes/PipeItemsLapis.java
@@ -22,6 +22,7 @@ import buildcraft.api.core.EnumColor;
 import buildcraft.api.core.IIconProvider;
 import buildcraft.api.statements.IActionInternal;
 import buildcraft.api.tools.IToolWrench;
+import buildcraft.api.transport.IPipeColorable;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeIconProvider;
 import buildcraft.transport.PipeTransportItems;
@@ -31,7 +32,7 @@ import buildcraft.transport.gates.StatementSlot;
 import buildcraft.transport.pipes.events.PipeEventItem;
 import buildcraft.transport.statements.ActionPipeColor;
 
-public class PipeItemsLapis extends Pipe<PipeTransportItems> {
+public class PipeItemsLapis extends Pipe<PipeTransportItems> implements IPipeColorable {
 
 	public PipeItemsLapis(Item item) {
 		super(new PipeTransportItems(), item);
@@ -68,10 +69,12 @@ public class PipeItemsLapis extends Pipe<PipeTransportItems> {
 		return false;
 	}
 
+	@Override
 	public EnumColor getColor() {
 		return EnumColor.fromId(container.getBlockMetadata());
 	}
 
+	@Override
 	public void setColor(EnumColor color) {
 		if (color.ordinal() != container.getBlockMetadata()) {
 			container.getWorldObj().setBlockMetadataWithNotify(container.xCoord, container.yCoord, container.zCoord, color.ordinal(), 3);


### PR DESCRIPTION
This allows modders from checking and changing the color of a pipe by only using the api. This allows people to not needing core access or having to do reflecting like I had to do.
