### PR TITLE
Fix builder inconsistently respecting OreDict

### DIFF
--- a/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
+++ b/common/buildcraft/core/blueprints/BptBuilderBlueprint.java
@@ -611,7 +611,7 @@ public class BptBuilderBlueprint extends BptBuilderBase {
 				FluidStack fluidStack = fluid != null ? FluidContainerRegistry.getFluidForFilledItem(invStk) : null;
 				boolean fluidFound = fluidStack != null && fluidStack.getFluid() == fluid && fluidStack.amount >= FluidContainerRegistry.BUCKET_VOLUME;
 
-				if (fluidFound || StackHelper.isCraftingEquivalent(reqStk, invStk, true)) {
+				if (fluidFound || StackHelper.isMatchingItem(reqStk, invStk, true, true)) {
 					try {
 						usedStack = slot.getSchematic().useItem(context, reqStk, slotInv);
 						slot.addStackConsumed (usedStack);


### PR DESCRIPTION
BptBuilderBlueprint.checkRequirements expects an exact match, but
BptBuilderBlueprint.useRequirements will accept ore-dictionary (and
other?) equivalent items.