### PR TITLE
Fix a crash when a machine "clicks" on a gate

### DIFF
--- a/common/buildcraft/transport/Gate.java
+++ b/common/buildcraft/transport/Gate.java
@@ -325,11 +325,10 @@ public final class Gate implements IGate, ISidedStatementContainer, IRedstoneSta
 	public void openGui(EntityPlayer player) {
 		if (!player.worldObj.isRemote) {
 			player.openGui(BuildCraftTransport.instance, GuiIds.GATES, pipe.container.getWorldObj(), pipe.container.xCoord, pipe.container.yCoord, pipe.container.zCoord);
-                        // ThermalExpansion Autonomous Activator crash fix
-                        if (player.openContainer instanceof ContainerGateInterface)
-                        {
-                          ((ContainerGateInterface) player.openContainer).setGate(direction.ordinal());
-                        }
+			// ThermalExpansion Autonomous Activator crash fix
+			if (player.openContainer instanceof ContainerGateInterface) {
+				((ContainerGateInterface) player.openContainer).setGate(direction.ordinal());
+			}
 		}
 	}
 

--- a/common/buildcraft/transport/Gate.java
+++ b/common/buildcraft/transport/Gate.java
@@ -325,7 +325,11 @@ public final class Gate implements IGate, ISidedStatementContainer, IRedstoneSta
 	public void openGui(EntityPlayer player) {
 		if (!player.worldObj.isRemote) {
 			player.openGui(BuildCraftTransport.instance, GuiIds.GATES, pipe.container.getWorldObj(), pipe.container.xCoord, pipe.container.yCoord, pipe.container.zCoord);
-			((ContainerGateInterface) player.openContainer).setGate(direction.ordinal());
+                        // ThermalExpansion Autonomous Activator crash fix
+                        if (player.openContainer instanceof ContainerGateInterface)
+                        {
+                          ((ContainerGateInterface) player.openContainer).setGate(direction.ordinal());
+                        }
 		}
 	}
 


### PR DESCRIPTION
Fix a crash when a Thermal Expansion Autonomous Activator clicks on a BuildCraft gate.