### PR TITLE
Fix #4608 Mining well can not move through flowing water blocks

### DIFF
--- a/common/buildcraft/factory/tile/TileMiningWell.java
+++ b/common/buildcraft/factory/tile/TileMiningWell.java
@@ -87,7 +87,7 @@ public class TileMiningWell extends TileMiner {
     }
 
     private boolean canBreak() {
-        if (world.isAirBlock(currentPos) || BlockUtil.isUnbreakableBlock(world, currentPos, getOwner())) {
+        if (world.getBlockState(currentPos).getBlockHardness(world, currentPos) < 0) {
             return false;
         }
 


### PR DESCRIPTION
### Changed block breaking criteria to match Quarry

Changed criteria on which it's decided, if the mining well can break a block to match the quarry. This should resolve issue #4608, in which the mining well can not move through flowing water blocks, since the quarry doesn't suffer from such issue.

**Please test proposed code before accepting the pull request.**