### PR TITLE
Fix filters on another pipe making items prioritize sides

### DIFF
--- a/common/buildcraft/transport/LensFilterHandler.java
+++ b/common/buildcraft/transport/LensFilterHandler.java
@@ -37,12 +37,13 @@ public class LensFilterHandler {
 				pluggable = otherContainer.getPipePluggable(dir.getOpposite());
 				if (pluggable != null && pluggable instanceof LensPluggable && ((LensPluggable) pluggable).isFilter) {
 					int otherColor = ((LensPluggable) pluggable).color;
-					// Check if colors conflict - if so, the side is unpassable
-					if (sideColor >= 0 && otherColor != sideColor) {
-						continue;
-					} else {
-						sideColor = otherColor;
+					// if we are colored and this side is different one
+					if (myColor >= 0 && myColor != otherColor) {
+						continue; // This side is no use
 					}
+					// Else just do nothing, as filer is on another pipe
+					// it should not get priority so it is just another 'uncolored' side.
+
 				}
 			}
 


### PR DESCRIPTION
When item decides where to go it has take into account two filers. Exit filter on current pipe and input filter on pipe it would go.
Exit filter should give priority for this side but input filter that is on a pipe next to current should only work as filters (no priority)
Current behaviour is really counter-intuitive when there are filters on current pipe and pipe next to it.
This change allows for chaining of golden-iron pipes with filters used to make item prioritize one side.

This also means that uncoloured items will be able to enter through input filters. The exit filter behaviour is still the same.

This makes exit filters work as priority and strict filter (no uncoloured) and input filters as refusing only wrong colours.