### PR TITLE
Fixed AutoWorkbench item duplication (#3468).

### DIFF
--- a/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
+++ b/common/buildcraft/factory/tile/TileAutoWorkbenchBase.java
@@ -47,6 +47,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
     public final ItemHandlerSimple invResult;
     public final ItemHandlerSimple invOverflow;
     protected final Map<ItemStackKey, TIntHashSet> itemStackCache;
+    private ItemHandlerSimple invMaterialsCopy = null;
 
     public IRecipe currentRecipe;
     private int progress = -1;
@@ -114,11 +115,23 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         if (currentRecipe == null) {
             return false;
         }
+
         crafting.enableBindings();
         boolean has = currentRecipe.matches(crafting, getWorld());
         crafting.disableBindings();
         return has;
     }
+
+    private ItemHandlerSimple copyInvMaterials() {
+        ItemHandlerSimple newItemHandler = itemManager.addInvHandler("materials", invMaterials.getSlots(), EnumAccess.INSERT, EnumPipePart.VALUES);
+
+        for(int i = 0; i < invMaterials.getSlots(); ++i) {
+            newItemHandler.setStackInSlot(i, invMaterials.getStackInSlot(i).copy());
+        }
+
+        return newItemHandler;
+    }
+
 
     private void moveOverflowDown() {
         // TODO!
@@ -144,12 +157,15 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         // }
     }
 
+
     @Override
     protected void onSlotChange(IItemHandlerModifiable handler, int slot, @Nonnull ItemStack before, @Nonnull ItemStack after) {
         super.onSlotChange(handler, slot, before, after);
         if (handler == invMaterials) {
-            ItemStackKey keyBefore = new ItemStackKey(before);
-            ItemStackKey keyAfter = new ItemStackKey(after);
+
+            ItemStackKey keyBefore = getUnitStack(before);
+            ItemStackKey keyAfter = getUnitStack(after);
+
             if (keyAfter.equals(keyBefore)) return;
             if (itemStackCache.containsKey(keyBefore)) {
                 TIntHashSet set = itemStackCache.get(keyBefore);
@@ -174,6 +190,12 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
 
     public void updateRecipe() {
         this.currentRecipe = CraftingUtil.findMatchingRecipe(this.crafting, world);
+    }
+
+    private ItemStackKey getUnitStack(ItemStack stack) {
+        ItemStack newStack = stack.copy();
+        newStack.setCount(1);
+        return new ItemStackKey(newStack);
     }
 
     @Override
@@ -229,12 +251,14 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
         }
 
         public void enableBindings() {
+            invMaterialsCopy = copyInvMaterials();
             for (int i = 0; i < craftingSlots.length; i++) {
                 craftingSlots[i] = craftingSlots[i].getBoundVersion();
             }
         }
 
         public void disableBindings() {
+            invMaterialsCopy = null;
             for (int i = 0; i < craftingSlots.length; i++) {
                 craftingSlots[i] = craftingSlots[i].getUnboundVersion();
             }
@@ -327,6 +351,7 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
     protected class CraftSlotItemBound extends CraftingSlot {
         protected final CraftSlotItem nonBound;
         protected TIntHashSet boundTo = null;
+        protected ItemStack boundStack = null;
 
         public CraftSlotItemBound(CraftSlotItem from) {
             super(from.slot);
@@ -337,23 +362,32 @@ public abstract class TileAutoWorkbenchBase extends TileBC_Neptune implements IT
             ItemStack wanted = nonBound.get();
             ItemStackKey key = new ItemStackKey(wanted);
             boundTo = itemStackCache.get(key);
-        }
 
-        @Nonnull
-        @Override
-        public ItemStack get() {
-            if (boundTo == null) {
-                return StackUtil.EMPTY;
+            if(boundTo == null){
+                boundStack = StackUtil.EMPTY;
+                return;
             }
+
             for (int s : boundTo.toArray()) {
-                if (!invMaterials.getStackInSlot(s).isEmpty()) {
-                    ItemStack inSlot = invMaterials.extractItem(s, 1, true);
+                if(invMaterialsCopy == null || invMaterialsCopy.getStackInSlot(s) == null) {
+                    boundStack = StackUtil.EMPTY;
+                    return;
+                }
+                if (!invMaterialsCopy.getStackInSlot(s).isEmpty()) {
+                    ItemStack inSlot = invMaterialsCopy.extractItem(s, 1, false);
                     if (!inSlot.isEmpty()) {
-                        return inSlot;
+                        boundStack = inSlot;
+                        return;
                     }
                 }
             }
-            return StackUtil.EMPTY;
+
+            boundStack = StackUtil.EMPTY;
+        }
+
+        @Override
+        public ItemStack get() {
+            return boundStack;
         }
 
         @Override


### PR DESCRIPTION
IRecipe.matches ( called from hasMaterialsForRecipe() ) uses CraftSlotItemBound.get(). Since it only simulated extracting items from the materials inventory, it returned an ItemStack even if it has been already used. My solution was to copy the materials inventory before applying the bindings and actually extracting from it.

I found some issues with how itemStackcache caused by onSlotChange() behaviour and ItemStackKey comparisons so I added a method to get the key of a given ItemStack which only contains one item and that seemed to solve those issues.

I'm honestly not too happy with how the rebind() method turned out so please do tell me if there's a cleaner solution.