### PR TITLE
Fix mcmod.info

### DIFF
--- a/misc/dist.sh
+++ b/misc/dist.sh
@@ -18,7 +18,9 @@ for i in `find -name *.png`; do ../../tools/pngout "$i"; done
 
 # Function to extract modules mcmod.info data
 modinfo(){
-	../../tools/jq ".[] | select( .modid == \"$1\" )" mcmod.info.json > mcmod.info
+	modinfo=$(../../tools/jq ".[] | select( .modid == \"$1\" )" mcmod.info.json)
+	echo "[$modinfo]" > mcmod.info
+	clear modinfo
 }
 
 # Move mcmod.info for safe keeping


### PR DESCRIPTION
Adds square brackets at the beginning and end of the modules mcmod.info file.

This fixes issue #3034.

Sorry I didn't notice this issue sooner.