### PR TITLE
Improvements to Heat Exchanger code

### DIFF
--- a/buildcraft_resources/changelog/7.99.17
+++ b/buildcraft_resources/changelog/7.99.17
@@ -1,4 +1,8 @@
 
+Improvements:
+
+* [#4135] Made Heat Exchanger process arbitrary amounts of fluid.
+
 Ported content:
 
 * [#4080] Re-added the config option to change the rate of oil well generation and generation of a spout.

--- a/common/buildcraft/factory/tile/TileHeatExchange.java
+++ b/common/buildcraft/factory/tile/TileHeatExchange.java
@@ -65,9 +65,9 @@ public class TileHeatExchange extends TileBC_Neptune implements ITickable, IDebu
     public static final int NET_ID_TANK_OUT = IDS.allocId("TANK_OUT");
     public static final int NET_ID_STATE = IDS.allocId("STATE");
 
-    /** Fluid amount multipliers -- this is the maximum amount of fluid that can be transfered per tick. All numbers
-     * need to be divisors of 1000 */
-    private static final int[] FLUID_MULT = { 10, 16, 20 };
+    /** the maximum amount of fluid that can be transferred per tick for each number of middle sections.
+     * numbers need to be divisors of 1000 */
+    private static final int[] FLUID_MULT = { 5, 10, 20 };
 
     @Override
     public IdAllocator getIdAllocator() {

--- a/common/buildcraft/factory/tile/TileHeatExchange.java
+++ b/common/buildcraft/factory/tile/TileHeatExchange.java
@@ -584,17 +584,10 @@ public class TileHeatExchange extends TileBC_Neptune implements ITickable, IDebu
                 throw new IllegalStateException("Invalid recipe " + c_recipe + ", " + h_recipe);
             }
 
-            FluidStack c_in_f_raw = c_recipe.in();
-            FluidStack c_out_f_raw = c_recipe.out();
-            FluidStack h_in_f_raw = h_recipe.in();
-            FluidStack h_out_f_raw = h_recipe.out();
-
             // TODO: Use "charge" to add mb to the charge
             // Ok, so how is the API meant to work? It looks like we just drop the relative amounts...
             // TODO: Make mult the *maximum* multiplier, not the exact one.
             int max = FLUID_MULT[middleCount - 1];
-            boolean needs_c = true;// heatProvided <= 0;
-            boolean needs_h = true;// coolingProvided <= 0;
 
             FluidStack c_in_f = setAmount(c_recipe.in(), max);
             FluidStack c_out_f = setAmount(c_recipe.out(), max);
@@ -605,19 +598,11 @@ public class TileHeatExchange extends TileBC_Neptune implements ITickable, IDebu
                 if (progressState == EnumProgressState.OFF) {
                     progressState = EnumProgressState.PREPARING;
                 } else if (progressState == EnumProgressState.RUNNING) {
-                    // heatProvided--;
-                    // coolingProvided--;
-                    if (needs_c) {
-                        // heatProvided += c_diff;
-                        fill(c_out, c_out_f);
-                        drain(c_in, c_in_f);
-                    }
+                    fill(c_out, c_out_f);
+                    drain(c_in, c_in_f);
 
-                    if (needs_h) {
-                        // coolingProvided += h_diff;
-                        fill(h_out, h_out_f);
-                        drain(h_in, h_in_f);
-                    }
+                    fill(h_out, h_out_f);
+                    drain(h_in, h_in_f);
                 }
             } else {
                 progressState = EnumProgressState.STOPPING;


### PR DESCRIPTION
This allows the Heat Exchanger to receive multiples of 5, which allows to process every combination of fluids from the distiller.

Also removed the multiplier non-divisible by 1000 that was in contradiction to the comment.

af7743f is about allowing the HE to process multiple multiples. E.g. a 3-middle section HE can now process 10 units of liquid if it accepts it.