### PR TITLE
Release ByteBufs that are ensured empty

### DIFF
--- a/common/buildcraft/lib/misc/MessageUtil.java
+++ b/common/buildcraft/lib/misc/MessageUtil.java
@@ -284,7 +284,7 @@ public class MessageUtil {
     }
 
     /** Checks to make sure that this buffer has been *completely* read (so that there are no readable bytes left
-     * over */
+     * over) */
     public static void ensureEmpty(ByteBuf buf, boolean throwError, String extra) {
         int readableBytes = buf.readableBytes();
         int rb = readableBytes;
@@ -339,5 +339,7 @@ public class MessageUtil {
             }
             buf.clear();
         }
+
+        buf.release(); //Finished with the buffer so it can now be deallocated
     }
 }


### PR DESCRIPTION
Ever since Forge started doing `ByteBuf#retain` on packets, running with `-Dio.netty.leakDetection.level=advanced` to find unreleased packets results in periodic warnings from packets BuildCraft hasn't released. Given that `MessageUtil#ensureEmpty` is for checking that a buffer is empty, it is a reasonable presumption that it isn't going to be used subsequently thus is a good place to release the buffer too.
Releasing buffers can cause issues if they're already released, but from what I've tested this never happens with the way BC is networking right now at the very least.