### PR TITLE
fix an error when loading old robots due to package renames

### DIFF
--- a/api/buildcraft/api/robots/AIRobot.java
+++ b/api/buildcraft/api/robots/AIRobot.java
@@ -169,7 +169,14 @@ public class AIRobot {
 			NBTTagCompound sub = nbt.getCompoundTag("delegateAI");
 
 			try {
-				delegateAI = (AIRobot) Class.forName(sub.getString("class")).getConstructor(EntityRobotBase.class)
+				String className = sub.getString("class");
+				// Package renames in 6.4.0
+				if (className.contains("buildcraft.core.robots.boards")) {
+					className = className.replace("buildcraft.core.robots.boards", "buildcraft.robots.boards");
+				} else if (className.contains("buildcraft.core.robots")) {
+					className = className.replace("buildcraft.core.robots", "buildcraft.robots.ai");
+				}
+				delegateAI = (AIRobot) Class.forName(className).getConstructor(EntityRobotBase.class)
 						.newInstance(robot);
 
 				if (delegateAI.canLoadFromNBT()) {
@@ -186,7 +193,12 @@ public class AIRobot {
 		AIRobot ai = null;
 
 		try {
-			ai = (AIRobot) Class.forName(nbt.getString("class")).getConstructor(EntityRobotBase.class)
+			String className = nbt.getString("class");
+			// Package renames in 6.4.0
+			if (className.contains("buildcraft.core.robots")) {
+				className = className.replace("buildcraft.core.robots", "buildcraft.robots.ai");
+			}
+			ai = (AIRobot) Class.forName(className).getConstructor(EntityRobotBase.class)
 					.newInstance(robot);
 			ai.loadFromNBT(nbt);
 		} catch (Throwable e) {

--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -141,7 +141,8 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler,
 							pluggableClass = FacadePluggable.class;
 						} else if ("buildcraft.transport.ItemPlug$PlugPluggable".equals(c)) {
 							pluggableClass = PlugPluggable.class;
-						} else if ("buildcraft.transport.gates.ItemRobotStation$RobotStationPluggable".equals(c)) {
+						} else if ("buildcraft.transport.gates.ItemRobotStation$RobotStationPluggable".equals(c)
+								|| "buildcraft.transport.ItemRobotStation$RobotStationPluggable".equals(c)) {
 							pluggableClass = PipeManager.getPluggableByName("robotStation");
 						}
 					} else {


### PR DESCRIPTION
Might be worth to note in the release that if you upgrade to 6.4.x and then downgrade, the robots won't load and you will lose them.