### PR TITLE
block breaking robots first scan for valid targets before attempting to ...

### DIFF
--- a/common/buildcraft/core/utils/PathFindingJob.java
+++ b/common/buildcraft/core/utils/PathFindingJob.java
@@ -32,6 +32,7 @@ public class PathFindingJob extends Thread {
 	@Override
 	public void run() {
 		try {
+			pathFinding.preRun();
 			for (int i = 0; i < maxIterations; ++i) {
 				if (isTerminated() || pathFinding.isDone()) {
 					break;


### PR DESCRIPTION
...pathfind

This does not fix #2306 completely, but at least allows robots not to get stuck in normal farm operation, i.e. they won't get stuck after clearing the farm.
