### PR TITLE
Make Travis builds logs less obscure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 
 before_install: git clone https://github.com/BuildCraft/BuildCraft-Localization.git ../BuildCraft-Localization
 install: ./gradlew setupCIWorkspace -S
-script: ./gradlew build -S
+script: ./gradlew build
 
 env:
   global:


### PR DESCRIPTION
Option -S enables full stack trace logging which in case of Grovy is very obscure.
Default logging shows CheckStyle errors in console.