### PR TITLE
Fix #4080 - Ported option to disable generation of oil spout and change rate of occurrence of large oil wells

### DIFF
--- a/buildcraft_resources/changelog/7.99.17
+++ b/buildcraft_resources/changelog/7.99.17
@@ -1,7 +1,7 @@
 
 Ported content:
 
-* Re-added the config option to change the rate of oil well generation and generation of a spout.
+* [#4080] Re-added the config option to change the rate of oil well generation and generation of a spout.
 
 Bug fixes:
 

--- a/buildcraft_resources/changelog/7.99.17
+++ b/buildcraft_resources/changelog/7.99.17
@@ -1,4 +1,8 @@
 
+Ported content:
+
+* Re-added the config option to change the rate of oil well generation.
+
 Bug fixes:
 
 * [#4124] The direction of an iron pipe cannot be changed by clicking the centre unless the pipe is already facing a direction.

--- a/buildcraft_resources/changelog/7.99.17
+++ b/buildcraft_resources/changelog/7.99.17
@@ -1,7 +1,7 @@
 
 Ported content:
 
-* Re-added the config option to change the rate of oil well generation.
+* Re-added the config option to change the rate of oil well generation and generation of a spout.
 
 Bug fixes:
 

--- a/common/buildcraft/energy/BCEnergyConfig.java
+++ b/common/buildcraft/energy/BCEnergyConfig.java
@@ -30,6 +30,7 @@ import buildcraft.core.BCCoreConfig;
 public class BCEnergyConfig {
 
     public static boolean enableOilGeneration;
+    public static double oilWellGenerationRate;
     public static final TIntSet excludedDimensions = new TIntHashSet();
     public static final Set<ResourceLocation> excessiveBiomes = new HashSet<>();
     public static final Set<ResourceLocation> surfaceDepositBiomes = new HashSet<>();
@@ -37,6 +38,7 @@ public class BCEnergyConfig {
     public static SpecialEventType christmasEventStatus = SpecialEventType.DAY_ONLY;
 
     private static Property propEnableOilGeneration;
+    private static Property propOilWellGenerationRate;
     private static Property propExcessiveBiomes;
     private static Property propSurfaceDepositBiomes;
     private static Property propExcludedBiomes;
@@ -48,8 +50,12 @@ public class BCEnergyConfig {
         EnumRestartRequirement game = EnumRestartRequirement.GAME;
 
         propEnableOilGeneration = BCCoreConfig.config.get("worldgen", "enableOilGen", true);
-        propEnableOilGeneration.setComment("Should any oil sprouts or lakes generate, at all?");
+        propEnableOilGeneration.setComment("Should any oil sprouts or lakes be generated at all?");
         game.setTo(propEnableOilGeneration);
+
+        propOilWellGenerationRate = BCCoreConfig.config.get("worldgen", "oilWellGenerationRate", 1.0);
+        propOilWellGenerationRate.setComment("The rate of occurrence of oil wells.");
+        game.setTo(propOilWellGenerationRate);
 
         String[] _excessive = { //
             BCEnergy.MODID + ":oil_desert", //
@@ -101,6 +107,7 @@ public class BCEnergyConfig {
 
             if (EnumRestartRequirement.GAME.hasBeenRestarted(restarted)) {
                 enableOilGeneration = propEnableOilGeneration.getBoolean();
+                oilWellGenerationRate = propOilWellGenerationRate.getDouble();
                 christmasEventStatus = ConfigUtil.parseEnumForConfig(propChristmasEventType, SpecialEventType.DAY_ONLY);
             } else {
                 validateBiomeNames();

--- a/common/buildcraft/energy/BCEnergyConfig.java
+++ b/common/buildcraft/energy/BCEnergyConfig.java
@@ -31,6 +31,7 @@ public class BCEnergyConfig {
 
     public static boolean enableOilGeneration;
     public static double oilWellGenerationRate;
+    public static boolean enableOilSpouts;
     public static final TIntSet excludedDimensions = new TIntHashSet();
     public static final Set<ResourceLocation> excessiveBiomes = new HashSet<>();
     public static final Set<ResourceLocation> surfaceDepositBiomes = new HashSet<>();
@@ -39,6 +40,7 @@ public class BCEnergyConfig {
 
     private static Property propEnableOilGeneration;
     private static Property propOilWellGenerationRate;
+    private static Property propEnableOilSpouts;
     private static Property propExcessiveBiomes;
     private static Property propSurfaceDepositBiomes;
     private static Property propExcludedBiomes;
@@ -56,6 +58,10 @@ public class BCEnergyConfig {
         propOilWellGenerationRate = BCCoreConfig.config.get("worldgen", "oilWellGenerationRate", 1.0);
         propOilWellGenerationRate.setComment("The rate of occurrence of oil wells.");
         game.setTo(propOilWellGenerationRate);
+
+        propEnableOilSpouts = BCCoreConfig.config.get("worldgen", "enableOilSpouts", true);
+        propEnableOilSpouts.setComment("Whether oil spouts are generated or not. The oil spring at the bottom of large lakes will still exist.");
+        game.setTo(propEnableOilSpouts);
 
         String[] _excessive = { //
             BCEnergy.MODID + ":oil_desert", //
@@ -108,6 +114,7 @@ public class BCEnergyConfig {
             if (EnumRestartRequirement.GAME.hasBeenRestarted(restarted)) {
                 enableOilGeneration = propEnableOilGeneration.getBoolean();
                 oilWellGenerationRate = propOilWellGenerationRate.getDouble();
+                enableOilSpouts = propEnableOilSpouts.getBoolean();
                 christmasEventStatus = ConfigUtil.parseEnumForConfig(propChristmasEventType, SpecialEventType.DAY_ONLY);
             } else {
                 validateBiomeNames();

--- a/common/buildcraft/energy/generation/OilGenerator.java
+++ b/common/buildcraft/energy/generation/OilGenerator.java
@@ -104,6 +104,7 @@ public enum OilGenerator implements IWorldGenerator {
         boolean oilBiome = BCEnergyConfig.surfaceDepositBiomes.contains(biome.getRegistryName());
 
         double bonus = oilBiome ? 3.0 : 1.0;
+        bonus *= BCEnergyConfig.oilWellGenerationRate;
         if (BCEnergyConfig.excessiveBiomes.contains(biome.getRegistryName())) {
             bonus *= 30.0;
         }

--- a/common/buildcraft/energy/generation/OilGenerator.java
+++ b/common/buildcraft/energy/generation/OilGenerator.java
@@ -110,15 +110,13 @@ public enum OilGenerator implements IWorldGenerator {
         }
         final GenType type;
 
-        final double random_number = rand.nextDouble();
-
-        if (random_number <= CHANCE_LARGE * bonus) {
+        if (rand.nextDouble() <= CHANCE_LARGE * bonus) {
             // 0.04%
             type = GenType.LARGE;
-        } else if (random_number <= CHANCE_MEDIUM * bonus) {
+        } else if (rand.nextDouble() <= CHANCE_MEDIUM * bonus) {
             // 0.1%
             type = GenType.MEDIUM;
-        } else if (oilBiome && random_number <= CHANCE_LAKE * bonus) {
+        } else if (oilBiome && rand.nextDouble() <= CHANCE_LAKE * bonus) {
             // 2%
             type = GenType.LAKE;
         } else {
@@ -164,7 +162,7 @@ public enum OilGenerator implements IWorldGenerator {
                     radius = 0;
                 }
                 structures.add(createSpout(new BlockPos(x, wellY, z), height, radius));
-            };
+            }
 
             // Generate a spring at the very bottom
             if (type == GenType.LARGE) {

--- a/common/buildcraft/energy/generation/OilGenerator.java
+++ b/common/buildcraft/energy/generation/OilGenerator.java
@@ -109,13 +109,16 @@ public enum OilGenerator implements IWorldGenerator {
             bonus *= 30.0;
         }
         final GenType type;
-        if (rand.nextDouble() <= CHANCE_LARGE * bonus) {
+
+        final double random_number = rand.nextDouble();
+
+        if (random_number <= CHANCE_LARGE * bonus) {
             // 0.04%
             type = GenType.LARGE;
-        } else if (rand.nextDouble() <= CHANCE_MEDIUM * bonus) {
+        } else if (random_number <= CHANCE_MEDIUM * bonus) {
             // 0.1%
             type = GenType.MEDIUM;
-        } else if (oilBiome && rand.nextDouble() <= CHANCE_LAKE * bonus) {
+        } else if (oilBiome && random_number <= CHANCE_LAKE * bonus) {
             // 2%
             type = GenType.LAKE;
         } else {
@@ -151,16 +154,17 @@ public enum OilGenerator implements IWorldGenerator {
             structures.add(createSphere(new BlockPos(x, wellY, z), radius));
 
             // Generate a spout
-
-            int height;
-            if (type == GenType.LARGE) {
-                height = 9 + rand.nextInt(10);
-                radius = 1;
-            } else {
-                height = 6 + rand.nextInt(7);
-                radius = 0;
-            }
-            structures.add(createSpout(new BlockPos(x, wellY, z), height, radius));
+            if (BCEnergyConfig.enableOilSpouts) {
+                int height;
+                if (type == GenType.LARGE) {
+                    height = 9 + rand.nextInt(10);
+                    radius = 1;
+                } else {
+                    height = 6 + rand.nextInt(7);
+                    radius = 0;
+                }
+                structures.add(createSpout(new BlockPos(x, wellY, z), height, radius));
+            };
 
             // Generate a spring at the very bottom
             if (type == GenType.LARGE) {

--- a/common/buildcraft/energy/generation/OilGenerator.java
+++ b/common/buildcraft/energy/generation/OilGenerator.java
@@ -39,7 +39,7 @@ public enum OilGenerator implements IWorldGenerator {
     private static final double CHANCE_MEDIUM = 0.001;
     private static final double CHANCE_LAKE = 0.02;
 
-    public enum GenType {
+    private enum GenType {
         LARGE,
         MEDIUM,
         LAKE,


### PR DESCRIPTION
* Ported option to disable generation of oil spout.
* Ported option to change rate of occurrence of large oil wells.

These are literal ports of the old code. I do not like very much that "rate" is not really a rate of how often a oil well appears, but how likely it is for them to be larger. I think that that is fine as a port, but I definitely support a new issue to improve how oil is generated and what quantities of it should be part of the config, as per #3966. I haven't addressed #3966 because of that.