### PR TITLE
Fixed Shift-Click crash (#3479)

### DIFF
--- a/common/buildcraft/energy/container/ContainerEngineStone_BC8.java
+++ b/common/buildcraft/energy/container/ContainerEngineStone_BC8.java
@@ -6,6 +6,8 @@ import net.minecraft.inventory.IContainerListener;
 import buildcraft.energy.tile.TileEngineStone_BC8;
 import buildcraft.lib.gui.ContainerBCTile;
 import buildcraft.lib.gui.slot.SlotBase;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntityFurnace;
 
 public class ContainerEngineStone_BC8 extends ContainerBCTile<TileEngineStone_BC8> {
     private static final int PLAYER_INV_START = 84;
@@ -14,7 +16,12 @@ public class ContainerEngineStone_BC8 extends ContainerBCTile<TileEngineStone_BC
         super(player, engine);
 
         addFullPlayerInventory(PLAYER_INV_START);
-        addSlotToContainer(new SlotBase(engine.invFuel, 0, 80, 41));
+        addSlotToContainer(new SlotBase(engine.invFuel, 0, 80, 41) {
+            @Override
+            public boolean isItemValid(ItemStack stack) {
+                return TileEntityFurnace.getItemBurnTime(stack) > 0;
+            }
+        });
     }
     
     @Override

--- a/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
+++ b/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
@@ -47,7 +47,6 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
     public final ItemHandlerSimple invResult;
     public final ItemHandlerSimple invOverflow;
     protected final Map<ItemStackKey, TIntHashSet> itemStackCache;
-    private ItemHandlerSimple invMaterialsCopy = null;
 
     public IRecipe currentRecipe;
     private int progress = 0;
@@ -94,7 +93,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         // craft 1 item
         updateRecipe();
         if (hasMaterialsForRecipe()) {
-         /*   if (progress == 0) {
+            if (progress == 0) {
                 deltaProgress.addDelta(0, 200, 100);
                 deltaProgress.addDelta(200, 205, -100);
             }
@@ -107,7 +106,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
                 ItemStack leftOver = invResult.insertItem(0, out, false);
                 InventoryUtil.drop(getWorld(), getPos(), leftOver);
                 progress = 0;
-            }*/
+            }
         } else if (progress != -1) {
             progress = -1;
             deltaProgress.setValue(0);
@@ -118,22 +117,10 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         if (currentRecipe == null) {
             return false;
         }
-        invMaterialsCopy = copyInvMaterials();
         crafting.enableBindings();
         boolean has = currentRecipe.matches(crafting, getWorld());
         crafting.disableBindings();
-        invMaterialsCopy = null;
         return has;
-    }
-
-    private ItemHandlerSimple copyInvMaterials() {
-        ItemHandlerSimple newItemHandler = itemManager.addInvHandler("materials", invMaterials.getSlots(), EnumAccess.INSERT, EnumPipePart.VALUES);
-
-        for(int i = 0; i < invMaterials.getSlots(); ++i) {
-            newItemHandler.setStackInSlot(i, invMaterials.getStackInSlot(i));
-        }
-
-        return newItemHandler;
     }
 
     @Override
@@ -165,8 +152,6 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         // }
     }
 
-
-    // todo: itemStackCache doesn't always get updated properly
     @Override
     protected void onSlotChange(IItemHandlerModifiable handler, int slot, ItemStack before, ItemStack after) {
         super.onSlotChange(handler, slot, before, after);
@@ -367,8 +352,8 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
                 return StackUtil.EMPTY;
             }
             for (int s : boundTo.toArray()) {
-                if (!invMaterialsCopy.getStackInSlot(s).isEmpty()) {
-                    ItemStack inSlot = invMaterialsCopy.extractItem(s, 1, false);
+                if (!invMaterials.getStackInSlot(s).isEmpty()) {
+                    ItemStack inSlot = invMaterials.extractItem(s, 1, true);
                     if (!inSlot.isEmpty()) {
                         return inSlot;
                     }

--- a/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
+++ b/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
@@ -47,6 +47,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
     public final ItemHandlerSimple invResult;
     public final ItemHandlerSimple invOverflow;
     protected final Map<ItemStackKey, TIntHashSet> itemStackCache;
+    private ItemHandlerSimple invMaterialsCopy = null;
 
     public IRecipe currentRecipe;
     private int progress = 0;
@@ -93,7 +94,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         // craft 1 item
         updateRecipe();
         if (hasMaterialsForRecipe()) {
-            if (progress == 0) {
+         /*   if (progress == 0) {
                 deltaProgress.addDelta(0, 200, 100);
                 deltaProgress.addDelta(200, 205, -100);
             }
@@ -106,7 +107,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
                 ItemStack leftOver = invResult.insertItem(0, out, false);
                 InventoryUtil.drop(getWorld(), getPos(), leftOver);
                 progress = 0;
-            }
+            }*/
         } else if (progress != -1) {
             progress = -1;
             deltaProgress.setValue(0);
@@ -117,10 +118,22 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         if (currentRecipe == null) {
             return false;
         }
+        invMaterialsCopy = copyInvMaterials();
         crafting.enableBindings();
         boolean has = currentRecipe.matches(crafting, getWorld());
         crafting.disableBindings();
+        invMaterialsCopy = null;
         return has;
+    }
+
+    private ItemHandlerSimple copyInvMaterials() {
+        ItemHandlerSimple newItemHandler = itemManager.addInvHandler("materials", invMaterials.getSlots(), EnumAccess.INSERT, EnumPipePart.VALUES);
+
+        for(int i = 0; i < invMaterials.getSlots(); ++i) {
+            newItemHandler.setStackInSlot(i, invMaterials.getStackInSlot(i));
+        }
+
+        return newItemHandler;
     }
 
     @Override
@@ -152,6 +165,8 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         // }
     }
 
+
+    // todo: itemStackCache doesn't always get updated properly
     @Override
     protected void onSlotChange(IItemHandlerModifiable handler, int slot, ItemStack before, ItemStack after) {
         super.onSlotChange(handler, slot, before, after);
@@ -352,8 +367,8 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
                 return StackUtil.EMPTY;
             }
             for (int s : boundTo.toArray()) {
-                if (!invMaterials.getStackInSlot(s).isEmpty()) {
-                    ItemStack inSlot = invMaterials.extractItem(s, 1, true);
+                if (!invMaterialsCopy.getStackInSlot(s).isEmpty()) {
+                    ItemStack inSlot = invMaterialsCopy.extractItem(s, 1, false);
                     if (!inSlot.isEmpty()) {
                         return inSlot;
                     }

--- a/common/buildcraft/lib/gui/ContainerBC_Neptune.java
+++ b/common/buildcraft/lib/gui/ContainerBC_Neptune.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
@@ -100,6 +101,52 @@ public abstract class ContainerBC_Neptune extends Container {
             return itemStack;
         }
         return super.slotClick(slotId, dragType, clickType, player);
+    }
+
+    @Override
+    public ItemStack transferStackInSlot(EntityPlayer playerIn, int index) {
+        ItemStack itemstack = ItemStack.EMPTY;
+        Slot slot = this.inventorySlots.get(index);
+        Slot firstSlot = this.inventorySlots.get(0);
+        int playerInventorySize = 36;
+        boolean playerInventoryFirst = firstSlot.inventory instanceof InventoryPlayer;
+
+        if (slot != null && slot.getHasStack())
+        {
+            ItemStack itemstack1 = slot.getStack();
+            itemstack = itemstack1.copy();
+
+            if(inventorySlots.size() == playerInventorySize) return ItemStack.EMPTY;
+            if(playerInventoryFirst) {
+                if (index < playerInventorySize) {
+                    if (!this.mergeItemStack(itemstack1, playerInventorySize, this.inventorySlots.size(), false)) {
+                        return ItemStack.EMPTY;
+                    }
+                } else if (!this.mergeItemStack(itemstack1, 0, playerInventorySize, true)) {
+                    return ItemStack.EMPTY;
+                }
+            }
+            else {
+                if (index < this.inventorySlots.size()-playerInventorySize) {
+                    if (!this.mergeItemStack(itemstack1, this.inventorySlots.size()-playerInventorySize, this.inventorySlots.size(), false)) {
+                        return ItemStack.EMPTY;
+                    }
+                } else if (!this.mergeItemStack(itemstack1, 0, this.inventorySlots.size()-playerInventorySize, true)) {
+                    return ItemStack.EMPTY;
+                }
+            }
+
+            if (itemstack1.isEmpty())
+            {
+                slot.putStack(ItemStack.EMPTY);
+            }
+            else
+            {
+                slot.onSlotChanged();
+            }
+        }
+
+        return itemstack;
     }
 
     public static ItemStack safeCopy(ItemStack in) {


### PR DESCRIPTION
I think I fixed the crashes caused by Shift-Clinking in any BC Container.

The crash is caused by the slotClick() function ofnet.minecraft.inventory.Container
which calls transferStackInSlot(). ContainerBC_Neptune didn't override this method, the default implementation was called which basicly does nothing. After this, slotClick() checks whether the transfer was successful and retrys if not. Since the transfer didn't happen it falls into an infinite loop and crashes.

ContainerEngineStone_BC8 still crashed because it only checked if an item is valid for a slot when it was already being inserted ( see ItemHandlerSimple, setStackInSlot() ) so I added isValidItem() to it's SlotBase implementation.