### PR TITLE
Return false when recolouring block to it's original colour.

### DIFF
--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -1312,8 +1312,7 @@ public class BlockGenericPipe extends BlockBuildCraft {
 	public boolean recolourBlock(World world, int x, int y, int z, ForgeDirection side, int colour) {
 		TileGenericPipe pipeTile = (TileGenericPipe) world.getTileEntity(x, y, z);
 		if (!pipeTile.hasPlug(side)) {
-			pipeTile.setColor(colour);
-			return true;
+			return pipeTile.setColor(colour);
 		}
 
 		return false;

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -434,13 +434,15 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler,
 		return worldObj.isRemote ? renderState.glassColor : this.glassColor;
 	}
 
-	public void setColor(int color) {
+	public boolean setColor(int color) {
 		// -1 = no color
-		if (!worldObj.isRemote && color >= -1 && color < 16) {
+		if (!worldObj.isRemote && color >= -1 && color < 16 && glassColor != color) {
 			glassColor = color;
 			notifyBlockChanged();
 			worldObj.notifyBlocksOfNeighborChange(xCoord, yCoord, zCoord, blockType);
+			return true;
 		}
+		return false;
 	}
 	
 	/**


### PR DESCRIPTION
When attempting to colour a pipe with the colour it is already painted with, the "recolourBlock" method should return false so the painting item knows not to use up it's paint (e.g. take damage)
