### PR TITLE
Can to disable mods

### DIFF
--- a/api/buildcraft/api/boards/RedstoneBoardRegistry.java
+++ b/api/buildcraft/api/boards/RedstoneBoardRegistry.java
@@ -9,13 +9,14 @@
 package buildcraft.api.boards;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.nbt.NBTTagCompound;
 
 public abstract class RedstoneBoardRegistry {
 
-	public static RedstoneBoardRegistry instance;
+	public static RedstoneBoardRegistry instance = new NullRedstoneBoardRegistry();
 
 	public abstract void registerBoardClass(RedstoneBoardNBT<?> redstoneBoardNBT, float probability);
 
@@ -28,4 +29,34 @@ public abstract class RedstoneBoardRegistry {
 	public abstract void registerIcons(IIconRegister par1IconRegister);
 
 	public abstract Collection<RedstoneBoardNBT<?>> getAllBoardNBTs();
+}
+
+class NullRedstoneBoardRegistry extends RedstoneBoardRegistry {
+
+	@Override
+	public void registerBoardClass(RedstoneBoardNBT<?> redstoneBoardNBT, float probability) {
+	}
+
+	@Override
+	public void createRandomBoard(NBTTagCompound nbt) {
+	}
+
+	@Override
+	public RedstoneBoardNBT getRedstoneBoard(NBTTagCompound nbt) {
+		return null;
+	}
+
+	@Override
+	public RedstoneBoardNBT<?> getRedstoneBoard(String id) {
+		return null;
+	}
+
+	@Override
+	public void registerIcons(IIconRegister par1IconRegister) {
+	}
+
+	@Override
+	public Collection<RedstoneBoardNBT<?>> getAllBoardNBTs() {
+		return Collections.emptyList();
+	}
 }

--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -169,6 +169,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 	
 	@Mod.EventHandler
 	public void loadConfiguration(FMLPreInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		String blueprintServerDir = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL,
 				"blueprints.serverDir",
 				"\"$MINECRAFT" + File.separator + "config" + File.separator + "buildcraft" + File.separator
@@ -258,6 +261,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 	
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		HeuristicBlockDetection.start();
 		
 		if (debugPrintSchematicList) {
@@ -277,6 +283,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void init(FMLInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		// Register gui handler
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
 
@@ -451,6 +460,10 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent evt) {
+		if (isDisabled(evt.getModMetadata().modId)) {
+			disabled = true;
+			return;
+		}
 		templateItem = new ItemBlueprintTemplate();
 		templateItem.setUnlocalizedName("templateItem");
 		CoreProxy.proxy.registerItem(templateItem);
@@ -564,17 +577,26 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void processIMCRequests(FMLInterModComms.IMCEvent event) {
+		if (disabled) {
+			return;
+		}
 		InterModComms.processIMC(event);
 	}
 
 	@Mod.EventHandler
 	public void serverStop(FMLServerStoppingEvent event) {
+		if (disabled) {
+			return;
+		}
 		TilePathMarker.clearAvailableMarkersList();
 	}
 
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public void loadTextures(TextureStitchEvent.Pre evt) {
+		if (disabled) {
+			return;
+		}
 		if (evt.map.getTextureType() == 0) {
 			for (FillerPattern pattern : FillerPattern.patterns.values()) {
 				pattern.registerIcon(evt.map);
@@ -585,6 +607,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public void textureHook(TextureStitchEvent.Pre event) {
+		if (disabled) {
+			return;
+		}
 		if (event.map.getTextureType() == 1) {
 			UrbanistToolsIconProvider.INSTANCE.registerIcons(event.map);
 		}
@@ -592,6 +617,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void whiteListAppliedEnergetics(FMLInitializationEvent event) {
+		if (disabled) {
+			return;
+		}
 		//FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
 		//		TileMarker.class.getCanonicalName());
 		//FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
@@ -608,6 +636,9 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void remap(FMLMissingMappingsEvent event) {
+		if (disabled) {
+			return;
+		}
 		for (FMLMissingMappingsEvent.MissingMapping mapping: event.get()) {
 			if (mapping.name.equals("BuildCraft|Builders:null")) {
 				if (mapping.type == GameRegistry.Type.ITEM) {

--- a/common/buildcraft/BuildCraftEnergy.java
+++ b/common/buildcraft/BuildCraftEnergy.java
@@ -117,9 +117,12 @@ public class BuildCraftEnergy extends BuildCraftMod {
 	private static Fluid buildcraftFluidFuel;
 	private static Fluid buildcraftFluidRedPlasma;
 
-
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent evt) {
+		if (isDisabled(evt.getModMetadata().modId)) {
+			disabled = true;
+			return;
+		}
 		int oilDesertBiomeId = BuildCraftCore.mainConfiguration.get("biomes", "biomeOilDesert", DefaultProps.BIOME_OIL_DESERT).getInt(DefaultProps.BIOME_OIL_DESERT);
 		int oilOceanBiomeId = BuildCraftCore.mainConfiguration.get("biomes", "biomeOilOcean", DefaultProps.BIOME_OIL_OCEAN).getInt(DefaultProps.BIOME_OIL_OCEAN);
 		canOilBurn = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "burnOil", true, "Can oil burn?").getBoolean(true);
@@ -343,6 +346,9 @@ public class BuildCraftEnergy extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void init(FMLInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		channels = NetworkRegistry.INSTANCE.newChannel
 				(DefaultProps.NET_CHANNEL_NAME + "-ENERGY", new BuildCraftChannelHandler(),  new PacketHandlerTransport());
 
@@ -362,7 +368,9 @@ public class BuildCraftEnergy extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
-
+		if (disabled) {
+			return;
+		}
 		if (BuildCraftCore.modifyWorld) {
 			MinecraftForge.EVENT_BUS.register(OilPopulate.INSTANCE);
 			MinecraftForge.TERRAIN_GEN_BUS.register(new BiomeInitializer());
@@ -372,6 +380,9 @@ public class BuildCraftEnergy extends BuildCraftMod {
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public void textureHook(TextureStitchEvent.Post event) {
+		if (disabled) {
+			return;
+		}
 		if (event.map.getTextureType() == 0) {
 			if (buildcraftFluidOil != null) {
 				buildcraftFluidOil.setIcons(blockOil.getBlockTextureFromSide(1), blockOil.getBlockTextureFromSide(2));
@@ -420,11 +431,17 @@ public class BuildCraftEnergy extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void processIMCRequests(FMLInterModComms.IMCEvent event) {
+		if (disabled) {
+			return;
+		}
 		InterModComms.processIMC(event);
 	}
 
 	@Mod.EventHandler
 	public void whiteListAppliedEnergetics(FMLInitializationEvent event) {
+		if (disabled) {
+			return;
+		}
 		FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
 				TileEngine.class.getCanonicalName());
 	}

--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -100,6 +100,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		FactoryProxy.proxy.initializeNEIIntegration();
 		if (quarryLoadsChunks) {
 			ForgeChunkManager.setForcedChunkLoadingCallback(instance, new QuarryChunkloadCallback());
@@ -146,6 +149,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void load(FMLInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		NetworkRegistry.INSTANCE.registerGuiHandler(instance, new GuiHandler());
 
 		// EntityRegistry.registerModEntity(EntityMechanicalArm.class, "bcMechanicalArm", EntityIds.MECHANICAL_ARM, instance, 50, 1, true);
@@ -177,6 +183,10 @@ public class BuildCraftFactory extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void initialize(FMLPreInitializationEvent evt) {
+		if (isDisabled(evt.getModMetadata().modId)) {
+			disabled = true;
+			return;
+		}
 		channels = NetworkRegistry.INSTANCE.newChannel
 				(DefaultProps.NET_CHANNEL_NAME + "-FACTORY", new BuildCraftChannelHandler(), new PacketHandlerFactory());
 
@@ -341,12 +351,18 @@ public class BuildCraftFactory extends BuildCraftMod {
 
 	@Mod.EventHandler
     public void processIMCRequests(FMLInterModComms.IMCEvent event) {
+		if (disabled) {
+			return;
+		}
         InterModComms.processIMC(event);
     }
 
 	@SubscribeEvent
 	@SideOnly(Side.CLIENT)
 	public void loadTextures(TextureStitchEvent.Pre evt) {
+		if (disabled) {
+			return;
+		}
 		if (evt.map.getTextureType() == 0) {
 			TextureMap terrainTextures = evt.map;
 			FactoryProxyClient.pumpTexture = terrainTextures.registerIcon("buildcraft:pump_tube");
@@ -357,6 +373,9 @@ public class BuildCraftFactory extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void whiteListAppliedEnergetics(FMLInitializationEvent event) {
+		if (disabled) {
+			return;
+		}
 		//FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
 		//		TileQuarry.class.getCanonicalName());
 		//FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",

--- a/common/buildcraft/BuildCraftMod.java
+++ b/common/buildcraft/BuildCraftMod.java
@@ -23,11 +23,13 @@ import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.relauncher.Side;
 
 import buildcraft.api.core.BCLog;
+import buildcraft.api.core.JavaTools;
 import buildcraft.core.DefaultProps;
 import buildcraft.core.network.BuildCraftPacket;
 
 public class BuildCraftMod {
 	public EnumMap<Side, FMLEmbeddedChannel> channels;
+	protected boolean disabled;
 
 	public void sendToPlayers(BuildCraftPacket packet, World world, int x, int y, int z, int maxDistance) {
 		try {
@@ -95,5 +97,17 @@ public class BuildCraftMod {
 		} catch (Throwable t) {
 			BCLog.logger.log(Level.WARN, "sendToServer crash", t);
 		}
+	}
+
+	protected boolean isDisabled(String modId) {
+		String[] disabledMods = BuildCraftCore.mainConfiguration
+				.get("general", "disabledMods", new String[0])
+				.getStringList();
+		for (String disabledMod : disabledMods) {
+			if (JavaTools.stripSurroundingQuotes(disabledMod).equals(modId)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/common/buildcraft/BuildCraftSilicon.java
+++ b/common/buildcraft/BuildCraftSilicon.java
@@ -133,6 +133,10 @@ public class BuildCraftSilicon extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent evt) {
+		if (isDisabled(evt.getModMetadata().modId)) {
+			disabled = true;
+			return;
+		}
 		chipsetCostMultiplier = BuildCraftCore.mainConfiguration.getFloat("chipset.costMultiplier", Configuration.CATEGORY_GENERAL, 1.0F, 0.001F, 1000.0F, "The multiplier for chipset recipe cost.");
 
 		blacklistedRobots = new ArrayList<String>();
@@ -201,6 +205,9 @@ public class BuildCraftSilicon extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void init(FMLInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		channels = NetworkRegistry.INSTANCE
 				.newChannel
 				(DefaultProps.NET_CHANNEL_NAME + "-SILICON", new BuildCraftChannelHandler(), new PacketHandlerSilicon());
@@ -339,11 +346,17 @@ public class BuildCraftSilicon extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void processRequests(FMLInterModComms.IMCEvent event) {
+		if (disabled) {
+			return;
+		}
 		InterModComms.processIMC(event);
 	}
 
 	@Mod.EventHandler
 	public void whiteListAppliedEnergetics(FMLInitializationEvent event) {
+		if (disabled) {
+			return;
+		}
 		FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
 				TileLaser.class.getCanonicalName());
 		FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
@@ -356,6 +369,9 @@ public class BuildCraftSilicon extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void remap(FMLMissingMappingsEvent event) {
+		if (disabled) {
+			return;
+		}
 		for (FMLMissingMappingsEvent.MissingMapping mapping: event.get()) {
 			if (mapping.name.equals("BuildCraft|Silicon:null")) {
 				if (mapping.type == GameRegistry.Type.ITEM) {

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -252,6 +252,10 @@ public class BuildCraftTransport extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void preInit(FMLPreInitializationEvent evt) {
+		if (isDisabled(evt.getModMetadata().modId)) {
+			disabled = true;
+			return;
+		}
 		try {
 			Property durability = BuildCraftCore.mainConfiguration.get(Configuration.CATEGORY_GENERAL, "pipes.durability", DefaultProps.PIPES_DURABILITY);
 			durability.comment = "How long a pipe will take to break";
@@ -430,6 +434,9 @@ public class BuildCraftTransport extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void init(FMLInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		channels = NetworkRegistry.INSTANCE.newChannel
 				(DefaultProps.NET_CHANNEL_NAME + "-TRANSPORT", new BuildCraftChannelHandler(), new PacketHandlerTransport());
 
@@ -474,6 +481,9 @@ public class BuildCraftTransport extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void postInit(FMLPostInitializationEvent evt) {
+		if (disabled) {
+			return;
+		}
 		facadeItem.initialize();
 		
 		if (debugPrintFacadeList) {
@@ -590,6 +600,9 @@ public class BuildCraftTransport extends BuildCraftMod {
 	
 	@Mod.EventHandler
 	public void processIMCRequests(IMCEvent event) {
+		if (disabled) {
+			return;
+		}
 		InterModComms.processIMC(event);
 	}
 
@@ -648,6 +661,9 @@ public class BuildCraftTransport extends BuildCraftMod {
 
 	@Mod.EventHandler
 	public void whiteListAppliedEnergetics(FMLInitializationEvent event) {
+		if (disabled) {
+			return;
+		}
 		FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",
 				TileGenericPipe.class.getCanonicalName());
 		FMLInterModComms.sendMessage("appliedenergistics2", "whitelist-spatial",

--- a/common/buildcraft/core/CreativeTabBuildCraft.java
+++ b/common/buildcraft/core/CreativeTabBuildCraft.java
@@ -10,6 +10,7 @@ package buildcraft.core;
 
 import java.util.Locale;
 
+import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -44,18 +45,35 @@ public enum CreativeTabBuildCraft {
 	private ItemStack getItem() {
 		switch (this) {
 		case BLOCKS:
-			return new ItemStack (BuildCraftFactory.quarryBlock, 1);
+			return getAvailableItem(BuildCraftFactory.quarryBlock, BuildCraftCore.ironGearItem);
 		case ITEMS:
-			return new ItemStack (BuildCraftCore.wrenchItem, 1);
+			return new ItemStack(BuildCraftCore.wrenchItem, 1);
 		case PIPES:
-			return new ItemStack (BuildCraftTransport.pipeItemsDiamond, 1);
+			return getAvailableItem(BuildCraftTransport.pipeItemsDiamond, BuildCraftCore.stoneGearItem);
 		case FACADES:
-			return BuildCraftTransport.facadeItem.getFacadeForBlock(Blocks.brick_block, 0);
+			return BuildCraftTransport.facadeItem != null ? BuildCraftTransport.facadeItem.getFacadeForBlock(Blocks.brick_block, 0)
+					: new ItemStack(BuildCraftCore.woodenGearItem, 1);
 		case BOARDS:
-			return new ItemStack(BuildCraftSilicon.redstoneBoard, 1);
+			return getAvailableItem(BuildCraftSilicon.redstoneBoard, BuildCraftCore.diamondGearItem);
 		}
 
-		return BuildCraftTransport.facadeItem.getFacadeForBlock(Blocks.brick_block, 0);
+		return new ItemStack(BuildCraftCore.wrenchItem, 1);
+	}
+
+	private ItemStack getAvailableItem(Object... items) {
+		for (Object item : items) {
+			if (item == null) {
+				continue;
+			}
+			if (item instanceof Item) {
+				return new ItemStack((Item) item, 1);
+			}
+			if (item instanceof Block) {
+				return new ItemStack((Block) item, 1);
+			}
+			throw new IllegalArgumentException();
+		}
+		return null;
 	}
 
 	private final class Tab extends CreativeTabs {


### PR DESCRIPTION
There is a lot of blocks and items on BuildCraft.
I think users can select needful mod.

Example:
(main.conf)
    S:disabledMods <
        "BuildCraft|Energy"
        "BuildCraft|Silicon"
        "BuildCraft|Transport"
     >

--> User can use core, builders, and factory.
    This is useful when using with EnderIO and others.
