### PR TITLE
Improve quarry arm rendering (and a bunch more)

### DIFF
--- a/common/buildcraft/core/EntityBlock.java
+++ b/common/buildcraft/core/EntityBlock.java
@@ -94,4 +94,9 @@ public class EntityBlock extends Entity {
 	public int getBrightnessForRender(float par1) {
 		return brightness > 0 ? brightness : super.getBrightnessForRender(par1);
 	}
+	
+	@SideOnly(Side.CLIENT)
+    public boolean isInRangeToRenderDist(double distance) {
+		return distance < 50000;
+    }
 }

--- a/common/buildcraft/core/render/FluidRenderer.java
+++ b/common/buildcraft/core/render/FluidRenderer.java
@@ -121,7 +121,7 @@ public final class FluidRenderer {
 			liquidBlock.maxY = (float) s / (float) DISPLAY_STAGES;
 			liquidBlock.maxZ = 0.99f;
 
-			RenderEntityBlock.INSTANCE.renderBlock(liquidBlock, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(liquidBlock);
 
 			GL11.glEndList();
 		}

--- a/common/buildcraft/core/render/RenderEntityBlock.java
+++ b/common/buildcraft/core/render/RenderEntityBlock.java
@@ -10,8 +10,6 @@ package buildcraft.core.render;
 
 import java.util.Arrays;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
@@ -22,7 +20,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.IBlockAccess;
-import net.minecraft.world.World;
+
+import org.lwjgl.opengl.GL11;
 
 import buildcraft.core.EntityBlock;
 
@@ -134,17 +133,16 @@ public final class RenderEntityBlock extends Render {
 	}
 
 	@Override
-	public void doRender(Entity entity, double i, double j, double k, float f, float f1) {
-		doRenderBlock((EntityBlock) entity, i, j, k);
+	public void doRender(Entity entity, double x, double y, double z, float f, float f1) {
+		doRenderBlock((EntityBlock) entity, x, y, z);
 	}
 
-	public void doRenderBlock(EntityBlock entity, double i, double j, double k) {
+	public void doRenderBlock(EntityBlock entity, double x, double y, double z) {
 		if (entity.isDead) {
 			return;
 		}
 
 		shadowSize = entity.shadowSize;
-		World world = entity.worldObj;
 		RenderInfo util = new RenderInfo();
 		util.texture = entity.texture;
 		bindTexture(TextureMap.locationBlocksTexture);
@@ -166,21 +164,13 @@ public final class RenderEntityBlock extends Render {
 					util.maxZ = remainZ > 1.0 ? 1.0 : remainZ;
 
 					GL11.glPushMatrix();
-					GL11.glTranslatef((float) i, (float) j, (float) k);
+					GL11.glTranslatef((float) x, (float) y, (float) z);
 					GL11.glRotatef(entity.rotationX, 1, 0, 0);
 					GL11.glRotatef(entity.rotationY, 0, 1, 0);
 					GL11.glRotatef(entity.rotationZ, 0, 0, 1);
 					GL11.glTranslatef(iBase, jBase, kBase);
 
-					int lightX, lightY, lightZ;
-
-					lightX = (int) (Math.floor(entity.posX) + iBase);
-					lightY = (int) (Math.floor(entity.posY) + jBase);
-					lightZ = (int) (Math.floor(entity.posZ) + kBase);
-
-					GL11.glDisable(2896 /* GL_LIGHTING */);
-					renderBlock(util, world, 0, 0, 0, lightX, lightY, lightZ, false, true);
-					GL11.glEnable(2896 /* GL_LIGHTING */);
+					renderBlock(util);
 					GL11.glPopMatrix();
 
 				}
@@ -188,99 +178,36 @@ public final class RenderEntityBlock extends Render {
 		}
 	}
 
-	public void renderBlock(RenderInfo info, IBlockAccess blockAccess, int x, int y, int z, boolean doLight, boolean doTessellating) {
-		renderBlock(info, blockAccess, x, y, z, x, y, z, doLight, doTessellating);
-	}
-
-	public void renderBlock(RenderInfo info, IBlockAccess blockAccess, double x, double y, double z, int lightX, int lightY, int lightZ, boolean doLight, boolean doTessellating) {
-		float lightBottom = 0.5F;
-		float lightTop = 1.0F;
-		float lightEastWest = 0.8F;
-		float lightNorthSouth = 0.6F;
-
+	public void renderBlock(RenderInfo info) {
 		Tessellator tessellator = Tessellator.instance;
-
-		boolean realDoLight = doLight;
-
-		if (blockAccess == null) {
-			realDoLight = false;
-		}
-
-		if (doTessellating) {
-			tessellator.startDrawingQuads();
-		}
-
-		float light = 0;
-		if (realDoLight) {
-			if (info.light < 0) {
-				light = info.baseBlock.getMixedBrightnessForBlock(blockAccess, lightX, lightY, lightZ);
-				light = light + ((1.0f - light) * 0.4f);
-			} else {
-				light = info.light;
-			}
-			int brightness = 0;
-			if (info.brightness < 0) {
-				brightness = info.baseBlock.getMixedBrightnessForBlock(blockAccess, lightX, lightY, lightZ);
-			} else {
-				brightness = info.brightness;
-			}
-			tessellator.setBrightness(brightness);
-			tessellator.setColorOpaque_F(lightBottom * light, lightBottom * light, lightBottom * light);
-		} else {
-//			tessellator.setColorOpaque_F(1.0F, 1.0F, 1.0F);
-			if (info.brightness >= 0) {
-				tessellator.setBrightness(info.brightness);
-			}
-		}
-
+		tessellator.startDrawingQuads();
+		
 		renderBlocks.setRenderBounds(info.minX, info.minY, info.minZ, info.maxX, info.maxY, info.maxZ);
 
 		if (info.renderSide[0]) {
-			renderBlocks.renderFaceYNeg(info.baseBlock, x, y, z, info.getBlockTextureFromSide(0));
+			tessellator.setNormal(0, -1, 0);
+			renderBlocks.renderFaceYNeg(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(0));
 		}
-
-		if (realDoLight) {
-			tessellator.setColorOpaque_F(lightTop * light, lightTop * light, lightTop * light);
-		}
-
 		if (info.renderSide[1]) {
-			renderBlocks.renderFaceYPos(info.baseBlock, x, y, z, info.getBlockTextureFromSide(1));
+			tessellator.setNormal(0, 1, 0);
+			renderBlocks.renderFaceYPos(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(1));
 		}
-
-		if (realDoLight) {
-			tessellator.setColorOpaque_F(lightEastWest * light, lightEastWest * light, lightEastWest * light);
-		}
-
 		if (info.renderSide[2]) {
-			renderBlocks.renderFaceZNeg(info.baseBlock, x, y, z, info.getBlockTextureFromSide(2));
+			tessellator.setNormal(0, 0, -1);
+			renderBlocks.renderFaceZNeg(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(2));
 		}
-
-		if (realDoLight) {
-			tessellator.setColorOpaque_F(lightEastWest * light, lightEastWest * light, lightEastWest * light);
-		}
-
 		if (info.renderSide[3]) {
-			renderBlocks.renderFaceZPos(info.baseBlock, x, y, z, info.getBlockTextureFromSide(3));
+			tessellator.setNormal(0, 0, 1);
+			renderBlocks.renderFaceZPos(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(3));
 		}
-
-		if (realDoLight) {
-			tessellator.setColorOpaque_F(lightNorthSouth * light, lightNorthSouth * light, lightNorthSouth * light);
-		}
-
 		if (info.renderSide[4]) {
-			renderBlocks.renderFaceXNeg(info.baseBlock, x, y, z, info.getBlockTextureFromSide(4));
+			tessellator.setNormal(-1, 0, 0);
+			renderBlocks.renderFaceXNeg(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(4));
 		}
-
-		if (realDoLight) {
-			tessellator.setColorOpaque_F(lightNorthSouth * light, lightNorthSouth * light, lightNorthSouth * light);
-		}
-
 		if (info.renderSide[5]) {
-			renderBlocks.renderFaceXPos(info.baseBlock, x, y, z, info.getBlockTextureFromSide(5));
+			tessellator.setNormal(1, 0, 0);
+			renderBlocks.renderFaceXPos(info.baseBlock, 0, 0, 0, info.getBlockTextureFromSide(5));
 		}
-
-		if (doTessellating) {
-			tessellator.draw();
-		}
+		tessellator.draw();
 	}
 }

--- a/common/buildcraft/core/render/RenderLaser.java
+++ b/common/buildcraft/core/render/RenderLaser.java
@@ -81,8 +81,7 @@ public class RenderLaser extends Render {
 					block.maxY = maxSize / 2F - diff;
 					block.maxZ = maxSize / 2F - diff;
 
-					RenderEntityBlock.INSTANCE.renderBlock(block, null, 0, 0,
-							0, false, true);
+					RenderEntityBlock.INSTANCE.renderBlock(block);
 
 					GL11.glEndList();
 				}

--- a/common/buildcraft/transport/render/PipeRendererTESR.java
+++ b/common/buildcraft/transport/render/PipeRendererTESR.java
@@ -10,10 +10,6 @@ package buildcraft.transport.render;
 
 import java.util.HashMap;
 
-import com.google.common.collect.Maps;
-
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.GLAllocation;
@@ -33,6 +29,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+
+import org.lwjgl.opengl.GL11;
+
 import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftCore.RenderMode;
 import buildcraft.BuildCraftTransport;
@@ -46,7 +45,6 @@ import buildcraft.core.render.RenderEntityBlock;
 import buildcraft.core.render.RenderEntityBlock.RenderInfo;
 import buildcraft.core.render.RenderUtils;
 import buildcraft.core.utils.MatrixTranformations;
-import buildcraft.transport.Gate;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeIconProvider;
 import buildcraft.transport.PipeRenderState;
@@ -56,6 +54,8 @@ import buildcraft.transport.PipeTransportPower;
 import buildcraft.transport.TileGenericPipe;
 import buildcraft.transport.TravelingItem;
 import buildcraft.transport.gates.GatePluggable;
+
+import com.google.common.collect.Maps;
 
 public class PipeRendererTESR extends TileEntitySpecialRenderer {
 	public static final float DISPLAY_MULTIPLIER = 0.1f;
@@ -151,7 +151,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minY = CoreConstants.PIPE_MIN_POS + 0.01F;
 			block.maxY = block.minY + (size - 0.02F) * ratio;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 
@@ -169,7 +169,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minZ = 0.5 - (size / 2 - 0.01) * ratio;
 			block.maxZ = 0.5 + (size / 2 - 0.01) * ratio;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 
@@ -187,7 +187,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minY = CoreConstants.PIPE_MIN_POS + 0.01;
 			block.maxY = block.minY + (size - 0.02F) * ratio;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 
@@ -205,7 +205,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minZ = 0.5 - (size / 2 - 0.02) * ratio;
 			block.maxZ = 0.5 + (size / 2 - 0.02) * ratio;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 
@@ -243,7 +243,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minX = 0;
 			block.maxX = 0.5 + (minSize / 2F) + unit * s;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 		}
@@ -269,7 +269,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.minX = 0;
 			block.maxX = 0.5 + (minSize / 2F) + unit * s;
 
-			RenderEntityBlock.INSTANCE.renderBlock(block, world, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 
 			GL11.glEndList();
 		}
@@ -446,7 +446,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 		if (minZ != CoreConstants.PIPE_MIN_POS || maxZ != CoreConstants.PIPE_MAX_POS || !found) {
 			renderBox.setBounds(cx == CoreConstants.PIPE_MIN_POS ? cx - 0.05F : cx, cy == CoreConstants.PIPE_MIN_POS ? cy - 0.05F : cy, minZ, cx == CoreConstants.PIPE_MIN_POS ? cx
 					: cx + 0.05F, cy == CoreConstants.PIPE_MIN_POS ? cy : cy + 0.05F, maxZ);
-			RenderEntityBlock.INSTANCE.renderBlock(renderBox, pipe.getWorldObj(), 0, 0, 0, pipe.xCoord, pipe.yCoord, pipe.zCoord, true, true);
+			RenderEntityBlock.INSTANCE.renderBlock(renderBox);
 		}
 
 		// X render
@@ -454,7 +454,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 		if (minX != CoreConstants.PIPE_MIN_POS || maxX != CoreConstants.PIPE_MAX_POS || !found) {
 			renderBox.setBounds(minX, cy == CoreConstants.PIPE_MIN_POS ? cy - 0.05F : cy, cz == CoreConstants.PIPE_MIN_POS ? cz - 0.05F : cz, maxX, cy == CoreConstants.PIPE_MIN_POS ? cy
 					: cy + 0.05F, cz == CoreConstants.PIPE_MIN_POS ? cz : cz + 0.05F);
-			RenderEntityBlock.INSTANCE.renderBlock(renderBox, pipe.getWorldObj(), 0, 0, 0, pipe.xCoord, pipe.yCoord, pipe.zCoord, true, true);
+			RenderEntityBlock.INSTANCE.renderBlock(renderBox);
 		}
 
 		// Y render
@@ -462,13 +462,13 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 		if (minY != CoreConstants.PIPE_MIN_POS || maxY != CoreConstants.PIPE_MAX_POS || !found) {
 			renderBox.setBounds(cx == CoreConstants.PIPE_MIN_POS ? cx - 0.05F : cx, minY, cz == CoreConstants.PIPE_MIN_POS ? cz - 0.05F : cz, cx == CoreConstants.PIPE_MIN_POS ? cx
 					: cx + 0.05F, maxY, cz == CoreConstants.PIPE_MIN_POS ? cz : cz + 0.05F);
-			RenderEntityBlock.INSTANCE.renderBlock(renderBox, pipe.getWorldObj(), 0, 0, 0, pipe.xCoord, pipe.yCoord, pipe.zCoord, true, true);
+			RenderEntityBlock.INSTANCE.renderBlock(renderBox);
 		}
 
 		if (center || !found) {
 			renderBox.setBounds(cx == CoreConstants.PIPE_MIN_POS ? cx - 0.05F : cx, cy == CoreConstants.PIPE_MIN_POS ? cy - 0.05F : cy, cz == CoreConstants.PIPE_MIN_POS ? cz - 0.05F : cz,
 					cx == CoreConstants.PIPE_MIN_POS ? cx : cx + 0.05F, cy == CoreConstants.PIPE_MIN_POS ? cy : cy + 0.05F, cz == CoreConstants.PIPE_MIN_POS ? cz : cz + 0.05F);
-			RenderEntityBlock.INSTANCE.renderBlock(renderBox, pipe.getWorldObj(), 0, 0, 0, pipe.xCoord, pipe.yCoord, pipe.zCoord, true, true);
+			RenderEntityBlock.INSTANCE.renderBlock(renderBox);
 		}
 
 		RenderHelper.enableStandardItemLighting();
@@ -577,8 +577,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 		}
 
 		renderBox.setBounds(rotated[0][0], rotated[1][0], rotated[2][0], rotated[0][1], rotated[1][1], rotated[2][1]);
-		RenderEntityBlock.INSTANCE.renderBlock(renderBox, tile.getWorldObj(), 0, 0, 0, tile.xCoord, tile.yCoord,
-				tile.zCoord, true, true);
+		RenderEntityBlock.INSTANCE.renderBlock(renderBox);
 		GL11.glPopMatrix();
 	}
 
@@ -846,7 +845,7 @@ public class PipeRendererTESR extends TileEntitySpecialRenderer {
 			block.maxX = max;
 
 			RenderUtils.setGLColorFromInt(color.getLightHex());
-			RenderEntityBlock.INSTANCE.renderBlock(block, null, 0, 0, 0, false, true);
+			RenderEntityBlock.INSTANCE.renderBlock(block);
 		}
 
 		GL11.glPopMatrix();


### PR DESCRIPTION
The block rendering code (used to render the quarry arm, lasers, fluid in tanks, gates and etc) was extremely clunky, so I gave it a good clean up :D

So now instead of looking like this:
![screen shot 2014-12-17 at 04 32 48](https://cloud.githubusercontent.com/assets/5294529/5467401/f1a71978-85a5-11e4-9ff3-98ee438a29a0.png)

The quarry arm looks like this:
![screen shot 2014-12-17 at 04 31 39](https://cloud.githubusercontent.com/assets/5294529/5467408/ffea39d4-85a5-11e4-9ea7-4fe18c93727a.png)

This PR also fixes the issue mentioned on #2247 where the mining drill would not render from a distance larger than 40 blocks.
