### PR TITLE
8.0.x

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
 mc_version=1.12.2
 forge_version=14.23.0.2544
 mappings_version=snapshot_20171120
-mod_version=7.99.24.3-pre1
+mod_version=7.99.24.3-pre2

--- a/buildcraft_resources/changelog/7.99.24.3
+++ b/buildcraft_resources/changelog/7.99.24.3
@@ -2,3 +2,4 @@ Bug fixes:
 
 * [#4468] Stopped buildcraft tiles from uselessly logging that the *client* lacked ownership information (despite ownership only being used on the server).
 * [#4471] Fixed a crash when spawning block breaking particles in an invalid state.
+* [#4472] Add frame and mining box validation checks when the quarry is read from NBT. 


### PR DESCRIPTION
Since we're using 8.0.x-1.12.2 instead of 8.0.x this commit went to the wrong place. Woops!