### PR TITLE
More Ore Dictionary support for recipes

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -616,10 +616,10 @@ public class BuildCraftBuilders extends BuildCraftMod {
 			"dyeBlack", 'p', Items.paper);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(blueprintItem, 1), "ppp", "pip", "ppp", 'i',
-			new ItemStack(Items.dye, 1, 4), 'p', Items.paper);
+			"gemLapis", 'p', Items.paper);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(markerBlock, 1), "l ", "r ", 'l',
-			new ItemStack(Items.dye, 1, 4), 'r', Blocks.redstone_torch);
+			"gemLapis", 'r', Blocks.redstone_torch);
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(pathMarkerBlock, 1), "l ", "r ", 'l',
 			"dyeGreen", 'r', Blocks.redstone_torch);
@@ -629,15 +629,15 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(fillerBlock, 1), "btb", "ycy", "gCg", 'b',
 			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
-			'c', Blocks.crafting_table, 'g', "gearGold", 'C', Blocks.chest);
+			'c', "craftingTableWood", 'g', "gearGold", 'C', "chestWood");
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(builderBlock, 1), "btb", "ycy", "gCg", 'b',
 			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
-			'c', Blocks.crafting_table, 'g', "gearDiamond", 'C', Blocks.chest);
+			'c', "craftingTableWood", 'g', "gearDiamond", 'C', "chestWood");
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(architectBlock, 1), "btb", "ycy", "gCg", 'b',
 			"dyeBlack", 't', markerBlock, 'y', "dyeYellow",
-			'c', Blocks.crafting_table, 'g', "gearDiamond", 'C',
+			'c', "craftingTableWood", 'g', "gearDiamond", 'C',
 			new ItemStack(blueprintItem, 1));
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(libraryBlock, 1), "bbb", "bBb", "bbb", 'b',

--- a/common/buildcraft/BuildCraftCore.java
+++ b/common/buildcraft/BuildCraftCore.java
@@ -364,6 +364,9 @@ public class BuildCraftCore extends BuildCraftMod {
 		FMLCommonHandler.instance().bus().register(this);
 		MinecraftForge.EVENT_BUS.register(this);
 		MinecraftForge.EVENT_BUS.register(new BlockHighlightHandler());
+
+		OreDictionary.registerOre("chestWood", Blocks.chest);
+		OreDictionary.registerOre("craftingTableWood", Blocks.crafting_table);
 	}
 
 	@Mod.EventHandler

--- a/common/buildcraft/BuildCraftFactory.java
+++ b/common/buildcraft/BuildCraftFactory.java
@@ -198,14 +198,14 @@ public class BuildCraftFactory extends BuildCraftMod {
 		if (autoWorkbenchBlock != null) {
 			CoreProxy.proxy.addCraftingRecipe(new ItemStack(autoWorkbenchBlock),
 					"gwg",
-					'w', Blocks.crafting_table,
+					'w', "craftingTableWood",
 					'g', "gearStone");
 
 			CoreProxy.proxy.addCraftingRecipe(new ItemStack(autoWorkbenchBlock),
 					"g",
 					"w",
 					"g",
-					'w', Blocks.crafting_table,
+					'w', "craftingTableWood",
 					'g', "gearStone");
 		}
 
@@ -232,7 +232,7 @@ public class BuildCraftFactory extends BuildCraftMod {
 					"ICI",
 					" G ",
 					'I', "ingotIron",
-					'C', Blocks.chest,
+					'C', "chestWood",
 					'G', "gearStone");
 
 			CoreProxy.proxy.addShapelessRecipe(new ItemStack(hopperBlock), Blocks.hopper, "gearStone");

--- a/common/buildcraft/BuildCraftRobotics.java
+++ b/common/buildcraft/BuildCraftRobotics.java
@@ -367,7 +367,7 @@ public class BuildCraftRobotics extends BuildCraftMod {
 				"IPI",
 				"GCG",
 				"IRI",
-				'C', Blocks.chest,
+				'C', "chestWood",
 				'R', "dustRedstone",
 				'P', Blocks.piston,
 				'G', "gearIron",

--- a/common/buildcraft/BuildCraftSilicon.java
+++ b/common/buildcraft/BuildCraftSilicon.java
@@ -237,7 +237,7 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"OGO",
 				'O', Blocks.obsidian,
 				'R', new ItemStack(redstoneChipset, 1, 0),
-				'C', Items.emerald,
+				'C', "gemEmerald",
 				'G', "gearDiamond");
 
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(assemblyTableBlock, 1, 5),
@@ -245,7 +245,7 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"ORO",
 				"OGO",
 				'O', Blocks.obsidian,
-				'W', Blocks.crafting_table,
+				'W', "craftingTableWood",
 				'G', "gearGold",
 				'R', new ItemStack(redstoneChipset, 1, 0));
 
@@ -254,7 +254,7 @@ public class BuildCraftSilicon extends BuildCraftMod {
 				"ICI",
 				" P ",
 				'I', "ingotIron",
-				'C', Blocks.crafting_table,
+				'C', "craftingTableWood",
 				'P', Blocks.piston);
 
 		// CHIPSETS

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -648,7 +648,7 @@ public class BuildCraftTransport extends BuildCraftMod {
 		
 		CoreProxy.proxy.addCraftingRecipe(new ItemStack(filteredBufferBlock, 1),
 				"wdw", "wcw", "wpw", 'w', "plankWood", 'd',
-				BuildCraftTransport.pipeItemsDiamond, 'c', Blocks.chest, 'p',
+				BuildCraftTransport.pipeItemsDiamond, 'c', "chestWood", 'p',
 				Blocks.piston);
 
 		//Facade turning helper
@@ -676,11 +676,11 @@ public class BuildCraftTransport extends BuildCraftMod {
 				String dye = ColorUtils.getOreDictionaryName(15 - i);
 				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(lensItem, 8, i),
 						"OSO", "SGS", "OSO",
-						'O', "ingotIron", 'S', dye, 'G', "blockGlass"
+						'O', "ingotIron", 'S', "dye", 'G', "blockGlass"
 						));
 				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(lensItem, 8, i + 16),
 						"OSO", "SGS", "OSO",
-						'O', Blocks.iron_bars, 'S', dye, 'G', "blockGlass"
+						'O', Blocks.iron_bars, 'S', "dye", 'G', "blockGlass"
 				));
 			}
 		}

--- a/common/buildcraft/BuildCraftTransport.java
+++ b/common/buildcraft/BuildCraftTransport.java
@@ -676,11 +676,11 @@ public class BuildCraftTransport extends BuildCraftMod {
 				String dye = ColorUtils.getOreDictionaryName(15 - i);
 				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(lensItem, 8, i),
 						"OSO", "SGS", "OSO",
-						'O', "ingotIron", 'S', "dye", 'G', "blockGlass"
+						'O', "ingotIron", 'S', dye, 'G', "blockGlass"
 						));
 				GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(lensItem, 8, i + 16),
 						"OSO", "SGS", "OSO",
-						'O', Blocks.iron_bars, 'S', "dye", 'G', "blockGlass"
+						'O', Blocks.iron_bars, 'S', dye, 'G', "blockGlass"
 				));
 			}
 		}


### PR DESCRIPTION
Chests and crafting tables were registered in Ore Dictionary to support Wood Stuff mod by ganymedes01. I've decided to make a PR for 7.0.x branch instead of 7.1.x since 7.1.x still in Beta and there are no ETA when it's out from Beta. I've tested this in-game and didn't found any issues, so it's shouldn't hurt anything. (I know very little about coding mods, so I'm not sure that I've put OreDictionary.registerOre strings into correct place but at least it works)