### PR TITLE
Wix API-core dependencies

### DIFF
--- a/api/buildcraft/api/blueprints/SchematicBlock.java
+++ b/api/buildcraft/api/blueprints/SchematicBlock.java
@@ -24,7 +24,7 @@ import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.BlockFluidBase;
-import buildcraft.core.BlockBuildCraft;
+import buildcraft.api.core.BuildCraftProperties;
 
 public class SchematicBlock extends SchematicBlockBase {
 
@@ -190,7 +190,7 @@ public class SchematicBlock extends SchematicBlockBase {
 	
 	public EnumFacing getFace()
 	{
-		return ((EnumFacing)state.getValue(BlockBuildCraft.FACING_PROP));
+		return ((EnumFacing)state.getValue(BuildCraftProperties.BLOCK_FACING));
 	}
 	
 	public int getMetaData()
@@ -200,6 +200,6 @@ public class SchematicBlock extends SchematicBlockBase {
 	
 	public void setMetaData(int newValue)
 	{
-		state = state.withProperty(BlockBuildCraft.FACING_PROP, EnumFacing.getFront(newValue));
+		state = state.withProperty(BuildCraftProperties.BLOCK_FACING, EnumFacing.getFront(newValue));
 	}
 }

--- a/api/buildcraft/api/blueprints/SchematicBlock.java
+++ b/api/buildcraft/api/blueprints/SchematicBlock.java
@@ -25,7 +25,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.BlockFluidBase;
 import buildcraft.core.BlockBuildCraft;
-import buildcraft.core.utils.Utils;
 
 public class SchematicBlock extends SchematicBlockBase {
 
@@ -47,7 +46,7 @@ public class SchematicBlock extends SchematicBlockBase {
 			if (storedRequirements.length != 0) {
 				Collections.addAll(requirements, storedRequirements);
 			} else {
-				requirements.add(Utils.getItemStack(state));
+				requirements.add(getItemStack(state));
 			}
 		}
 	}
@@ -179,6 +178,14 @@ public class SchematicBlock extends SchematicBlockBase {
 
 			nbt.setTag("rq", rq);
 		}
+	}
+    
+    protected ItemStack getItemStack(IBlockState state, int quantity) {
+		return new ItemStack(state.getBlock(), quantity, state.getBlock().damageDropped(state));
+	}
+
+	protected ItemStack getItemStack(IBlockState state) {
+		return getItemStack(state, 1);
 	}
 	
 	public EnumFacing getFace()

--- a/api/buildcraft/api/blueprints/SchematicBlock.java
+++ b/api/buildcraft/api/blueprints/SchematicBlock.java
@@ -179,15 +179,15 @@ public class SchematicBlock extends SchematicBlockBase {
 			nbt.setTag("rq", rq);
 		}
 	}
-    
-    protected ItemStack getItemStack(IBlockState state, int quantity) {
+
+	protected ItemStack getItemStack(IBlockState state, int quantity) {
 		return new ItemStack(state.getBlock(), quantity, state.getBlock().damageDropped(state));
 	}
 
 	protected ItemStack getItemStack(IBlockState state) {
 		return getItemStack(state, 1);
 	}
-	
+
 	public EnumFacing getFace()
 	{
 		return ((EnumFacing)state.getValue(BuildCraftProperties.BLOCK_FACING));

--- a/api/buildcraft/api/blueprints/SchematicFluid.java
+++ b/api/buildcraft/api/blueprints/SchematicFluid.java
@@ -10,7 +10,6 @@ package buildcraft.api.blueprints;
 
 import java.util.LinkedList;
 
-import buildcraft.core.BlockBuildCraft;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockPos;

--- a/api/buildcraft/api/core/BuildCraftProperties.java
+++ b/api/buildcraft/api/core/BuildCraftProperties.java
@@ -1,0 +1,25 @@
+package buildcraft.api.core;
+
+import net.minecraft.block.properties.PropertyDirection;
+import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.properties.PropertyInteger;
+import net.minecraft.util.EnumFacing;
+import buildcraft.core.BlockSpring.EnumSpring;
+import buildcraft.energy.BlockEngine.EngineType;
+import buildcraft.silicon.BlockLaserTable.LaserTableType;
+
+public final class BuildCraftProperties {
+
+	public static final PropertyDirection BLOCK_FACING = PropertyDirection.create("facing", EnumFacing.Plane.HORIZONTAL);
+	public static final PropertyDirection BLOCK_FACING_6 = PropertyDirection.create("facing");
+
+	public static final PropertyEnum BLOCK_COLOR = PropertyEnum.create("color", EnumColor.class, EnumColor.VALUES);
+
+	public static final PropertyEnum SPRING_TYPE = PropertyEnum.create("type", EnumSpring.class);
+
+	public static final PropertyEnum ENGINE_TYPE = PropertyEnum.create("type", EngineType.class);
+	
+	public static final PropertyEnum LASER_TABLE_TYPE = PropertyEnum.create("type", LaserTableType.class);
+	
+	public static final PropertyInteger PIPE_DATA = PropertyInteger.create("data", 0, 15);
+}

--- a/api/buildcraft/api/robots/ResourceId.java
+++ b/api/buildcraft/api/robots/ResourceId.java
@@ -54,7 +54,7 @@ public abstract class ResourceId {
 	}
 
 	protected void readFromNBT(NBTTagCompound nbt) {
-        NBTTagCompound tagIndex = nbt.getCompoundTag("index");
+		NBTTagCompound tagIndex = nbt.getCompoundTag("index");
 		index = new BlockPos(tagIndex.getInteger("x"), tagIndex.getShort("y"), tagIndex.getInteger("z"));
 		side = EnumFacing.values()[nbt.getByte("side")];
 		localId = nbt.getInteger("localId");

--- a/api/buildcraft/api/robots/ResourceId.java
+++ b/api/buildcraft/api/robots/ResourceId.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumFacing;
-import buildcraft.core.utils.Utils;
 
 public abstract class ResourceId {
 
@@ -43,7 +42,11 @@ public abstract class ResourceId {
 
 	public void writeToNBT(NBTTagCompound nbt) {
 		NBTTagCompound indexNBT = new NBTTagCompound();
-		Utils.writeBlockPos(nbt, index);
+        
+		indexNBT.setInteger("x", index.getX());
+		indexNBT.setShort("y", (short) index.getY());
+		indexNBT.setInteger("z", index.getZ());
+        
 		nbt.setTag("index", indexNBT);
 		nbt.setByte("side", (byte) side.ordinal());
 		nbt.setInteger("localId", localId);
@@ -51,7 +54,8 @@ public abstract class ResourceId {
 	}
 
 	protected void readFromNBT(NBTTagCompound nbt) {
-		index = Utils.readBlockPos(nbt.getCompoundTag("index"));
+        NBTTagCompound tagIndex = nbt.getCompoundTag("index");
+		index = new BlockPos(tagIndex.getInteger("x"), tagIndex.getShort("y"), tagIndex.getInteger("z"));
 		side = EnumFacing.values()[nbt.getByte("side")];
 		localId = nbt.getInteger("localId");
 	}

--- a/common/buildcraft/core/BlockBuildCraft.java
+++ b/common/buildcraft/core/BlockBuildCraft.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.Random;
 
 import com.sun.org.apache.xpath.internal.operations.Bool;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
@@ -36,6 +37,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import buildcraft.api.core.BuildCraftProperties;
 import buildcraft.api.core.EnumColor;
 import buildcraft.api.events.BlockPlacedDownEvent;
 import buildcraft.api.tiles.IHasWork;
@@ -46,10 +48,10 @@ public abstract class BlockBuildCraft extends BlockContainer {
 	protected static boolean keepInventory = false;
 	protected final Random rand = new Random();
 	
-	public static final PropertyDirection FACING_PROP = PropertyDirection.create("facing", EnumFacing.Plane.HORIZONTAL);
-	public static final PropertyDirection FACING_6_PROP = PropertyDirection.create("facing");
+	public static final PropertyDirection FACING_PROP = BuildCraftProperties.BLOCK_FACING;
+	public static final PropertyDirection FACING_6_PROP = BuildCraftProperties.BLOCK_FACING_6;
 
-	public static final IProperty COLOR_PROP = PropertyEnum.create("color", EnumColor.class, EnumColor.VALUES);
+	public static final PropertyEnum COLOR_PROP = BuildCraftProperties.BLOCK_COLOR;
 
 	protected final IProperty[] properties;
 
@@ -61,7 +63,7 @@ public abstract class BlockBuildCraft extends BlockContainer {
 	}
 
 	protected BlockBuildCraft(Material material, CreativeTabBuildCraft creativeTab) {
-		this(material, creativeTab, new IProperty[]{});
+		this(material, creativeTab, new IProperty[0]);
 	}
 
 	protected BlockBuildCraft(Material material, IProperty[] properties) {

--- a/common/buildcraft/core/BlockSpring.java
+++ b/common/buildcraft/core/BlockSpring.java
@@ -24,11 +24,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockPos;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.world.World;
+import buildcraft.api.core.BuildCraftProperties;
 
 public class BlockSpring extends Block {
 
 	public static final Random rand = new Random();
-	public static final PropertyEnum TYPE = PropertyEnum.create("type", EnumSpring.class);
+	public static final PropertyEnum TYPE = BuildCraftProperties.SPRING_TYPE;
 
 	public enum EnumSpring implements IStringSerializable {
 

--- a/common/buildcraft/energy/BlockEngine.java
+++ b/common/buildcraft/energy/BlockEngine.java
@@ -38,6 +38,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import buildcraft.BuildCraftCore;
+import buildcraft.api.core.BuildCraftProperties;
 import buildcraft.api.events.BlockInteractionEvent;
 import buildcraft.core.BlockBuildCraft;
 import buildcraft.core.ICustomHighlight;
@@ -59,7 +60,7 @@ public class BlockEngine extends BlockBuildCraft implements ICustomHighlight, IM
 		}
 	};
 
-	public static final PropertyEnum TYPE = PropertyEnum.create("type", EngineType.class);
+	public static final PropertyEnum TYPE = BuildCraftProperties.ENGINE_TYPE;
 
 	private static final AxisAlignedBB[][] boxes = {
 			{AxisAlignedBB.fromBounds(0.0, 0.5, 0.0, 1.0, 1.0, 1.0), AxisAlignedBB.fromBounds(0.25, 0.0, 0.25, 0.75, 0.5, 0.75)}, // -Y

--- a/common/buildcraft/silicon/BlockLaserTable.java
+++ b/common/buildcraft/silicon/BlockLaserTable.java
@@ -27,6 +27,7 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import buildcraft.BuildCraftSilicon;
+import buildcraft.api.core.BuildCraftProperties;
 import buildcraft.api.events.BlockInteractionEvent;
 import buildcraft.api.power.ILaserTargetBlock;
 import buildcraft.core.BlockBuildCraft;
@@ -50,7 +51,7 @@ public class BlockLaserTable extends BlockBuildCraft implements ILaserTargetBloc
 		}
 	};
 
-	public static final PropertyEnum TYPE = PropertyEnum.create("type", LaserTableType.class);
+	public static final PropertyEnum TYPE = BuildCraftProperties.LASER_TABLE_TYPE;
 
 	public BlockLaserTable() {
 		super(Material.iron, new PropertyEnum[]{TYPE});

--- a/common/buildcraft/transport/BlockGenericPipe.java
+++ b/common/buildcraft/transport/BlockGenericPipe.java
@@ -55,6 +55,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import buildcraft.BuildCraftTransport;
 import buildcraft.api.core.BCLog;
+import buildcraft.api.core.BuildCraftProperties;
 import buildcraft.api.events.BlockInteractionEvent;
 import buildcraft.api.events.PipePlacedEvent;
 import buildcraft.api.events.RobotPlacementEvent;
@@ -117,7 +118,7 @@ public class BlockGenericPipe extends BlockBuildCraft implements IModelRegister 
 		}
 	}
 
-	public static final PropertyInteger DATA_PROP = PropertyInteger.create("data", 0, 15);
+	public static final PropertyInteger DATA_PROP = BuildCraftProperties.PIPE_DATA;
 
 	private boolean skippedFirstIconRegister;
 


### PR DESCRIPTION
The API package mustn't depend on the core, in order or it to be independent.
To do that, I extracted some methods from Utils, and moved the Block Property declarations to a new class in the API, so classes in the API, and addon mods too, can use them.