### PR TITLE
Fixed facades returning BlockFaceShape.UNDEFINED when they shouldn't

### DIFF
--- a/common/buildcraft/transport/block/BlockPipeHolder.java
+++ b/common/buildcraft/transport/block/BlockPipeHolder.java
@@ -645,7 +645,7 @@ public class BlockPipeHolder extends BlockBCTile_Neptune implements ICustomPaint
             return BlockFaceShape.UNDEFINED;
         }
         PipePluggable pluggable = tile.getPluggable(face);
-        return pluggable != null && pluggable.isSideSolid() ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
+        return pluggable != null ? pluggable.getBlockFaceShape() : BlockFaceShape.UNDEFINED;
     }
 
     private static void removePluggable(EnumFacing side, TilePipeHolder tile, NonNullList<ItemStack> toDrop) {

--- a/common/buildcraft/transport/plug/FacadeBlockStateInfo.java
+++ b/common/buildcraft/transport/plug/FacadeBlockStateInfo.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.google.common.collect.ImmutableSet;
 
 import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
@@ -23,6 +24,7 @@ public class FacadeBlockStateInfo implements IFacadeState {
     public final boolean isTransparent;
     public final boolean isVisible;
     public final boolean[] isSideSolid = new boolean[6];
+    public final BlockFaceShape[] blockFaceShape = new BlockFaceShape[6];
 
     public FacadeBlockStateInfo(IBlockState state, ItemStack requiredStack,
         ImmutableSet<IProperty<?>> varyingProperties) {
@@ -37,6 +39,7 @@ public class FacadeBlockStateInfo implements IFacadeState {
         IBlockAccess access = new SingleBlockAccess(state);
         for (EnumFacing side : EnumFacing.VALUES) {
             isSideSolid[side.ordinal()] = state.isSideSolid(access, BlockPos.ORIGIN, side);
+            blockFaceShape[side.ordinal()] = state.getBlockFaceShape(access, BlockPos.ORIGIN, side);
         }
     }
 

--- a/common/buildcraft/transport/plug/FacadeInstance.java
+++ b/common/buildcraft/transport/plug/FacadeInstance.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -119,6 +120,13 @@ public class FacadeInstance implements IFacade {
             }
         }
         return true;
+    }
+
+    public BlockFaceShape getBlockFaceShape(EnumFacing side) {
+        if (type == FacadeType.Basic) {
+            return phasedStates[0].isHollow() ? BlockFaceShape.UNDEFINED : phasedStates[0].getBlockFaceShape(side);
+        }
+        return BlockFaceShape.UNDEFINED;
     }
 
     // IFacade

--- a/common/buildcraft/transport/plug/FacadePhasedState.java
+++ b/common/buildcraft/transport/plug/FacadePhasedState.java
@@ -2,6 +2,7 @@ package buildcraft.transport.plug;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.nbt.NBTTagCompound;
@@ -93,6 +94,10 @@ public class FacadePhasedState implements IFacadePhasedState {
 
     public boolean isSideSolid(EnumFacing side) {
         return stateInfo.isSideSolid[side.ordinal()];
+    }
+
+    public BlockFaceShape getBlockFaceShape(EnumFacing side) {
+        return stateInfo.blockFaceShape[side.ordinal()];
     }
 
     @Override

--- a/common/buildcraft/transport/plug/PluggableFacade.java
+++ b/common/buildcraft/transport/plug/PluggableFacade.java
@@ -8,6 +8,7 @@ package buildcraft.transport.plug;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
@@ -42,12 +43,14 @@ public class PluggableFacade extends PipePluggable implements IFacade {
     public static final int SIZE = 2;
     public final FacadeInstance states;
     public final boolean isSideSolid;
+    public BlockFaceShape blockFaceShape;
     public int activeState;
 
     public PluggableFacade(PluggableDefinition definition, IPipeHolder holder, EnumFacing side, FacadeInstance states) {
         super(definition, holder, side);
         this.states = states;
         isSideSolid = states.areAllStatesSolid(side);
+        blockFaceShape = states.getBlockFaceShape(side);
     }
 
     public PluggableFacade(PluggableDefinition def, IPipeHolder holder, EnumFacing side, NBTTagCompound nbt) {
@@ -55,6 +58,7 @@ public class PluggableFacade extends PipePluggable implements IFacade {
         this.states = FacadeInstance.readFromNbt(nbt, "states");
         activeState = MathUtil.clamp(nbt.getInteger("activeState"), 0, states.phasedStates.length - 1);
         isSideSolid = states.areAllStatesSolid(side);
+        blockFaceShape = states.getBlockFaceShape(side);
     }
 
     @Override
@@ -72,6 +76,7 @@ public class PluggableFacade extends PipePluggable implements IFacade {
         PacketBufferBC buf = PacketBufferBC.asPacketBufferBc(buffer);
         states = FacadeInstance.readFromBuffer(buf);
         isSideSolid = buf.readBoolean();
+        blockFaceShape = states.getBlockFaceShape(side);
     }
 
     @Override
@@ -106,6 +111,11 @@ public class PluggableFacade extends PipePluggable implements IFacade {
     @Override
     public float getExplosionResistance(@Nullable Entity exploder, Explosion explosion) {
         return states.phasedStates[activeState].stateInfo.state.getBlock().getExplosionResistance(exploder);
+    }
+
+    @Override
+    public BlockFaceShape getBlockFaceShape() {
+        return blockFaceShape;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/BuildCraft/BuildCraft/issues/3994.

Also changed hollow facades to be considered as not solid.