### PR TITLE
Extract a public reflow method for balancing tank capacities

### DIFF
--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -104,34 +104,7 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     public void onPlacedBy(EntityLivingBase placer, ItemStack stack) {
         super.onPlacedBy(placer, stack);
         if (!placer.world.isRemote) {
-            List<TileTank> tanks = getTanks();
-            FluidStack fluid = null;
-            for (TileTank tile : tanks) {
-                FluidStack held = tile.tank.getFluid();
-                if (held == null) {
-                    continue;
-                }
-                if (fluid == null) {
-                    fluid = held;
-                } else if (!fluid.isFluidEqual(held)) {
-                    return;
-                }
-            }
-            if (fluid == null) {
-                return;
-            }
-            if (fluid.getFluid().isGaseous(fluid)) {
-                Collections.reverse(tanks);
-            }
-            TileTank prev = null;
-            isPlayerInteracting = true;
-            for (TileTank tile : tanks) {
-                if (prev != null) {
-                    FluidUtilBC.move(tile.tank, prev.tank);
-                }
-                prev = tile;
-            }
-            isPlayerInteracting = false;
+            reflowTanks();
         }
     }
 
@@ -211,6 +184,43 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
      * @return True if both could connect, false otherwise. */
     public static boolean canTanksConnect(TileTank from, TileTank to, EnumFacing direction) {
         return from.canConnectTo(to, direction) && to.canConnectTo(from, direction.getOpposite());
+    }
+
+    /** Attempts to reflow fluids to the bottom most tank, and gasses to the uppermost tank. This is necessary whenever
+     * a new tank is added to the stack, or can be run by addons which directly manipulate connectivity, capacities or
+     * fluid amount in a single tank.
+     *
+     * @return void
+     */
+    public void reflowTanks() {
+        List<TileTank> tanks = getTanks();
+        FluidStack fluid = null;
+        for (TileTank tile : tanks) {
+            FluidStack held = tile.tank.getFluid();
+            if (held == null) {
+                continue;
+            }
+            if (fluid == null) {
+                fluid = held;
+            } else if (!fluid.isFluidEqual(held)) {
+                return;
+            }
+        }
+        if (fluid == null) {
+            return;
+        }
+        if (fluid.getFluid().isGaseous(fluid)) {
+            Collections.reverse(tanks);
+        }
+        TileTank prev = null;
+        isPlayerInteracting = true;
+        for (TileTank tile : tanks) {
+            if (prev != null) {
+                FluidUtilBC.move(tile.tank, prev.tank);
+            }
+            prev = tile;
+        }
+        isPlayerInteracting = false;
     }
 
     /** @return A list of all connected tanks around this block, ordered by position from bottom to top. */

--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -189,8 +189,6 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     /** Attempts to reflow fluids to the bottom most tank, and gasses to the uppermost tank. This is necessary whenever
      * a new tank is added to the stack, or can be run by addons which directly manipulate connectivity, capacities or
      * fluid amount in a single tank.
-     *
-     * @return void
      */
     public void reflowTanks() {
         List<TileTank> tanks = getTanks();


### PR DESCRIPTION
If the amount of fluid is directly adjusted on a single tile's tank instance the tank stack doesn't update. Buildcraft doesn't directly manipulate single tile tank instances, but add-ons can (in particular see indemnity83/irontanks#57). 

This PR simply pulls the logic used when a new tank block is added to a stack out into a public method that can be called to force a reflow of the tanks fluid/gas. 

I'm not totally clear on the purpose of `isPlayerInteracting`; it may be that toggling this during reflow needs to be passed as a parameter: `public void reflowTanks(boolean doPlayerInteraction)` or similar. 