### PR TITLE
Obsidian pipes no longer draw power when not connected to other pipes

### DIFF
--- a/common/buildcraft/transport/pipe/behaviour/PipeBehaviourObsidian.java
+++ b/common/buildcraft/transport/pipe/behaviour/PipeBehaviourObsidian.java
@@ -191,18 +191,22 @@ public class PipeBehaviourObsidian extends PipeBehaviour implements IMjRedstoneR
             return microJoules;
         }
         EnumFacing openFace = getOpenFace();
-        for (int d = 1; d < 5; d++) {
-            AxisAlignedBB aabb = getSuckingBox(openFace, d);
-            List<Entity> discoveredEntities = pipe.getHolder().getPipeWorld().getEntitiesWithinAABB(Entity.class, aabb);
+        if(openFace != null){
+            for (int d = 1; d < 5; d++) {
+                AxisAlignedBB aabb = getSuckingBox(openFace, d);
+                List<Entity> discoveredEntities = pipe.getHolder().getPipeWorld().getEntitiesWithinAABB(Entity.class, aabb);
 
-            for (Entity entity : discoveredEntities) {
-                long leftOver = trySuckEntity(entity, openFace, microJoules, simulate);
-                if (leftOver < microJoules) {
-                    return leftOver;
+                for (Entity entity : discoveredEntities) {
+                    long leftOver = trySuckEntity(entity, openFace, microJoules, simulate);
+                    if (leftOver < microJoules) {
+                        return leftOver;
+                    }
                 }
             }
+            return microJoules - MjAPI.MJ;
+        }else{
+            return microJoules;
         }
-        return microJoules - MjAPI.MJ;
     }
 
     @Override

--- a/common/buildcraft/transport/pipe/behaviour/PipeBehaviourObsidian.java
+++ b/common/buildcraft/transport/pipe/behaviour/PipeBehaviourObsidian.java
@@ -191,22 +191,22 @@ public class PipeBehaviourObsidian extends PipeBehaviour implements IMjRedstoneR
             return microJoules;
         }
         EnumFacing openFace = getOpenFace();
-        if(openFace != null){
-            for (int d = 1; d < 5; d++) {
-                AxisAlignedBB aabb = getSuckingBox(openFace, d);
-                List<Entity> discoveredEntities = pipe.getHolder().getPipeWorld().getEntitiesWithinAABB(Entity.class, aabb);
-
-                for (Entity entity : discoveredEntities) {
-                    long leftOver = trySuckEntity(entity, openFace, microJoules, simulate);
-                    if (leftOver < microJoules) {
-                        return leftOver;
-                    }
-                }
-            }
-            return microJoules - MjAPI.MJ;
-        }else{
+        if(openFace == null) {
             return microJoules;
         }
+
+        for (int d = 1; d < 5; d++) {
+            AxisAlignedBB aabb = getSuckingBox(openFace, d);
+            List<Entity> discoveredEntities = pipe.getHolder().getPipeWorld().getEntitiesWithinAABB(Entity.class, aabb);
+
+            for (Entity entity : discoveredEntities) {
+                long leftOver = trySuckEntity(entity, openFace, microJoules, simulate);
+                if (leftOver < microJoules) {
+                    return leftOver;
+                }
+            }
+        }
+        return microJoules - MjAPI.MJ;
     }
 
     @Override


### PR DESCRIPTION
As per #3884 obsidian pipes that were not connected to any other pipes caused a crash as they had nowhere to send items to.

To fix this, if there are no pipes to send items to then the obsidian pipes don't try to suck items and don't draw power (as they cannot function)