### PR TITLE
fix oil tendrill generation (#3601)

### DIFF
--- a/common/buildcraft/energy/generation/OilPopulate.java
+++ b/common/buildcraft/energy/generation/OilPopulate.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 
+import buildcraft.lib.misc.BlockUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDynamicLiquid;
 import net.minecraft.block.BlockFlower;
@@ -28,6 +29,8 @@ import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent.Populate.EventType;
 import net.minecraftforge.event.terraingen.TerrainGen;
 import net.minecraftforge.fluids.BlockFluidBase;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.IFluidBlock;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -259,9 +262,8 @@ public final class OilPopulate {
     }
 
     private boolean isReplaceableFluid(World world, BlockPos pos) {
-        Block block = world.getBlockState(pos).getBlock();
-        return (block instanceof BlockStaticLiquid || block instanceof BlockFluidBase || block instanceof IFluidBlock || block instanceof BlockDynamicLiquid)
-            && world.getBlockState(pos).getMaterial() != Material.LAVA || block.isAir(world.getBlockState(pos), world, pos);
+        Fluid fluid = BlockUtil.getFluidWithFlowing(world, pos);
+        return (fluid != null && fluid != FluidRegistry.LAVA) || world.isAirBlock(pos);
     }
 
     private boolean isOil(World world, int x, int y, int z) {

--- a/common/buildcraft/energy/generation/OilPopulate.java
+++ b/common/buildcraft/energy/generation/OilPopulate.java
@@ -11,6 +11,7 @@ import java.util.Random;
 import java.util.Set;
 
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockDynamicLiquid;
 import net.minecraft.block.BlockFlower;
 import net.minecraft.block.BlockStaticLiquid;
 import net.minecraft.block.material.Material;
@@ -219,7 +220,6 @@ public final class OilPopulate {
 
     private void generateSurfaceDeposit(World world, Random rand, Biome biome, int x, int y, int z, int radius) {
         int depth = rand.nextDouble() < 0.5 ? 1 : 2;
-
         // Center
         setOilColumnForLake(world, biome, x, y, z, depth, 2);
 
@@ -260,8 +260,8 @@ public final class OilPopulate {
 
     private boolean isReplaceableFluid(World world, BlockPos pos) {
         Block block = world.getBlockState(pos).getBlock();
-        return (block instanceof BlockStaticLiquid || block instanceof BlockFluidBase || block instanceof IFluidBlock)
-            && world.getBlockState(pos).getMaterial() != Material.LAVA;
+        return (block instanceof BlockStaticLiquid || block instanceof BlockFluidBase || block instanceof IFluidBlock || block instanceof BlockDynamicLiquid)
+            && world.getBlockState(pos).getMaterial() != Material.LAVA || block.isAir(world.getBlockState(pos), world, pos);
     }
 
     private boolean isOil(World world, int x, int y, int z) {
@@ -335,7 +335,7 @@ public final class OilPopulate {
 
             for (int d = 1; d <= depth - 1; d++) {
                 BlockPos down = pos.down(d);
-                if (isReplaceableFluid(world, down) || !world.isSideSolid(down.down(), EnumFacing.UP)) {
+                if (!isReplaceableFluid(world, down) || world.isSideSolid(down.down(), EnumFacing.UP)) {
                     return;
                 }
                 world.setBlockState(down, BCEnergyFluids.crudeOil[0].getBlock().getDefaultState(), 2);


### PR DESCRIPTION
base problem was a check that got inverted, also some extra checks for if a block is replacable, tendrills spill into nearby chunks that have not generated yet so the first block(s) eighter return air or flowing water while the generator realises the chunk has not been generated and interups the oil spilage to generate the new chunk