### PR TITLE
Add a config option to change the max water pumping distance.

### DIFF
--- a/common/buildcraft/core/BCCoreConfig.java
+++ b/common/buildcraft/core/BCCoreConfig.java
@@ -180,7 +180,7 @@ public class BCCoreConfig {
         none.setTo(propMarkerMaxDistance);
 
         propPumpMaxDistance = config.get(general, "pumpMaxDistance", 64);
-        propPumpMaxDistance.setMinValue(16).setMaxValue(256);
+        propPumpMaxDistance.setMinValue(16).setMaxValue(128);
         propPumpMaxDistance.setComment("How far, in minecraft blocks, should pumps reach in fluids?");
         none.setTo(propPumpMaxDistance);
 

--- a/common/buildcraft/core/BCCoreConfig.java
+++ b/common/buildcraft/core/BCCoreConfig.java
@@ -45,6 +45,7 @@ public class BCCoreConfig {
     public static boolean hideFluid;
     public static boolean pumpsConsumeWater;
     public static int markerMaxDistance;
+    public static int pumpMaxDistance;
     public static int networkUpdateRate = 10;
 
     private static Property propColourBlindMode;
@@ -65,6 +66,7 @@ public class BCCoreConfig {
     private static Property propItemLifespan;
     private static Property propPumpsConsumeWater;
     private static Property propMarkerMaxDistance;
+    private static Property propPumpMaxDistance;
     private static Property propNetworkUpdateRate;
 
     public static void preInit(File cfgFolder) {
@@ -177,6 +179,11 @@ public class BCCoreConfig {
         propMarkerMaxDistance.setComment("How far, in minecraft blocks, should markers (volume and path) reach?");
         none.setTo(propMarkerMaxDistance);
 
+        propPumpMaxDistance = config.get(general, "pumpMaxDistance", 64);
+        propPumpMaxDistance.setMinValue(16).setMaxValue(256);
+        propPumpMaxDistance.setComment("How far, in minecraft blocks, should pumps reach in water?");
+        none.setTo(propPumpMaxDistance);
+
         propNetworkUpdateRate = config.get(general, "updateFactor", networkUpdateRate);
         propNetworkUpdateRate.setMinValue(1).setMaxValue(100);
         propNetworkUpdateRate.setComment(
@@ -229,6 +236,7 @@ public class BCCoreConfig {
         BCLibConfig.itemLifespan = propItemLifespan.getInt();
         pumpsConsumeWater = propPumpsConsumeWater.getBoolean();
         markerMaxDistance = propMarkerMaxDistance.getInt();
+        pumpMaxDistance = propPumpMaxDistance.getInt();
         BCLibConfig.colourBlindMode = propColourBlindMode.getBoolean();
         BCLibConfig.displayTimeGap = ConfigUtil.parseEnumForConfig(propDisplayTimeGap, TimeGap.TICKS);
         BCLibConfig.rotateTravelingItems =

--- a/common/buildcraft/core/BCCoreConfig.java
+++ b/common/buildcraft/core/BCCoreConfig.java
@@ -181,7 +181,7 @@ public class BCCoreConfig {
 
         propPumpMaxDistance = config.get(general, "pumpMaxDistance", 64);
         propPumpMaxDistance.setMinValue(16).setMaxValue(256);
-        propPumpMaxDistance.setComment("How far, in minecraft blocks, should pumps reach in water?");
+        propPumpMaxDistance.setComment("How far, in minecraft blocks, should pumps reach in fluids?");
         none.setTo(propPumpMaxDistance);
 
         propNetworkUpdateRate = config.get(general, "updateFactor", networkUpdateRate);

--- a/common/buildcraft/factory/tile/TilePump.java
+++ b/common/buildcraft/factory/tile/TilePump.java
@@ -114,11 +114,12 @@ public class TilePump extends TileMiner {
         outer: while (!nextPosesToCheck.isEmpty()) {
             List<BlockPos> nextPosesToCheckCopy = new ArrayList<>(nextPosesToCheck);
             nextPosesToCheck.clear();
+            final int maxLengthSquared = BCCoreConfig.pumpMaxDistance * BCCoreConfig.pumpMaxDistance;
             for (BlockPos posToCheck : nextPosesToCheckCopy) {
                 int count = 0;
                 for (EnumFacing side : SEARCH_DIRECTIONS) {
                     BlockPos offsetPos = posToCheck.offset(side);
-                    if (offsetPos.distanceSq(pos) > 64 * 64) {
+                    if (offsetPos.distanceSq(pos) > maxLengthSquared) {
                         continue;
                     }
                     if (checked.add(offsetPos)) {

--- a/common/buildcraft/factory/tile/TilePump.java
+++ b/common/buildcraft/factory/tile/TilePump.java
@@ -111,10 +111,10 @@ public class TilePump extends TileMiner {
         }
         world.profiler.endStartSection("build");
         boolean isWater = !BCCoreConfig.pumpsConsumeWater && FluidUtilBC.areFluidsEqual(queueFluid, FluidRegistry.WATER);
+        final int maxLengthSquared = BCCoreConfig.pumpMaxDistance * BCCoreConfig.pumpMaxDistance;
         outer: while (!nextPosesToCheck.isEmpty()) {
             List<BlockPos> nextPosesToCheckCopy = new ArrayList<>(nextPosesToCheck);
             nextPosesToCheck.clear();
-            final int maxLengthSquared = BCCoreConfig.pumpMaxDistance * BCCoreConfig.pumpMaxDistance;
             for (BlockPos posToCheck : nextPosesToCheckCopy) {
                 int count = 0;
                 for (EnumFacing side : SEARCH_DIRECTIONS) {


### PR DESCRIPTION
I decided to add this option for myself since I wanted to drain an Ocean Monument using a bunch of pumps around the perimeter and a finite water mod - it makes this possible but has a huge effect on performance when increased much above 64 as you might expect. If you don't want to merge this I'll just maintain my own fork 😄 