### PR TITLE
Move the Wrench Rotate Block to Server-Side.

### DIFF
--- a/common/buildcraft/core/ItemWrench.java
+++ b/common/buildcraft/core/ItemWrench.java
@@ -49,6 +49,10 @@ public class ItemWrench extends ItemBuildCraft implements IToolWrench {
 
 	@Override
 	public boolean onItemUseFirst(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
+		if (world.isRemote) {
+			return false;
+		}
+
 		Block block = world.getBlock(x, y, z);
 
 		if (block == null) {


### PR DESCRIPTION
Otherwise it will bypass the possible canceling of the Server-Side Forge
PlayerInteract Event which is used by Protection mods like MyTown2.