### PR TITLE
Fix #4621 by not rendering item frames with filled maps

### DIFF
--- a/common/buildcraft/builders/snapshot/ClientSnapshots.java
+++ b/common/buildcraft/builders/snapshot/ClientSnapshots.java
@@ -25,6 +25,9 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItemFrame;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 
@@ -167,6 +170,16 @@ public enum ClientSnapshots {
         }
         // noinspection Guava
         for (Entity entity : world.getEntities(Entity.class, Predicates.alwaysTrue())) {
+        	// Don't render filled maps, because they cause the client to crash, render an empty item frame instead
+        	if (entity instanceof EntityItemFrame) {
+				ItemStack i = ((EntityItemFrame) entity).getDisplayedItem();
+				        		
+	    		if (i.getItem().getRegistryName().toString().equals("minecraft:filled_map")) {
+	    			((EntityItemFrame) entity).setDisplayedItem(new ItemStack(Item.getByNameOrId("minecraft:air")));
+	    		}
+        	}
+        	
+        	// Render entities
             Vec3d pos = entity.getPositionVector();
             GlStateManager.pushAttrib();
             Minecraft.getMinecraft().getRenderManager().renderEntity(


### PR DESCRIPTION
### Fix #4621 Crash when looking at blueprint render containing item frame with map.

Tweaked the code rendering the blueprint preview, more specifically the method rendering entities. Changed it so in the preview, item frames with filled maps are rendered as simple empty item frames (filled by minecraft:air). This prevents the client from crashing when attempting to render the filled map.

**Proposed changes have been tested and seem to work.**

P.S. It might not be a super elegant fix, but definitely works, and fixes this game breaking bug. Open to other suggestions too, but looking at the fact that builders need major overhauling, until that happens it doesn't make sense to take the time to find a better solution.