### PR TITLE
Add thread names for Robotics/Tablet manager

### DIFF
--- a/common/buildcraft/BuildCraftRobotics.java
+++ b/common/buildcraft/BuildCraftRobotics.java
@@ -328,7 +328,7 @@ public class BuildCraftRobotics extends BuildCraftMod {
         stopMapManager();
 
         manager = new MapManager(f);
-        managerThread = new Thread(manager);
+        managerThread = new Thread(manager, "BuildCraft Robotics Manager");
         managerThread.start();
 
         BoardRobotPicker.onServerStart();

--- a/common/buildcraft/core/tablet/manager/TabletManagerClient.java
+++ b/common/buildcraft/core/tablet/manager/TabletManagerClient.java
@@ -15,7 +15,7 @@ public enum TabletManagerClient {
         if (currentTablet == null) {
             currentTablet = new TabletClient();
             currentTabletThread = new TabletThread(currentTablet);
-            new Thread(currentTabletThread).start();
+            new Thread(currentTabletThread, "BuildCraft Tablet Manager").start();
         }
         return currentTabletThread;
     }

--- a/common/buildcraft/core/tablet/manager/TabletManagerServer.java
+++ b/common/buildcraft/core/tablet/manager/TabletManagerServer.java
@@ -19,7 +19,7 @@ public enum TabletManagerServer {
             TabletServer tablet = new TabletServer(player);
             TabletThread thread = new TabletThread(tablet);
             threads.put(player, thread);
-            new Thread(thread).start();
+            new Thread(thread, "BuildCraft Tablet Manager").start();
         }
         return (TabletServer) threads.get(player).getTablet();
     }


### PR DESCRIPTION
Seeing Thread-xx in thread dumps isn't great.