### PR TITLE
Set particle for ModelHeatExchange

### DIFF
--- a/common/buildcraft/factory/client/model/ModelHeatExchange.java
+++ b/common/buildcraft/factory/client/model/ModelHeatExchange.java
@@ -6,7 +6,9 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.EnumFacing;
 
 import buildcraft.lib.block.BlockBCBase_Neptune;
@@ -52,6 +54,7 @@ public class ModelHeatExchange extends ModelItemSimple {
     }
 
     public final List<BakedQuad> itemQuads = new ArrayList<>();
+    private final TextureAtlasSprite particle;
     private final List<List<BakedQuad>> cache = new ArrayList<>();
 
     public ModelHeatExchange() {
@@ -66,6 +69,12 @@ public class ModelHeatExchange extends ModelItemSimple {
         for (MutableQuad quad : BCFactoryModels.HEAT_EXCHANGE_STATIC.getCutoutQuads()) {
             quad.multShade();
             itemQuads.add(quad.toBakedItem());
+        }
+
+        if (itemQuads.isEmpty()) {
+            particle = Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite();
+        } else {
+            particle = itemQuads.get(0).getSprite();
         }
 
         for (int i = 0; i < 4 * 8 * 3; i++) {
@@ -86,6 +95,11 @@ public class ModelHeatExchange extends ModelItemSimple {
 
             cache.add(quads);
         }
+    }
+
+    @Override
+    public TextureAtlasSprite getParticleTexture() {
+        return particle;
     }
 
     @Override

--- a/common/buildcraft/lib/client/model/ModelItemSimple.java
+++ b/common/buildcraft/lib/client/model/ModelItemSimple.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
+import net.minecraft.client.Minecraft;
 import org.lwjgl.util.vector.Vector3f;
 
 import net.minecraft.block.state.IBlockState;
@@ -122,10 +123,10 @@ public class ModelItemSimple implements IBakedModel {
     private final ItemCameraTransforms transforms;
 
     public ModelItemSimple(List<BakedQuad> quads, ItemCameraTransforms transforms, boolean isGui3d) {
-        this.quads = quads;
+        this.quads = quads == null ? ImmutableList.of() : quads;
         this.isGui3d = isGui3d;
         if (quads.isEmpty()) {
-            particle = null;
+            particle = Minecraft.getMinecraft().getTextureMapBlocks().getMissingSprite();
         } else {
             particle = quads.get(0).getSprite();
         }


### PR DESCRIPTION
Updated ModelHeatExchange to make sure the particle is always set from the quads in the constructor rather than staying null. #3874 