### PR TITLE
middleReached never true on Item Transport Pipes

### DIFF
--- a/common/buildcraft/transport/PipeTransportItems.java
+++ b/common/buildcraft/transport/PipeTransportItems.java
@@ -368,8 +368,8 @@ public class PipeTransportItems extends PipeTransport implements IDebuggable {
     }
 
     protected boolean middleReached(TravelingItem item) {
-        float middleLimit = item.getSpeed() * 1.01F;
-        return Utils.convertMiddle(container.getPos()).subtract(item.pos).lengthVector() < middleLimit;
+        //float middleLimit = item.getSpeed() * 1.01F;
+        return Utils.convertMiddle(container.getPos()).subtract(item.pos).lengthVector() < 0.3;
     }
 
     protected boolean endReached(TravelingItem item) {


### PR DESCRIPTION
Fixes: Item pipes don't work properly AlexIIL/Buildcraft_1.8_Issues#55

Can't see the need to multiply by item speed, as is already comparing the base container and travelling item positions.