### PR TITLE
Make swimming in oil a lot harder

### DIFF
--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -103,6 +103,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 	public static Item fuel;
 
 	public static boolean canOilBurn;
+	public static boolean isOilDense;
 	public static boolean canEnginesExplode;
 	public static double oilWellScalar = 1.0;
 	public static ITriggerExternal triggerBlueEngineHeat = new TriggerEngineHeat(EnergyStage.BLUE);
@@ -121,6 +122,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 		int oilDesertBiomeId = BuildCraftCore.mainConfiguration.get("biomes", "biomeOilDesert", DefaultProps.BIOME_OIL_DESERT).getInt(DefaultProps.BIOME_OIL_DESERT);
 		int oilOceanBiomeId = BuildCraftCore.mainConfiguration.get("biomes", "biomeOilOcean", DefaultProps.BIOME_OIL_OCEAN).getInt(DefaultProps.BIOME_OIL_OCEAN);
 		canOilBurn = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "burnOil", true, "Can oil burn?").getBoolean(true);
+		isOilDense = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "denseOil", true, "Should it be hard to swim in oil?").getBoolean(true);
 		oilWellScalar = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "oilWellGenerationRate", 1.0, "Probability of oil well generation").getDouble(1.0);
 		canEnginesExplode = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "enginesExplode", false, "Do engines explode upon overheat?").getBoolean(false);
 
@@ -192,7 +194,7 @@ public class BuildCraftEnergy extends BuildCraftMod {
 		fluidRedPlasma = FluidRegistry.getFluid("redplasma");
 
 		if (fluidOil.getBlock() == null) {
-			blockOil = new BlockBuildcraftFluid(fluidOil, Material.water, MapColor.blackColor).setFlammable(canOilBurn).setFlammability(0);
+			blockOil = new BlockBuildcraftFluid(fluidOil, Material.water, MapColor.blackColor).setFlammable(canOilBurn).setFlammability(0).setDense(isOilDense);
 			blockOil.setBlockName("blockOil").setLightOpacity(8);
 			CoreProxy.proxy.registerBlock(blockOil);
 			fluidOil.setBlock(blockOil);

--- a/common/buildcraft/energy/BlockBuildcraftFluid.java
+++ b/common/buildcraft/energy/BlockBuildcraftFluid.java
@@ -15,6 +15,7 @@ import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -37,6 +38,7 @@ public class BlockBuildcraftFluid extends BlockFluidClassic {
 	@SideOnly(Side.CLIENT)
 	protected IIcon[] theIcon;
 	protected boolean flammable;
+	protected boolean dense = false;
 	protected int flammability = 0;
 	private MapColor mapColor;
 
@@ -65,6 +67,27 @@ public class BlockBuildcraftFluid extends BlockFluidClassic {
 			world.newExplosion(null, x, y, z, 4F, true, true);
 			world.setBlockToAir(x, y, z);
 		}
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+
+		if(!dense || entity == null) return;
+
+		entity.motionY = Math.min(0.0, entity.motionY);
+
+		if (entity.motionY < -0.05) {
+			entity.motionY *= 0.05;
+		}
+
+		entity.motionX = Math.max(-0.05, Math.min(0.05, entity.motionX * 0.05));
+		entity.motionY -= 0.05;
+		entity.motionZ = Math.max(-0.05, Math.min(0.05, entity.motionZ * 0.05));
+	}
+
+	public BlockBuildcraftFluid setDense(boolean dense) {
+		this.dense = dense;
+		return this;
 	}
 
 	public BlockBuildcraftFluid setFlammable(boolean flammable) {


### PR DESCRIPTION
Swimming upwards is pretty much impossible in Vanilla with this (some mods might make it possible).
Crude Oil is a very dense semifluid, you should not be able to swim properly in it; if you jump into an oil well, you will most likely die but that's your own fault then. Oil is deadly.
Also added a config option to restore previous behaviour.