### PR TITLE
Fix #4082 - Fluids can no longer be broken by Mining Well

### DIFF
--- a/buildcraft_resources/changelog/7.99.17
+++ b/buildcraft_resources/changelog/7.99.17
@@ -2,3 +2,4 @@
 Bug fixes:
 
 * [#4124] The direction of an iron pipe cannot be changed by clicking the centre unless the pipe is already facing a direction.
+* [#4082] Fluids can no longer be mined by Mining Well

--- a/common/buildcraft/factory/tile/TileMiningWell.java
+++ b/common/buildcraft/factory/tile/TileMiningWell.java
@@ -16,6 +16,8 @@ import net.minecraft.world.IWorldEventListener;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
+import net.minecraftforge.fluids.Fluid;
+
 import buildcraft.api.core.EnumPipePart;
 import buildcraft.api.core.SafeTimeTracker;
 import buildcraft.api.mj.IMjReceiver;
@@ -84,7 +86,12 @@ public class TileMiningWell extends TileMiner {
     }
 
     private boolean canBreak() {
-        return !world.isAirBlock(currentPos) && !BlockUtil.isUnbreakableBlock(world, currentPos, getOwner());
+        if (world.isAirBlock(currentPos) || BlockUtil.isUnbreakableBlock(world, currentPos, getOwner())) {
+            return false;
+        }
+
+        Fluid fluid = BlockUtil.getFluidWithFlowing(world, currentPos);
+        return fluid == null || fluid.getViscosity() <= 1000;
     }
 
     private void nextPos() {


### PR DESCRIPTION
The code follows the same pattern as the code for the Quarry.

I tested this in-game for both lava, a fuel, and no liquid, confirming expected behavior (stops when a fluid is present)