### PR TITLE
Fast auto workbench

### DIFF
--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -92,6 +92,7 @@ public class BuildCraftFactory extends BuildCraftMod {
 	public static boolean quarryLoadsChunks = true;
 	public static boolean allowMining = true;
 	public static boolean quarryOneTimeUse = false;
+	public static boolean fastAutoWorkbench = false;
 	public static float miningMultiplier = 1;
 	public static int miningDepth = 256;
 	public static PumpDimensionList pumpDimensionList;
@@ -181,6 +182,7 @@ public class BuildCraftFactory extends BuildCraftMod {
 		miningMultiplier = genCat.get("mining.cost.multipler", 1F, 1F, 10F, "cost multiplier for mining operations, range (1.0 - 10.0)\nhigh values may render engines incapable of powering machines directly");
 		miningDepth = genCat.get("mining.depth", 2, 256, 256, "how far below the machine can mining machines dig, range (2 - 256), default 256");
 		quarryLoadsChunks = genCat.get("quarry.loads.chunks", true, "Quarry loads chunks required for mining");
+		fastAutoWorkbench = genCat.get("autoworkbench.fast", false, "Auto-workbench doesn't take time to craft items");
 
 		Property pumpList = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "pumping.controlList", DefaultProps.PUMP_DIMENSION_LIST);
 		pumpList.comment = "Allows admins to whitelist or blacklist pumping of specific fluids in specific dimensions.\n"

--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -21,9 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.WorldServer;
-
 import net.minecraftforge.common.util.ForgeDirection;
-
 import buildcraft.BuildCraftFactory;
 import buildcraft.api.core.IInvSlot;
 import buildcraft.core.TileBuildCraft;
@@ -46,7 +44,11 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 	public InventoryCrafting craftMatrix = new LocalInventoryCrafting();
 	public boolean useLast;
 	public int progress;
-
+	
+	/** Set when nothing can be crafted unless the input grid is changed.
+	 * Cleared whenever the input grid is changed. Not persisted. */
+	private boolean isJammed;
+	
 	private SimpleInventory resultInv = new SimpleInventory(1, "Auto Workbench", 64);
 
 	private IInventory inv = InventoryConcatenator.make().add(resultInv).add(craftMatrix);
@@ -65,6 +67,24 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 					return false;
 				}
 			}, 3, 3);
+		}
+		
+		@Override
+		public void setInventorySlotContents(int p_70299_1_, ItemStack p_70299_2_) {
+			super.setInventorySlotContents(p_70299_1_, p_70299_2_);
+			isJammed = false;
+		}
+		
+		@Override
+		public void markDirty() {
+			super.markDirty();
+			isJammed = false;
+		}
+		
+		@Override
+		public ItemStack decrStackSize(int p_70298_1_, int p_70298_2_) {
+			isJammed = false;
+			return super.decrStackSize(p_70298_1_, p_70298_2_);
 		}
 	}
 
@@ -176,6 +196,10 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 		if (worldObj.isRemote) {
 			return;
 		}
+		
+		if (isJammed) {
+			return;
+		}
 
 		balanceSlots();
 
@@ -230,10 +254,12 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 		IRecipe recipe = findRecipe();
 		if (recipe == null) {
 			progress = 0;
+			isJammed = true;
 			return;
 		}
 		if (!useLast && isLast()) {
 			progress = 0;
+			isJammed = true;
 			return;
 		}
 		progress += UPDATE_TIME;
@@ -244,6 +270,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 		useLast = false;
 		ItemStack result = recipe.getCraftingResult(craftMatrix);
 		if (result == null) {
+			isJammed = true;
 			return;
 		}
 		result = result.copy();

--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -24,6 +24,7 @@ import net.minecraft.world.WorldServer;
 
 import net.minecraftforge.common.util.ForgeDirection;
 
+import buildcraft.BuildCraftFactory;
 import buildcraft.api.core.IInvSlot;
 import buildcraft.core.TileBuildCraft;
 import buildcraft.core.inventory.InvUtils;
@@ -185,7 +186,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 			return;
 		}
 		update++;
-		if (update % UPDATE_TIME == 0) {
+		if (update % UPDATE_TIME == 0 || BuildCraftFactory.fastAutoWorkbench) {
 			updateCrafting();
 		}
 	}
@@ -236,7 +237,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 			return;
 		}
 		progress += UPDATE_TIME;
-		if (progress < CRAFT_TIME) {
+		if (progress < CRAFT_TIME && !BuildCraftFactory.fastAutoWorkbench) {
 			return;
 		}
 		progress = 0;

--- a/common/buildcraft/factory/TileAutoWorkbench.java
+++ b/common/buildcraft/factory/TileAutoWorkbench.java
@@ -49,6 +49,9 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 	 * Cleared whenever the input grid is changed. Not persisted. */
 	private boolean isJammed;
 	
+	/** Set when any slot changes. Cleared when balanceSlots is called. */
+	private boolean needsBalancing;
+
 	private SimpleInventory resultInv = new SimpleInventory(1, "Auto Workbench", 64);
 
 	private IInventory inv = InventoryConcatenator.make().add(resultInv).add(craftMatrix);
@@ -73,17 +76,20 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 		public void setInventorySlotContents(int p_70299_1_, ItemStack p_70299_2_) {
 			super.setInventorySlotContents(p_70299_1_, p_70299_2_);
 			isJammed = false;
+			needsBalancing = true;
 		}
 		
 		@Override
 		public void markDirty() {
 			super.markDirty();
 			isJammed = false;
+			needsBalancing = true;
 		}
 		
 		@Override
 		public ItemStack decrStackSize(int p_70298_1_, int p_70298_2_) {
 			isJammed = false;
+			needsBalancing = true;
 			return super.decrStackSize(p_70298_1_, p_70298_2_);
 		}
 	}
@@ -197,11 +203,12 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 			return;
 		}
 		
+		if(needsBalancing)
+			balanceSlots();
+		
 		if (isJammed) {
 			return;
 		}
-
-		balanceSlots();
 
 		if (craftSlot == null) {
 			craftSlot = new SlotCrafting(getInternalPlayer().get(), craftMatrix, craftResult, 0, 0, 0);
@@ -245,6 +252,7 @@ public class TileAutoWorkbench extends TileBuildCraft implements ISidedInventory
 				}
 			}
 		}
+		needsBalancing = false;
 	}
 
 	/**


### PR DESCRIPTION
This adds a config option "autoworkbench.fast", which makes auto-workbenches able to craft every tick (instead of every 256).

Also included is an optimization to make auto-workbenches not retry crafting unless the input grid has changed, and to make them not rebalance every tick (they rebalance when the input grid has changed since the last rebalance, or if the last rebalance hasn't finished yet).

