### PR TITLE
Improve tank texturing logic

### DIFF
--- a/common/buildcraft/factory/BlockTank.java
+++ b/common/buildcraft/factory/BlockTank.java
@@ -82,7 +82,7 @@ public class BlockTank extends BlockBuildCraft {
 	@SuppressWarnings({"all"})
 	@Override
 	public IIcon getIconAbsolute(IBlockAccess iblockaccess, int i, int j, int k, int side, int metadata) {
-		if (side >= 2 && iblockaccess.getBlock(i, j - 1, k) == this) {
+		if (side >= 2 && iblockaccess.getBlock(i, j - 1, k) instanceof BlockTank) {
 			return textureStackedSide;
 		} else {
 			return super.getIconAbsolute(side, metadata);
@@ -197,7 +197,7 @@ public class BlockTank extends BlockBuildCraft {
 	@Override
 	public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int side) {
 		if (side <= 1) {
-			return world.getBlock(x, y, z) != this;
+			return !(world.getBlock(x, y, z) instanceof BlockTank);
 		} else {
 			return super.shouldSideBeRendered(world, x, y, z, side);
 		}


### PR DESCRIPTION
The side texturing logic for the block is specifically looking for 'this' block instead of looking more generically if the block is an instance of BlockTank which means blocks extended from BlockTank do not render correctly when mixed. 

This brings the graphical portion of the BlockTank in-line with the way the TileTank actually works (checking instanceof when moving up and down a stack, not 'this'). 