### PR TITLE
Fix fluid rendering for tanks which cannot stack

### DIFF
--- a/common/buildcraft/factory/client/render/RenderTank.java
+++ b/common/buildcraft/factory/client/render/RenderTank.java
@@ -91,6 +91,9 @@ public class RenderTank extends TileEntitySpecialRenderer<TileTank> {
         TileEntity oTile = thisTank.getWorld().getTileEntity(pos);
         if (oTile instanceof TileTank) {
             TileTank oTank = (TileTank) oTile;
+            if (!TileTank.canTanksConnect(thisTank, oTank, face)) {
+                return false;
+            }
             FluidStackInterp forRender = oTank.getFluidForRender(partialTicks);
             if (forRender == null) {
                 return false;


### PR DESCRIPTION
Added a check when determining `connectedUp` & `connectedDown` to ensure that tanks are only 'connectedUp/Down' when the tanks being checked are allowed to be connected. 

fixes #4031 
