### PR TITLE
Kinesis Pipes throughput can be changed via config

### DIFF
--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -297,7 +297,13 @@ public class BuildCraftTransport extends BuildCraftMod {
 
 		try {
 			BuildCraftCore.mainConfigManager.register("experimental.kinesisPowerLossOnTravel", false, "Should kinesis pipes lose power over distance (think IC2 or BC pre-3.7)?", ConfigManager.RestartRequirement.WORLD);
-
+			BuildCraftCore.mainConfigManager.register("power.cobblestoneKinesisPipe", 80, "Set the Cobblestone kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.stoneKinesisPipe", 160, "Set the Stone kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.sandstoneKinesisPipe", 320, "Set the Sandstone kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.quartzKinesisPipe", 640, "Set the Quartz kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.ironKinesisPipe", 1280, "Set the Iron kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.goldKinesisPipe", 2560, "Set the Gold kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
+			BuildCraftCore.mainConfigManager.register("power.diamondKinesisPipe", 10240, "Set the Diamond kinesis pipe throughput.", ConfigManager.RestartRequirement.GAME);
 			BuildCraftCore.mainConfigManager.register("general.pipes.hardness", DefaultProps.PIPES_DURABILITY, "How hard to break should a pipe be?", ConfigManager.RestartRequirement.NONE);
 			BuildCraftCore.mainConfigManager.register("general.pipes.baseFluidRate", DefaultProps.PIPES_FLUIDS_BASE_FLOW_RATE, "What should the base flow rate of a fluid pipe be?", ConfigManager.RestartRequirement.GAME)
 					.setMinValue(1).setMaxValue(40);

--- a/common/buildcraft/core/PowerMode.java
+++ b/common/buildcraft/core/PowerMode.java
@@ -1,8 +1,15 @@
 package buildcraft.core;
 
+import buildcraft.BuildCraftCore;
 public enum PowerMode {
 
-	M2(20), M4(40), M8(80), M16(160), M32(320), M64(640), M128(1280);
+	M2(BuildCraftCore.mainConfigManager.get("power.cobblestoneKinesisPipe").getInt()),
+	M4(BuildCraftCore.mainConfigManager.get("power.stoneKinesisPipe").getInt()),
+	M8(BuildCraftCore.mainConfigManager.get("power.sandstoneKinesisPipe").getInt()),
+	M16(BuildCraftCore.mainConfigManager.get("power.quartzKinesisPipe").getInt()),
+	M32(BuildCraftCore.mainConfigManager.get("power.ironKinesisPipe").getInt()),
+	M64(BuildCraftCore.mainConfigManager.get("power.goldKinesisPipe").getInt()),
+	M128(BuildCraftCore.mainConfigManager.get("power.diamondKinesisPipe").getInt());
 	public static final PowerMode[] VALUES = values();
 	public final int maxPower;
 

--- a/common/buildcraft/transport/PipeTransportPower.java
+++ b/common/buildcraft/transport/PipeTransportPower.java
@@ -470,15 +470,16 @@ public class PipeTransportPower extends PipeTransport implements IDebuggable {
 	}
 
 	static {
-		powerCapacities.put(PipePowerCobblestone.class, 80);
-		powerCapacities.put(PipePowerStone.class, 160);
+		powerCapacities.put(PipePowerCobblestone.class, BuildCraftCore.mainConfigManager.get("power.cobblestoneKinesisPipe").getInt());
+		powerCapacities.put(PipePowerStone.class, BuildCraftCore.mainConfigManager.get("power.stoneKinesisPipe").getInt());
 		powerCapacities.put(PipePowerWood.class, 10240);
-        powerCapacities.put(PipePowerSandstone.class, 320);
-		powerCapacities.put(PipePowerQuartz.class, 640);
-		powerCapacities.put(PipePowerIron.class, 1280);
-		powerCapacities.put(PipePowerGold.class, 2560);
+        powerCapacities.put(PipePowerSandstone.class, BuildCraftCore.mainConfigManager.get("power.sandstoneKinesisPipe").getInt());
+		powerCapacities.put(PipePowerQuartz.class, BuildCraftCore.mainConfigManager.get("power.quartzKinesisPipe").getInt());
+		powerCapacities.put(PipePowerIron.class, BuildCraftCore.mainConfigManager.get("power.ironKinesisPipe").getInt());
+		powerCapacities.put(PipePowerGold.class, BuildCraftCore.mainConfigManager.get("power.goldKinesisPipe").getInt());
 		powerCapacities.put(PipePowerEmerald.class, 10240);
-		powerCapacities.put(PipePowerDiamond.class, 10240);
+		powerCapacities.put(PipePowerDiamond.class, BuildCraftCore.mainConfigManager.get("power.diamondKinesisPipe").getInt());
+
 
 		powerResistances.put(PipePowerCobblestone.class, 0.05F);
 		powerResistances.put(PipePowerStone.class, 0.025F);


### PR DESCRIPTION
This allows the max RF/t of a kinesis pipe to be changed via a config option. Changes to the config are also applied to the Iron pipe and Creative engine.