### PR TITLE
Fix complex stacks meta vs NBT comparison

### DIFF
--- a/common/buildcraft/lib/client/guide/loader/entry/ItemStackValueFilter.java
+++ b/common/buildcraft/lib/client/guide/loader/entry/ItemStackValueFilter.java
@@ -10,7 +10,7 @@ public class ItemStackValueFilter {
     public final boolean matchNbt;
     public final boolean matchMeta;
 
-    public ItemStackValueFilter(ItemStackKey stack, boolean matchNbt, boolean matchMeta) {
+    public ItemStackValueFilter(ItemStackKey stack, boolean matchMeta, boolean matchNbt) {
         this.stack = stack;
         this.matchNbt = matchNbt;
         this.matchMeta = matchMeta;


### PR DESCRIPTION
Right now if a stack wants just meta sensitivity it gets only NBT instead, and vice versa. This causes page misses in the guide book from comparing the wrong properties.

The actual logic is sound, it's just the [constructor args](https://github.com/BuildCraft/BuildCraft/blob/8.0.x/common/buildcraft/lib/client/guide/loader/entry/ItemStackValueFilter.java#L13) in ItemStackValueFilter are opposite to the order passed in by [EntryTypeItem](https://github.com/BuildCraft/BuildCraft/blob/8.0.x/common/buildcraft/lib/client/guide/loader/entry/EntryTypeItem.java#L50).