### PR TITLE
Build no longer fails

### DIFF
--- a/guidelines/buildcraft.checkstyle
+++ b/guidelines/buildcraft.checkstyle
@@ -9,7 +9,7 @@
     Description: none
 -->
 <module name="Checker">	
-  <property name="severity" value="error"/>
+  <property name="severity" value="warning"/>
   <module name="SuppressionCommentFilter">
     <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
     <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>


### PR DESCRIPTION
Downgrade the severity to `warning` and it just show warnings instead of breaking the build. Sponge's checkstyle just function like [this] (https://travis-ci.org/SpongePowered/SpongeAPI/jobs/62960677#L256-L314). It works like [this] (https://travis-ci.org/BuildCraft/BuildCraft/builds/62951436#L424-L426) for BuildCraft.

Good Point:
  - It no longer fails.
  - We can see the warnings.

Bad:
  - Won't show the warnings if you don't see the log.
  - You might not be hardworking on checkstyle.