### PR TITLE
Allow tanks to be explicitly associated

### DIFF
--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -193,7 +193,7 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
         TileEntity tile = world.getTileEntity(at);
         if (tile instanceof TileTank) {
             TileTank tileTank = (TileTank) tile;
-            if (tileTank.canConnectTo(this)) {
+            if (tileTank.canConnectTo(this) && this.canConnectTo(tileTank)) {
                 return tileTank;
             }
         }

--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -50,7 +49,6 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     private static boolean isPlayerInteracting = false;
 
     public final Tank tank;
-    public final String association;
     public final FluidSmoother smoothedTank;
 
     private int lastComparatorLevel;
@@ -60,13 +58,12 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     }
 
     protected TileTank(int capacity) {
-        this(new Tank("tank", capacity, null), null);
+        this(new Tank("tank", capacity, null));
     }
 
-    protected TileTank(Tank tank, String association) {
+    protected TileTank(Tank tank) {
         tank.setTileEntity(this);
         this.tank = tank;
-        this.association = association;
         tankManager.add(tank);
         caps.addCapabilityInstance(CapUtil.CAP_FLUIDS, this, EnumPipePart.VALUES);
         smoothedTank = new FluidSmoother(w -> createAndSendMessage(NET_FLUID_DELTA, w), tank);
@@ -188,11 +185,17 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
 
     // Tank helper methods
 
+    public boolean canConnectTo(TileTank tileTank) {
+        return true;
+    }
+
     private TileTank getTank(BlockPos at) {
         TileEntity tile = world.getTileEntity(at);
         if (tile instanceof TileTank) {
             TileTank tileTank = (TileTank) tile;
-            return Objects.equals(this.association, tileTank.association) ? tileTank : null;
+            if (tileTank.canConnectTo(this)) {
+                return tileTank;
+            }
         }
         return null;
     }

--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -191,8 +191,8 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     private TileTank getTank(BlockPos at) {
         TileEntity tile = world.getTileEntity(at);
         if (tile instanceof TileTank) {
-            TileTank tank = (TileTank) tile;
-            return Objects.equals(this.association, tank.association) ? tank : null;
+            TileTank tileTank = (TileTank) tile;
+            return Objects.equals(this.association, tileTank.association) ? tileTank : null;
         }
         return null;
     }

--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -49,6 +50,7 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     private static boolean isPlayerInteracting = false;
 
     public final Tank tank;
+    public final String association;
     public final FluidSmoother smoothedTank;
 
     private int lastComparatorLevel;
@@ -58,12 +60,13 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     }
 
     protected TileTank(int capacity) {
-        this(new Tank("tank", capacity, null));
+        this(new Tank("tank", capacity, null), null);
     }
 
-    protected TileTank(Tank tank) {
+    protected TileTank(Tank tank, String association) {
         tank.setTileEntity(this);
         this.tank = tank;
+        this.association = association;
         tankManager.add(tank);
         caps.addCapabilityInstance(CapUtil.CAP_FLUIDS, this, EnumPipePart.VALUES);
         smoothedTank = new FluidSmoother(w -> createAndSendMessage(NET_FLUID_DELTA, w), tank);
@@ -188,7 +191,8 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     private TileTank getTank(BlockPos at) {
         TileEntity tile = world.getTileEntity(at);
         if (tile instanceof TileTank) {
-            return (TileTank) tile;
+            TileTank tank = (TileTank) tile;
+            return Objects.equals(this.association, tank.association) ? tank : null;
         }
         return null;
     }


### PR DESCRIPTION
Tanks are currently implicitly associated when they're stacked together. This PR allows tanks to also be explicitly associated through an association key provided on the tile. 

The purpose of this is to allow third party add-ons (like Iron Tanks) to explicitly define and track an association key for their own tanks and control what tanks can pass fluid down (or up) the stack. 

Current implementation leaves association key for all Buildcraft tanks set to NULL, so no change in current behavior, any stacked set of tanks will allow fluid/gas flow between the tanks in the stack. 

Specific use case is for Iron Tanks Creative and Void tanks which should not stack with any other tanks. 

Potential future use case could include stained glass tanks which don't allow fluid flow between different colored tanks. 