### PR TITLE
Fixes handling of template extensions length != 3.

### DIFF
--- a/common/buildcraft/builders/LibraryDatabase.java
+++ b/common/buildcraft/builders/LibraryDatabase.java
@@ -157,7 +157,7 @@ public class LibraryDatabase {
 					String suffix = fileName.substring(sepIndex + 1);
 
 					id.name = prefix;
-					id.uniqueId = LibraryId.toBytes(suffix.substring(0, suffix.length() - 4));
+					id.uniqueId = LibraryId.toBytes(suffix.substring(0, suffix.length() - (extension.length() + 1)));
 				} else {
 					id.name = fileName.substring(0, dotIndex);
 					id.uniqueId = new byte[0];


### PR DESCRIPTION
When a template specifies an extension that is not of length 3 (such as the default `tpl` and `bpt` ones), loading the list currently generates broken entries, because the `uniqueId` is built assuming the extension length is always 3. The result is that such entries can neither be loaded nor deleted. This change should properly allow for arbitrary file extension lengths. (I say should, but I built it and tested it, and it worked).