### PR TITLE
Architect table render distance fix + other tweaks

### DIFF
--- a/common/buildcraft/builders/BlockArchitect.java
+++ b/common/buildcraft/builders/BlockArchitect.java
@@ -12,7 +12,6 @@ import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -22,7 +21,6 @@ import buildcraft.core.GuiIds;
 import buildcraft.core.lib.block.BlockBuildCraft;
 
 public class BlockArchitect extends BlockBuildCraft {
-	private IIcon[] led;
 
 	public BlockArchitect() {
 		super(Material.iron);

--- a/common/buildcraft/builders/TileArchitect.java
+++ b/common/buildcraft/builders/TileArchitect.java
@@ -21,6 +21,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraftforge.common.util.Constants;
 
 import buildcraft.BuildCraftCore;
@@ -350,4 +351,10 @@ public class TileArchitect extends TileBuildCraft implements IInventory, IBoxPro
 	public int getLEDLevel(int led) {
 		return (led == 0 ? isProcessing : box != null && box.isInitialized()) ? 15 : 0;
 	}
+	
+	@Override
+	@SideOnly(Side.CLIENT)
+    public double getMaxRenderDistanceSquared() {
+        return Double.MAX_VALUE;
+    }
 }

--- a/common/buildcraft/transport/utils/FluidRenderData.java
+++ b/common/buildcraft/transport/utils/FluidRenderData.java
@@ -19,6 +19,6 @@ public class FluidRenderData {
 		if (s == null) {
 			return 0;
 		}
-		return s.getFluid().getLuminosity();
+		return s.getFluid().getLuminosity(s);
 	}
 }


### PR DESCRIPTION
-Removed unused field on BlockArchitect
-Architect table area box not being visible from far away. It now uses the same render distance as the Builder. Closes #2921
-Use FluidStack sensitive version of Fluid.getLuminosity()