### PR TITLE
Prevent Crash and error logs from coreState.pipeId

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -260,7 +260,7 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler, IPipeT
         if (pipe != null) {
             nbt.setString("pipeId", Item.itemRegistry.getNameForObject(pipe.item).toString());
             pipe.writeToNBT(nbt);
-        } else {
+        } else if (coreState.pipeId != null){
             nbt.setString("pipeId", coreState.pipeId);
         }
 
@@ -298,12 +298,15 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler, IPipeT
             if (loc == null) coreState.pipeId = "";
             else coreState.pipeId = loc.toString();
         }
-        Item item = Item.itemRegistry.getObject(new ResourceLocation(coreState.pipeId));
-        if (item instanceof ItemPipe) {
-            pipe = BlockGenericPipe.createPipe((ItemPipe) item);
-        } else {
-            BCLog.logger.warn(item + " was not an instanceof ItemPipe!" + coreState.pipeId);
-            pipe = null;
+        // TODO: Find out why coreState.pipeId is sometimes null
+        if(coreState.pipeId != null) {
+            Item item = Item.itemRegistry.getObject(new ResourceLocation(coreState.pipeId));
+            if (item instanceof ItemPipe) {
+                pipe = BlockGenericPipe.createPipe((ItemPipe) item);
+            } else {
+                BCLog.logger.warn(item + " was not an instanceof ItemPipe!" + coreState.pipeId);
+                pipe = null;
+            }
         }
 
         bindPipe();


### PR DESCRIPTION
This fixes #3199 and AlexIIL/Buildcraft_1.8_Issues#109 

Prevents errors and also allowed removal of the invalid/invisible pipes from my test world, although doesn't explain the cause, added todo.