### PR TITLE
Fix compositeTank capacity calculation

### DIFF
--- a/common/buildcraft/factory/TileTank.java
+++ b/common/buildcraft/factory/TileTank.java
@@ -261,7 +261,7 @@ public class TileTank extends TileBuildCraft implements IFluidHandler {
 
 		TileTank tile = getBottomTank();
 
-		int capacity = tank.getCapacity();
+		int capacity = tile.tank.getCapacity();
 
 		if (tile != null && tile.tank.getFluid() != null) {
 			compositeTank.setFluid(tile.tank.getFluid().copy());


### PR DESCRIPTION
Correct a logic error in the calculation of the capacity of a tank stack (compositeTank) which could cause an incorrect total capacity calculation if individual tiles in the stack have different capacities.

Line 264 was incorrectly using the wrong tank object (the current one, not the bottom one). This fixes indemnity83/irontank#6 and possibly others where the BuildCraft TileTank is extended. 