### PR TITLE
changed getTankProperties to test for fluid on top

### DIFF
--- a/common/buildcraft/factory/tile/TileTank.java
+++ b/common/buildcraft/factory/tile/TileTank.java
@@ -262,7 +262,11 @@ public class TileTank extends TileBC_Neptune implements ITickable, IDebuggable, 
     public IFluidTankProperties[] getTankProperties() {
         List<TileTank> tanks = getTanks();
         TileTank bottom = tanks.get(0);
+        TileTank top = tanks.get(tanks.size() - 1);
         FluidStack total = bottom.tank.getFluid();
+        if(total == null) {
+            total = top.tank.getFluid();
+        }
         int capacity = 0;
         if (total == null) {
             for (TileTank t : tanks) {


### PR DESCRIPTION
the getTankProperties method previously did not account for gasseous liquids, which end up in the top tank.  The function now also checks the top tank in case there is gasseous liquid in it.  It appears this fixes #4133.