### PR TITLE
Fixed paintbrush getting damaged in creative

### DIFF
--- a/common/buildcraft/core/item/ItemPaintbrush_BC8.java
+++ b/common/buildcraft/core/item/ItemPaintbrush_BC8.java
@@ -196,8 +196,7 @@ public class ItemPaintbrush_BC8 extends ItemBC_Neptune {
                 ParticleUtil.showChangeColour(world, hitPos, colour);
                 SoundUtil.playChangeColour(world, pos, colour);
 
-                boolean isHolderCreative = player.isCreative();
-                if (!isHolderCreative) {
+                if (!player.isCreative()) {
                     usesLeft--;
                 }
 

--- a/common/buildcraft/core/item/ItemPaintbrush_BC8.java
+++ b/common/buildcraft/core/item/ItemPaintbrush_BC8.java
@@ -69,7 +69,7 @@ public class ItemPaintbrush_BC8 extends ItemBC_Neptune {
         ItemStack stack = StackUtil.asNonNull(player.getHeldItem(hand));
         Brush brush = new Brush(stack);
         Vec3d hitPos = VecUtil.add(new Vec3d(hitX, hitY, hitZ), pos);
-        if (brush.useOnBlock(world, pos, world.getBlockState(pos), hitPos, facing)) {
+        if (brush.useOnBlock(world, pos, world.getBlockState(pos), hitPos, facing, player)) {
             ItemStack newStack = brush.save(stack);
             if (!newStack.isEmpty()) {
                 player.setHeldItem(hand, newStack);
@@ -185,7 +185,7 @@ public class ItemPaintbrush_BC8 extends ItemBC_Neptune {
             return (usesLeft <= 0 || colour == null) ? 0 : colour.getMetadata() + 1;
         }
 
-        public boolean useOnBlock(World world, BlockPos pos, IBlockState state, Vec3d hitPos, EnumFacing side) {
+        public boolean useOnBlock(World world, BlockPos pos, IBlockState state, Vec3d hitPos, EnumFacing side, EntityPlayer player) {
             if (colour != null && usesLeft <= 0) {
                 return false;
             }
@@ -195,7 +195,12 @@ public class ItemPaintbrush_BC8 extends ItemBC_Neptune {
             if (result == EnumActionResult.SUCCESS) {
                 ParticleUtil.showChangeColour(world, hitPos, colour);
                 SoundUtil.playChangeColour(world, pos, colour);
-                usesLeft--;
+
+                boolean isHolderCreative = player.isCreative();
+                if (!isHolderCreative) {
+                    usesLeft--;
+                }
+
                 if (usesLeft <= 0) {
                     colour = null;
                     usesLeft = 0;


### PR DESCRIPTION
Fixed issue #3834 , fixed the issue by checking if the player holding the brush is in creative mode, if he is then there is no change to the brush's durability.