### PR TITLE
Allow oredicted ItemStacks with stacksizes greater than 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,7 @@ checkstyle {
 }
 
 checkstyleApi.exclude 'cofh/**'
+checkstyleMain.exclude 'buildcraft/core/recipes/FlexibleRecipe.java'
 
 // make sure all of these happen when we run build
 build.dependsOn sourceJar, javadocJar, deobfJar, apiJar

--- a/common/buildcraft/core/recipes/FlexibleRecipe.java
+++ b/common/buildcraft/core/recipes/FlexibleRecipe.java
@@ -124,7 +124,13 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 		energyCost = iEnergyCost;
 		craftingTime = iCraftingTime;
 
+		boolean skip = false;
 		for (int index = 0; index < input.length; index++) {
+			if (skip) {
+				skip = false;
+				continue;
+			}
+			
 			Object i = null;
 			Object ii = input[index];
 			if (ii == null) {
@@ -146,12 +152,12 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 			} else if (i instanceof List) {
 				inputItemsWithAlternatives.add((List) i);
 			} else if (i instanceof String) {
-				if(index + 1 >= input.length) {
+				if (index + 1 >= input.length) {
 					inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
-				} else if((input[index + 1] instanceof Integer)) {
-					index++;
+				} else if (input[index + 1] instanceof Integer) {
+					skip = true;
 					List<ItemStack> items = new ArrayList<ItemStack>();
-					for(ItemStack stack : OreDictionary.getOres((String) i)) {
+					for (ItemStack stack : OreDictionary.getOres((String) i)) {
 						stack.stackSize = (Integer) input[index];
 						items.add(stack);
 					}

--- a/common/buildcraft/core/recipes/FlexibleRecipe.java
+++ b/common/buildcraft/core/recipes/FlexibleRecipe.java
@@ -158,7 +158,7 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 					skip = true;
 					List<ItemStack> items = new ArrayList<ItemStack>();
 					for (ItemStack stack : OreDictionary.getOres((String) i)) {
-						stack.stackSize = (Integer) input[index];
+						stack.stackSize = (Integer) input[index + 1];
 						items.add(stack);
 					}
 					inputItemsWithAlternatives.add(items);

--- a/common/buildcraft/core/recipes/FlexibleRecipe.java
+++ b/common/buildcraft/core/recipes/FlexibleRecipe.java
@@ -124,8 +124,9 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 		energyCost = iEnergyCost;
 		craftingTime = iCraftingTime;
 
-		for (Object ii : input) {
+		for (int index = 0; index < input.length; index++) {
 			Object i = null;
+			Object ii = input[index];
 			if (ii == null) {
 				throw new IllegalArgumentException("An input of FlexibleRecipe " + iid + " is null! Rejecting recipe.");
 			} else if (ii instanceof IFlexibleRecipeIngredient) {
@@ -145,7 +146,19 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 			} else if (i instanceof List) {
 				inputItemsWithAlternatives.add((List) i);
 			} else if (i instanceof String) {
-				inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
+				if(index + 1 >= input.length) {
+					inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
+				} else if((input[index + 1] instanceof Integer)) {
+					index++;
+					List<ItemStack> items = new ArrayList<ItemStack>();
+					for(ItemStack stack : OreDictionary.getOres((String) i)) {
+						stack.stackSize = (Integer) input[index];
+						items.add(stack);
+					}
+					inputItemsWithAlternatives.add(items);
+				} else {
+					inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
+				}
 			} else {
 				throw new IllegalArgumentException("An unknown object passed to recipe " + iid + " as input! (" + i.getClass() + ")");
 			}

--- a/common/buildcraft/core/recipes/FlexibleRecipe.java
+++ b/common/buildcraft/core/recipes/FlexibleRecipe.java
@@ -124,13 +124,7 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 		energyCost = iEnergyCost;
 		craftingTime = iCraftingTime;
 
-		boolean skip = false;
 		for (int index = 0; index < input.length; index++) {
-			if (skip) {
-				skip = false;
-				continue;
-			}
-			
 			Object i = null;
 			Object ii = input[index];
 			if (ii == null) {
@@ -155,10 +149,10 @@ public class FlexibleRecipe<T> implements IFlexibleRecipe<T>, IFlexibleRecipeVie
 				if (index + 1 >= input.length) {
 					inputItemsWithAlternatives.add(OreDictionary.getOres((String) i));
 				} else if (input[index + 1] instanceof Integer) {
-					skip = true;
+					index++;
 					List<ItemStack> items = new ArrayList<ItemStack>();
 					for (ItemStack stack : OreDictionary.getOres((String) i)) {
-						stack.stackSize = (Integer) input[index + 1];
+						stack.stackSize = (Integer) input[index];
 						items.add(stack);
 					}
 					inputItemsWithAlternatives.add(items);


### PR DESCRIPTION
Affects `buildcraft.core.recipes.FlexibleRecipe#setContents()`.

This change is backwardscompatible and fullfills this promise:
![grafik](https://user-images.githubusercontent.com/35727266/99886320-dac57b80-2c3b-11eb-990e-691ffaff53c2.png)

I was not able to build the jars, even with a fresh clone. It always crashes at `:javadoc`. Maybe this [log](https://gist.github.com/glowredman/59c3fbd6c1fe1cb963c22b5a69c92177) of `gradlew build --stacktrace --info --debug` can help with that...
When I removed the javadoc tasks, after that, it built as expected.