### PR TITLE
Actually use the render pass parameter - Fixes API calls that use renderPluggable with facades

### DIFF
--- a/common/buildcraft/transport/FacadePluggable.java
+++ b/common/buildcraft/transport/FacadePluggable.java
@@ -29,7 +29,7 @@ public class FacadePluggable extends PipePluggable implements IFacadePluggable {
 
 		@Override
 		public void renderPluggable(RenderBlocks renderblocks, IPipe pipe, ForgeDirection side, PipePluggable pipePluggable, ITextureStates blockStateMachine, int renderPass, int x, int y, int z) {
-			FacadeRenderHelper.pipeFacadeRenderer(renderblocks, blockStateMachine, pipe.getTile(), x, y, z, side, (IFacadePluggable) pipePluggable);
+			FacadeRenderHelper.pipeFacadeRenderer(renderblocks, blockStateMachine, pipe.getTile(), renderPass, x, y, z, side, (IFacadePluggable) pipePluggable);
 		}
 	}
 

--- a/common/buildcraft/transport/render/FacadeRenderHelper.java
+++ b/common/buildcraft/transport/render/FacadeRenderHelper.java
@@ -94,7 +94,7 @@ public final class FacadeRenderHelper {
 				rotated[2][1] - zOffsets[side.ordinal()]);
 	}
 
-	public static void pipeFacadeRenderer(RenderBlocks renderblocks, ITextureStates blockStateMachine, IPipeTile tile, int x, int y, int z, ForgeDirection direction, IFacadePluggable pluggable) {
+	public static void pipeFacadeRenderer(RenderBlocks renderblocks, ITextureStates blockStateMachine, IPipeTile tile, int renderPass, int x, int y, int z, ForgeDirection direction, IFacadePluggable pluggable) {
 		ITextureStates textureManager = blockStateMachine;
 		IIcon[] textures = ((TextureStateManager) textureManager.getTextureState()).popArray();
 
@@ -104,7 +104,7 @@ public final class FacadeRenderHelper {
 			IBlockAccess facadeBlockAccess = new FacadeBlockAccess(tile.getWorld(), direction);
 
 			// If the facade is meant to render in the current pass
-			if (renderBlock.canRenderInPass(PipeRendererWorld.renderPass)) {
+			if (renderBlock.canRenderInPass(renderPass)) {
 				int renderMeta = pluggable.getCurrentMetadata();
 
 				for (ForgeDirection side : ForgeDirection.VALID_DIRECTIONS) {
@@ -200,7 +200,7 @@ public final class FacadeRenderHelper {
 		textureManager.getTextureState().set(BuildCraftTransport.instance.pipeIconProvider.getIcon(PipeIconProvider.TYPE.PipeStructureCobblestone.ordinal())); // Structure Pipe
 
 		// Always render connectors in pass 0
-		if (PipeRendererWorld.renderPass == 0 && !pluggable.isHollow()) {
+		if (renderPass == 0 && !pluggable.isHollow()) {
 			float[][] rotated = MatrixTranformations.deepClone(zeroStateSupport);
 			MatrixTranformations.transform(rotated, direction);
 


### PR DESCRIPTION
Facades rendered on LP pipes are always invisible without this change.
This does not change anything on BC internals as `PipeRendererWorld.renderPass` is the same that is used to call the function anyway, but until now it was ignored.