### PR TITLE
Store tank capacities in nbt data

### DIFF
--- a/common/buildcraft/lib/fluid/Tank.java
+++ b/common/buildcraft/lib/fluid/Tank.java
@@ -140,11 +140,17 @@ public class Tank extends FluidTank implements IFluidHandlerAdv {
 
     /** Writes some additional information to the nbt, for example {@link SingleUseTank} will write out the filtering
      * fluid. */
-    protected void writeTankToNBT(NBTTagCompound nbt) {}
+    protected void writeTankToNBT(NBTTagCompound nbt) {
+        nbt.setInteger("Capacity", getCapacity());
+    }
 
     /** Reads some additional information to the nbt, for example {@link SingleUseTank} will read in the filtering
      * fluid. */
-    protected void readTankFromNBT(NBTTagCompound nbt) {}
+    protected void readTankFromNBT(NBTTagCompound nbt) {
+        if (nbt.hasKey("Capacity")) {
+            setCapacity(nbt.getInteger("Capacity"));
+        }
+    }
 
     public ToolTip getToolTip() {
         return toolTip;


### PR DESCRIPTION
This is related to our discussions in Discord about reloading tank tile entities with capacities other than the default 16 buckets. I see three possible solutions to this issue: 

1) Addons like IronTanks implement their own tile (which can still extend the BC TileTank) which has the correct magic number of buckets in the constructor (or as a static property if the most recent commit is rolled back):

```
public class CustomTank extends TileTank {
    public TileTank() {
        this(45 * Fluid.BUCKET_VOLUME);
    }
} 
```

2) Implement reading/writing the tank capacity from/to NBT data in the BuildCraft tank (**this PR**). 

3) Push this functionality upstream into the Forge FluidTank class (not sure what the other implications are of this though).