### PR TITLE
Fixed Javadoc build errors

### DIFF
--- a/common/buildcraft/lib/script/SimpleScript.java
+++ b/common/buildcraft/lib/script/SimpleScript.java
@@ -636,17 +636,17 @@ public class SimpleScript {
     public enum TokenType {
         /** "string" */
         QUOTED_STRING(true),
-        /** `a<br/>
-         * multi<br/>
-         * line<br/>
+        /** `a<br>
+         * multi<br>
+         * line<br>
          * string` */
         BACKTICK_STRING(true),
         /** functionName */
         SEPARATE(false),
         /** // Comment */
         COMMENT(false),
-        /** {@literal /}** Comment<br/>
-         * * % argument comment<br/>
+        /** {@literal /}** Comment<br>
+         * * % argument comment<br>
          * *{@literal /} */
         FUNC_DOCS(false);
 

--- a/sub_projects/expression/src/main/java/buildcraft/lib/expression/api/NodeTypes.java
+++ b/sub_projects/expression/src/main/java/buildcraft/lib/expression/api/NodeTypes.java
@@ -272,10 +272,10 @@ public class NodeTypes {
 
         /** Relational operators:
          * <ul>
-         * <li>LT: "<", less than</li>
-         * <li>GT: ">", greater than</li>
-         * <li>LE: "<=", less than or equals</li>
-         * <li>GE: ">=", greater than or equals</li>
+         * <li>LT: "&lt;", less than</li>
+         * <li>GT: "&gt;", greater than</li>
+         * <li>LE: "&lt;=", less than or equals</li>
+         * <li>GE: "&gt;=", greater than or equals</li>
          * <li>EQ: "==", equals</li>
          * <li>NE: "!=", not equal</li>
          * </ul>
@@ -324,10 +324,10 @@ public class NodeTypes {
 
         /** Relational operators:
          * <ul>
-         * <li>LT: "<", less than</li>
-         * <li>GT: ">", greater than</li>
-         * <li>LE: "<=", less than or equals</li>
-         * <li>GE: ">=", greater than or equals</li>
+         * <li>LT: "&lt;", less than</li>
+         * <li>GT: "&gt;", greater than</li>
+         * <li>LE: "&lt;=", less than or equals</li>
+         * <li>GE: "&gt;=", greater than or equals</li>
          * <li>EQ: "==", equals</li>
          * <li>NE: "!=", not equal</li>
          * </ul>


### PR DESCRIPTION
I fixed the main issues in the Javadoc, caused by malformed HTML code, which lead to build errors 