### PR TITLE
Tweaks to chute rendering

### DIFF
--- a/common/buildcraft/factory/render/RenderHopper.java
+++ b/common/buildcraft/factory/render/RenderHopper.java
@@ -8,8 +8,6 @@
  */
 package buildcraft.factory.render;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.Tessellator;
@@ -17,6 +15,8 @@ import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
+
+import org.lwjgl.opengl.GL11;
 
 import buildcraft.BuildCraftCore;
 import buildcraft.BuildCraftCore.RenderMode;
@@ -64,16 +64,15 @@ public class RenderHopper extends TileEntitySpecialRenderer implements IInventor
 		}
 
 		GL11.glPushMatrix();
-		GL11.glDisable(GL11.GL_LIGHTING);
-
 		GL11.glTranslated(x, y, z);
 		bindTexture(HOPPER_TEXTURE);
 		top.render((float) (1.0 / 16.0));
 		bottom.render((float) (1.0 / 16.0));
 		bindTexture(HOPPER_MIDDLE_TEXTURE);
+		GL11.glTranslated(0.005, 0, 0.005);
+		GL11.glScaled(0.99, 1, 0.99);
 		middle.render(Tessellator.instance, 1F / 16F);
 
-		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glPopMatrix();
 	}
 }

--- a/common/buildcraft/silicon/SiliconRenderBlock.java
+++ b/common/buildcraft/silicon/SiliconRenderBlock.java
@@ -43,12 +43,10 @@ public class SiliconRenderBlock implements ISimpleBlockRenderingHandler {
 			renderblocks.uvRotateTop = 1;
 			renderblocks.uvRotateBottom = 2;
 
-			block.setBlockBounds(0.0F, 0.0F, 0.0F, 4F / 16F, 1, 1);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(0.0F, 0.0F, 0.0F, 4F / 16F, 1, 1);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(4F / 16F, 5F / 16F, 5F / 16F, 13F / 16F, 11F / 16F, 11F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(4F / 16F, 5F / 16F, 5F / 16F, 13F / 16F, 11F / 16F, 11F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		} else if (meta == ForgeDirection.WEST.ordinal()) {
 			renderblocks.uvRotateEast = 1;
@@ -56,23 +54,19 @@ public class SiliconRenderBlock implements ISimpleBlockRenderingHandler {
 			renderblocks.uvRotateTop = 2;
 			renderblocks.uvRotateBottom = 1;
 
-			block.setBlockBounds(1F - 4F / 16F, 0.0F, 0.0F, 1, 1, 1);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(1F - 4F / 16F, 0.0F, 0.0F, 1, 1, 1);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(1F - 13F / 16F, 5F / 16F, 5F / 16F, 1F - 4F / 16F, 11F / 16F, 11F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(1F - 13F / 16F, 5F / 16F, 5F / 16F, 1F - 4F / 16F, 11F / 16F, 11F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		} else if (meta == ForgeDirection.NORTH.ordinal()) {
 			renderblocks.uvRotateSouth = 1;
 			renderblocks.uvRotateNorth = 2;
 
-			block.setBlockBounds(0.0F, 0.0F, 1F - 4F / 16F, 1, 1, 1);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(0.0F, 0.0F, 1F - 4F / 16F, 1, 1, 1);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(5F / 16F, 5F / 16F, 1F - 13F / 16F, 11F / 16F, 11F / 16F, 1F - 4F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(5F / 16F, 5F / 16F, 1F - 13F / 16F, 11F / 16F, 11F / 16F, 1F - 4F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		} else if (meta == ForgeDirection.SOUTH.ordinal()) {
 			renderblocks.uvRotateSouth = 2;
@@ -80,12 +74,10 @@ public class SiliconRenderBlock implements ISimpleBlockRenderingHandler {
 			renderblocks.uvRotateTop = 3;
 			renderblocks.uvRotateBottom = 3;
 
-			block.setBlockBounds(0.0F, 0.0F, 0.0F, 1, 1, 4F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(0.0F, 0.0F, 0.0F, 1, 1, 4F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(5F / 16F, 5F / 16F, 4F / 16F, 11F / 16F, 11F / 16F, 13F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(5F / 16F, 5F / 16F, 4F / 16F, 11F / 16F, 11F / 16F, 13F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		} else if (meta == ForgeDirection.DOWN.ordinal()) {
 			renderblocks.uvRotateEast = 3;
@@ -93,24 +85,19 @@ public class SiliconRenderBlock implements ISimpleBlockRenderingHandler {
 			renderblocks.uvRotateSouth = 3;
 			renderblocks.uvRotateNorth = 3;
 
-			block.setBlockBounds(0.0F, 1.0F - 4F / 16F, 0.0F, 1.0F, 1.0F, 1.0F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(0.0F, 1.0F - 4F / 16F, 0.0F, 1.0F, 1.0F, 1.0F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(5F / 16F, 1F - 13F / 16F, 5F / 16F, 11F / 16F, 1F - 4F / 16F, 11F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(5F / 16F, 1F - 13F / 16F, 5F / 16F, 11F / 16F, 1F - 4F / 16F, 11F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		} else if (meta == ForgeDirection.UP.ordinal()) {
-			block.setBlockBounds(0.0F, 0.0F, 0.0F, 1, 4F / 16F, 1);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(0.0F, 0.0F, 0.0F, 1, 0.25, 1);
 			renderblocks.renderStandardBlock(block, x, y, z);
 
-			block.setBlockBounds(5F / 16F, 4F / 16F, 5F / 16F, 11F / 16F, 13F / 16F, 11F / 16F);
-			renderblocks.setRenderBoundsFromBlock(block);
+			renderblocks.setRenderBounds(5F / 16F, 4F / 16F, 5F / 16F, 11F / 16F, 13F / 16F, 11F / 16F);
 			renderblocks.renderStandardBlock(block, x, y, z);
 		}
 
-		block.setBlockBounds(0.0F, 0.0F, 0.0F, 1, 1, 1);
 		renderblocks.uvRotateEast = 0;
 		renderblocks.uvRotateWest = 0;
 		renderblocks.uvRotateSouth = 0;

--- a/common/buildcraft/silicon/render/RenderLaserBlock.java
+++ b/common/buildcraft/silicon/render/RenderLaserBlock.java
@@ -8,11 +8,11 @@
  */
 package buildcraft.silicon.render;
 
-import org.lwjgl.opengl.GL11;
-
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
+
+import org.lwjgl.opengl.GL11;
 
 import buildcraft.core.render.RenderLaser;
 import buildcraft.silicon.TileLaser;
@@ -25,22 +25,13 @@ public class RenderLaserBlock extends TileEntitySpecialRenderer {
 
 		if (laser != null) {
 			GL11.glPushMatrix();
-			GL11.glPushAttrib(GL11.GL_ENABLE_BIT);
-			GL11.glEnable(GL11.GL_CULL_FACE);
-			GL11.glEnable(GL11.GL_LIGHTING);
-			GL11.glEnable(GL11.GL_BLEND);
-			GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-
 			GL11.glTranslated(x, y, z);
 			GL11.glTranslated(-tileentity.xCoord, -tileentity.yCoord, -tileentity.zCoord);
 
 			GL11.glPushMatrix();
-			RenderLaser.doRenderLaser(TileEntityRendererDispatcher.instance.field_147553_e,
-					laser.laser, laser.getTexture());
+			RenderLaser.doRenderLaser(TileEntityRendererDispatcher.instance.field_147553_e, laser.laser, laser.getTexture());
 			GL11.glPopMatrix();
-
-			//GL11.glEnable(GL11.GL_LIGHTING);
-			GL11.glPopAttrib();
+			
 			GL11.glPopMatrix();
 		}
 	}


### PR DESCRIPTION
- laser block rendering clean up (no noticeable changes)

Could probably make the chute look a lot better (like actually have a hole on the top) but I was thinking... Why is the chute still a thing? Hoppers are vanilla and work a lot better than them (since they can insert items to the sides as well)...

Here's what it looks like now:
![screen shot 2014-12-17 at 17 40 20](https://cloud.githubusercontent.com/assets/5294529/5477641/478ccf54-8614-11e4-8d38-ceff4a282444.png)
