### PR TITLE
Allow builders to place floating tripwires

### DIFF
--- a/common/buildcraft/BuildCraftBuilders.java
+++ b/common/buildcraft/BuildCraftBuilders.java
@@ -124,6 +124,7 @@ import buildcraft.builders.schematics.SchematicSilverfish;
 import buildcraft.builders.schematics.SchematicSkull;
 import buildcraft.builders.schematics.SchematicStone;
 import buildcraft.builders.schematics.SchematicTripWireHook;
+import buildcraft.builders.schematics.SchematicTripwire;
 import buildcraft.builders.statements.BuildersActionProvider;
 import buildcraft.core.BCRegistry;
 import buildcraft.core.CompatHooks;
@@ -134,7 +135,6 @@ import buildcraft.core.TilePathMarker;
 import buildcraft.core.Version;
 import buildcraft.core.blueprints.SchematicRegistry;
 import buildcraft.core.builders.schematics.SchematicBlockCreative;
-import buildcraft.core.builders.schematics.SchematicBlockFloored;
 import buildcraft.core.builders.schematics.SchematicFree;
 import buildcraft.core.builders.schematics.SchematicIgnore;
 import buildcraft.core.builders.schematics.SchematicRotateMeta;
@@ -371,7 +371,7 @@ public class BuildCraftBuilders extends BuildCraftMod {
 
 		schemes.registerSchematicBlock(Blocks.flower_pot, SchematicTile.class);
 
-		schemes.registerSchematicBlock(Blocks.tripwire, SchematicBlockFloored.class);
+		schemes.registerSchematicBlock(Blocks.tripwire, SchematicTripwire.class);
 		schemes.registerSchematicBlock(Blocks.tripwire_hook, SchematicTripWireHook.class);
 
 		schemes.registerSchematicBlock(Blocks.skull, SchematicSkull.class);

--- a/common/buildcraft/builders/schematics/SchematicTripwire.java
+++ b/common/buildcraft/builders/schematics/SchematicTripwire.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2011-2015, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ * <p/>
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.builders.schematics;
+
+import java.util.LinkedList;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+
+import buildcraft.api.blueprints.IBuilderContext;
+import buildcraft.api.blueprints.SchematicBlock;
+
+public class SchematicTripwire extends SchematicBlock {
+
+	@Override
+	public void getRequirementsForPlacement(IBuilderContext context, LinkedList<ItemStack> requirements) {
+		requirements.add(new ItemStack(Items.string));
+	}
+
+	@Override
+	public void storeRequirements(IBuilderContext context, int x, int y, int z) {
+		// cancel requirements reading
+	}
+
+	@Override
+	public void placeInWorld(IBuilderContext context, int x, int y, int z, LinkedList<ItemStack> stacks) {
+		context.world().setBlock(x, y, z, Blocks.tripwire, 0, 3);
+	}
+
+	@Override
+	public boolean isAlreadyBuilt(IBuilderContext context, int x, int y, int z) {
+		return context.world().getBlock(x, y, z) == Blocks.tripwire;
+	}
+}


### PR DESCRIPTION
The builder was using BlockFloored for the tripwire(string), but tripwires can be placed in the air without a supporting block - this allows this behaviour.