### PR TITLE
Make mining robots work with gregtech ores

### DIFF
--- a/common/buildcraft/core/properties/WorldPropertyIsOre.java
+++ b/common/buildcraft/core/properties/WorldPropertyIsOre.java
@@ -10,12 +10,14 @@ package buildcraft.core.properties;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -56,12 +58,24 @@ public class WorldPropertyIsOre extends WorldProperty {
 		if (block == null) {
 			return false;
 		} else {
-			ItemStack stack = new ItemStack(block, 1, meta);
 
-			if (stack.getItem() != null) {
-				for (int id : OreDictionary.getOreIDs(stack)) {
-					if (ores.contains(id)) {
-						return true;
+			List<ItemStack> itemsDropped;
+			//Check for blocks that drop an item that is an ore
+			//On the off-chance blockAccess isn't a world, just get the itemstack from the block
+			if (blockAccess instanceof World) {
+				itemsDropped = block.getDrops((World) blockAccess, x, y, z, blockAccess.getBlockMetadata(x, y, z), 0);
+			} else {
+				itemsDropped = new ArrayList<ItemStack>();
+				ItemStack stack = new ItemStack(block, 1, meta);
+				itemsDropped.add(stack);
+			}
+			
+			for (ItemStack stack : itemsDropped) {
+				if (stack.getItem() != null) {
+					for (int id : OreDictionary.getOreIDs(stack)) {
+						if (ores.contains(id)) {
+							return true;
+						}
 					}
 				}
 			}

--- a/common/buildcraft/core/properties/WorldPropertyIsOre.java
+++ b/common/buildcraft/core/properties/WorldPropertyIsOre.java
@@ -59,13 +59,15 @@ public class WorldPropertyIsOre extends WorldProperty {
 			return false;
 		} else {
 
-			List<ItemStack> itemsDropped;
+			List<ItemStack> itemsDropped = new ArrayList<ItemStack>();
 			//Check for blocks that drop an item that is an ore
 			//On the off-chance blockAccess isn't a world, just get the itemstack from the block
 			if (blockAccess instanceof World) {
-				itemsDropped = block.getDrops((World) blockAccess, x, y, z, blockAccess.getBlockMetadata(x, y, z), 0);
+				itemsDropped.addAll(block.getDrops((World) blockAccess, x, y, z, blockAccess.getBlockMetadata(x, y, z), 0));
+				
+				//Make sure we grab things like redstone ore
+				itemsDropped.add(new ItemStack(block, 1, meta));
 			} else {
-				itemsDropped = new ArrayList<ItemStack>();
 				ItemStack stack = new ItemStack(block, 1, meta);
 				itemsDropped.add(stack);
 			}


### PR DESCRIPTION
Modified the ore check to check against what is actually dropped by the ore rather than the block itself.  This should fix almost any tile entity based ore.

Considerations:
getDrops() can be slightly slower than ItemStack(block, 1, meta) though in most cases should be unnoticeable.