### PR TITLE
Log when SimpleScript fails to find a lib file

### DIFF
--- a/common/buildcraft/lib/script/SimpleScript.java
+++ b/common/buildcraft/lib/script/SimpleScript.java
@@ -448,6 +448,7 @@ public class SimpleScript {
                 log("" + e.getMessage());
             }
         }
+        log("Unable to find " + libDomain + "/compat/" + registry.getEntryType() + "/" + path + ".txt from " + roots);
         return null;
     }
 


### PR DESCRIPTION
As discussed a few days ago on Discord, when `SimpleScript` parses an import it expects missing files to already be logged ([here](https://github.com/BuildCraft/BuildCraft/blob/8.0.x/common/buildcraft/lib/script/SimpleScript.java#L249)). Whilst it does for invalidly formatted imports (ie missing a colon), if the for loop can't find it nothing is logged.

Went with logging the file path it's looking for and the places it looked for it purely to make it quite obvious whether it's because it's missing a domain from `roots` or because the lib isn't in the right place.