### PR TITLE
3729: fixing handling of stacked fluid container by tank

### DIFF
--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -28,6 +28,7 @@ import net.minecraftforge.fluids.capability.IFluidTankProperties;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 import buildcraft.api.core.EnumPipePart;
 import buildcraft.api.core.IFluidFilter;
@@ -43,7 +44,6 @@ import buildcraft.lib.misc.SoundUtil;
 import buildcraft.lib.misc.data.IdAllocator;
 import buildcraft.lib.net.PacketBufferBC;
 import buildcraft.lib.tile.TileBC_Neptune;
-import net.minecraftforge.items.ItemHandlerHelper;
 
 public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, IFluidHandlerAdv {
     public static final IdAllocator IDS = TileBC_Neptune.IDS.makeChild("tank");

--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -43,6 +43,7 @@ import buildcraft.lib.misc.SoundUtil;
 import buildcraft.lib.misc.data.IdAllocator;
 import buildcraft.lib.net.PacketBufferBC;
 import buildcraft.lib.tile.TileBC_Neptune;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, IFluidHandlerAdv {
     public static final IdAllocator IDS = TileBC_Neptune.IDS.makeChild("tank");
@@ -129,7 +130,18 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
             return false;
         }
         boolean replace = !player.capabilities.isCreativeMode;
-        IFluidHandlerItem flItem = FluidUtil.getFluidHandler(replace ? held : held.copy());
+        boolean single = held.getCount() == 1;
+        IFluidHandlerItem flItem;
+        if (replace && single) {
+            flItem = FluidUtil.getFluidHandler(held);
+        } else {
+            // replace and not single - need a copy and count set to 1
+            // not replace and single - need a copy, does not need change of count but it should be ok
+            // not replace and not single - need a copy count set to 1
+            ItemStack copy = held.copy();
+            copy.setCount(1);
+            flItem = FluidUtil.getFluidHandler(copy);
+        }
         if (flItem == null) {
             return false;
         }
@@ -146,8 +158,16 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
         } else {
             changed = false;
         }
-        if (changed & replace) {
-            player.setHeldItem(hand, flItem.getContainer());
+
+        if (changed && replace) {
+            if (single) {
+                // if it was the single item, replace with changed one
+                player.setHeldItem(hand, flItem.getContainer());
+            } else {
+                // if it was part of stack, shrink stack and give / drop the new one
+                held.shrink(1);
+                ItemHandlerHelper.giveItemToPlayer(player, flItem.getContainer());
+            }
             player.inventoryContainer.detectAndSendChanges();
         }
         isPlayerInteracting = false;


### PR DESCRIPTION
Adding a check for quantity of items. If there are more than one item try to use one item from the stack. If item from the stack is filled `give it to the player or drop it at their feet` as is done in core forge.

Closes #3729 
