### PR TITLE
Fix #4407 - Minecraft doesn't crash anymore when gate sets filler pattern

### DIFF
--- a/common/buildcraft/builders/tile/TileFiller.java
+++ b/common/buildcraft/builders/tile/TileFiller.java
@@ -496,7 +496,7 @@ public class TileFiller extends TileBC_Neptune
     @Override
     public void setPattern(IFillerPattern pattern, IStatementParameter[] params) {
         patternStatement.set(pattern);
-        IntStream.range(0, patternStatement.maxParams).forEach(i -> patternStatement.set(i, params[i]));
+        IntStream.range(0, params.length).forEach(i -> patternStatement.set(i, params[i]));
         finished = false;
         lockedTicks = 3;
     }


### PR DESCRIPTION
Game doesn't crash anymore, when gate sets filler pattern