### PR TITLE
Filter fix

### DIFF
--- a/common/buildcraft/transport/Pipe.java
+++ b/common/buildcraft/transport/Pipe.java
@@ -61,8 +61,8 @@ public abstract class Pipe<T extends PipeTransport> implements IDropControlInven
 		this.transport = transport;
 		this.item = item;
 
-		eventBus.registerHandler(this);
 		eventBus.registerHandler(new LensFilterHandler(this));
+		eventBus.registerHandler(this);
 	}
 
 	public void setTile(TileEntity tile) {


### PR DESCRIPTION
For https://github.com/BuildCraft/BuildCraft/issues/2372 .
Tested and confirmed to solve the problem. If the event bus truly handles events in order of registration, it should work fine.