### PR TITLE
Fix #4553

### DIFF
--- a/common/buildcraft/lib/misc/StackMatchingPredicate.java
+++ b/common/buildcraft/lib/misc/StackMatchingPredicate.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020 SpaceToad and the BuildCraft team
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/
+ */
+
+package buildcraft.lib.misc;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.item.ItemStack;
+
+@FunctionalInterface
+public interface StackMatchingPredicate {
+    boolean isMatching(@Nonnull ItemStack base, @Nonnull ItemStack comparison);
+}

--- a/common/buildcraft/lib/misc/StackNbtMatcher.java
+++ b/common/buildcraft/lib/misc/StackNbtMatcher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020 SpaceToad and the BuildCraft team
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not
+ * distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/
+ */
+
+package buildcraft.lib.misc;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * Predicate that compares values of specified NBT keys subset.
+ */
+public class StackNbtMatcher implements StackMatchingPredicate {
+    private String[] keys;
+
+    public StackNbtMatcher(@Nonnull String ...keys) {
+        this.keys = keys;
+    }
+
+    @Override
+    public boolean isMatching(@Nonnull ItemStack base, @Nonnull ItemStack comparison) {
+        NBTTagCompound baseNBT = base.getTagCompound();
+        NBTTagCompound comparisonNBT = comparison.getTagCompound();
+
+        for (String key : keys) {
+            NBTBase baseValue = baseNBT != null ? baseNBT.getTag(key) : null;
+            NBTBase comparisonValue = comparisonNBT != null ? comparisonNBT.getTag(key) : null;
+            if (!Objects.equals(baseValue, comparisonValue)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
It is a part of the fix. The second part will go to BuildCraftCompat. There will be a registration of NBT keys for ic2 cables.