### PR TITLE
[1.12.2] Optimize wire system powered checks

### DIFF
--- a/common/buildcraft/lib/tile/TileBC_Neptune.java
+++ b/common/buildcraft/lib/tile/TileBC_Neptune.java
@@ -375,10 +375,7 @@ public abstract class TileBC_Neptune extends TileEntity implements IPayloadRecei
      * the current chunk is saved after the last tick. */
     public void markChunkDirty() {
         if (world != null) {
-            Chunk chunk = getContainingChunk();
-            if (chunk != null) {
-                chunk.markDirty();
-            }
+            world.markChunkDirty(this.pos, this);
         }
     }
 

--- a/common/buildcraft/transport/statements/TriggerPipeSignal.java
+++ b/common/buildcraft/transport/statements/TriggerPipeSignal.java
@@ -66,11 +66,7 @@ public class TriggerPipeSignal extends BCStatement implements ITriggerInternal {
         IGate gate = (IGate) container;
         IWireManager wires = gate.getPipeHolder().getWireManager();
 
-        if (active) {
-            if (!wires.isAnyPowered(colour)) {
-                return false;
-            }
-        } else if (wires.isAnyPowered(colour)) {
+        if (this.active != wires.isAnyPowered(this.colour)) {
             return false;
         }
 
@@ -80,11 +76,7 @@ public class TriggerPipeSignal extends BCStatement implements ITriggerInternal {
                 if (signal.colour == null) {
                     continue;
                 }
-                if (signal.active) {
-                    if (!wires.isAnyPowered(signal.colour)) {
-                        return false;
-                    }
-                } else if (wires.isAnyPowered(signal.colour)) {
+                if (signal.active != wires.isAnyPowered(signal.colour)) {
                     return false;
                 }
             }

--- a/common/buildcraft/transport/wire/MessageWireSystems.java
+++ b/common/buildcraft/transport/wire/MessageWireSystems.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 
 import net.minecraft.network.PacketBuffer;
@@ -49,12 +50,15 @@ public class MessageWireSystems implements IMessage {
         wireSystems.clear();
         int count = pb.readInt();
         for (int i = 0; i < count; i++) {
-            WireSystem wireSystem = new WireSystem();
             int wiresHashCode = pb.readInt();
             int localCount = pb.readInt();
+
+            ImmutableList.Builder<WireSystem.WireElement> elements = ImmutableList.builder();
             for (int j = 0; j < localCount; j++) {
-                wireSystem.elements.add(new WireSystem.WireElement(pb));
+                elements.add(new WireSystem.WireElement(pb));
             }
+            WireSystem wireSystem = new WireSystem(elements.build(), null);
+
             wireSystems.put(wiresHashCode, wireSystem);
         }
     }

--- a/common/buildcraft/transport/wire/WireManager.java
+++ b/common/buildcraft/transport/wire/WireManager.java
@@ -185,8 +185,7 @@ public class WireManager implements IWireManager {
 
     @Override
     public boolean isAnyPowered(EnumDyeColor color) {
-        return parts.entrySet().stream().filter(partColor -> partColor.getValue() == color)
-            .anyMatch(partColor -> isPowered(partColor.getKey()));
+        return parts.entrySet().stream().anyMatch(partColor -> partColor.getValue() == color && isPowered(partColor.getKey()));
     }
 
     public NBTTagCompound writeToNbt() {

--- a/common/buildcraft/transport/wire/WireManager.java
+++ b/common/buildcraft/transport/wire/WireManager.java
@@ -176,8 +176,9 @@ public class WireManager implements IWireManager {
         if (holder.getPipeWorld().isRemote) {
             return poweredClient.contains(part);
         } else {
-            return getWireSystems().getWireSystemsWithElementAsReadOnlyStream(new WireSystem.WireElement(holder.getPipePos(), part))
-                .map(wireSystem -> getWireSystems().wireSystems.get(wireSystem)).filter(Objects::nonNull)
+            WorldSavedDataWireSystems wireSystems = this.getWireSystems();
+            return wireSystems.getWireSystemsWithElementAsReadOnlyStream(new WireSystem.WireElement(holder.getPipePos(), part))
+                .map(wireSystems.wireSystems::get).filter(Objects::nonNull)
                 .reduce(Boolean::logicalOr).orElse(false);
         }
     }

--- a/common/buildcraft/transport/wire/WireManager.java
+++ b/common/buildcraft/transport/wire/WireManager.java
@@ -176,8 +176,8 @@ public class WireManager implements IWireManager {
         if (holder.getPipeWorld().isRemote) {
             return poweredClient.contains(part);
         } else {
-            return getWireSystems().getWireSystemsWithElement(new WireSystem.WireElement(holder.getPipePos(), part))
-                .stream().map(wireSystem -> getWireSystems().wireSystems.get(wireSystem)).filter(Objects::nonNull)
+            return getWireSystems().getWireSystemsWithElementAsReadOnlyStream(new WireSystem.WireElement(holder.getPipePos(), part))
+                .map(wireSystem -> getWireSystems().wireSystems.get(wireSystem)).filter(Objects::nonNull)
                 .reduce(Boolean::logicalOr).orElse(false);
         }
     }

--- a/common/buildcraft/transport/wire/WireManager.java
+++ b/common/buildcraft/transport/wire/WireManager.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -177,15 +178,29 @@ public class WireManager implements IWireManager {
             return poweredClient.contains(part);
         } else {
             WorldSavedDataWireSystems wireSystems = this.getWireSystems();
-            return wireSystems.getWireSystemsWithElementAsReadOnlyStream(new WireSystem.WireElement(holder.getPipePos(), part))
-                .map(wireSystems.wireSystems::get).filter(Objects::nonNull)
-                .reduce(Boolean::logicalOr).orElse(false);
+            List<WireSystem> wireSystemsWithElement = wireSystems.getWireSystemsWithElementAsReadOnlyList(new WireSystem.WireElement(holder.getPipePos(), part));
+            if (!wireSystemsWithElement.isEmpty()) {
+                for (WireSystem wireSystem : wireSystemsWithElement) {
+                    Boolean powered = wireSystems.wireSystems.get(wireSystem);
+                    if (powered != null && powered) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
 
     @Override
     public boolean isAnyPowered(EnumDyeColor color) {
-        return parts.entrySet().stream().anyMatch(partColor -> partColor.getValue() == color && isPowered(partColor.getKey()));
+        if (!this.parts.isEmpty()) {
+            for (Map.Entry<EnumWirePart, EnumDyeColor> partColor : this.parts.entrySet()) {
+                if (partColor.getValue() == color && this.isPowered(partColor.getKey())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public NBTTagCompound writeToNbt() {

--- a/common/buildcraft/transport/wire/WireSystem.java
+++ b/common/buildcraft/transport/wire/WireSystem.java
@@ -51,6 +51,8 @@ public class WireSystem {
     public final List<WireElement> elements = new ArrayList<>();
     public EnumDyeColor color = null;
 
+    private transient long cachedHashCode = -1L;
+
     public boolean hasElement(WireElement element) {
         return elements.contains(element);
     }
@@ -149,6 +151,7 @@ public class WireSystem {
         while (!queue.isEmpty()) {
             build.accept(queue.remove());
         }
+        this.markDirty();
         return this;
     }
 
@@ -192,6 +195,7 @@ public class WireSystem {
         NBTTagList elementsList = nbt.getTagList("elements", Constants.NBT.TAG_COMPOUND);
         IntStream.range(0, elementsList.tagCount()).mapToObj(elementsList::getCompoundTagAt).map(WireElement::new).forEach(elements::add);
         color = EnumDyeColor.byMetadata(nbt.getInteger("color"));
+        this.markDirty();
         return this;
     }
 
@@ -214,9 +218,22 @@ public class WireSystem {
 
     @Override
     public int hashCode() {
+        if (this.cachedHashCode >= 0L) {
+            return (int) this.cachedHashCode;
+        }
+        return this.computeHashCode();
+    }
+
+    private int computeHashCode() {
         int result = elements.hashCode();
         result = 31 * result + (color != null ? color.hashCode() : 0);
+
+        this.cachedHashCode = Integer.toUnsignedLong(result);
         return result;
+    }
+
+    public void markDirty() {
+        this.cachedHashCode = -1L;
     }
 
     public static class WireElement {

--- a/common/buildcraft/transport/wire/WireSystem.java
+++ b/common/buildcraft/transport/wire/WireSystem.java
@@ -127,8 +127,8 @@ public final class WireSystem {
         Queue<WireElement> queue = new ArrayDeque<>();
         queue.add(startElement);
 
-        EnumDyeColor color = null;
-        ImmutableList.Builder<WireElement> elements = ImmutableList.builder();
+        EnumDyeColor tempColor = null;
+        ImmutableList.Builder<WireElement> elementBuilder = ImmutableList.builder();
 
         while (!queue.isEmpty()) {
             WireElement element = queue.remove();
@@ -146,21 +146,21 @@ public final class WireSystem {
                 if (holder != null) {
                     if (element.type == WireElement.Type.WIRE_PART) {
                         EnumDyeColor colorOfPart = holder.getWireManager().getColorOfPart(element.wirePart);
-                        if (color == null) {
+                        if (tempColor == null) {
                             if (colorOfPart != null) {
-                                color = colorOfPart;
+                                tempColor = colorOfPart;
                             }
                         }
-                        if (color != null && colorOfPart == color) {
-                            EnumDyeColor colorButFinal = color; //damn you java
+                        if (tempColor != null && colorOfPart == tempColor) {
+                            EnumDyeColor colorButFinal = tempColor; //damn you java
                             wireSystems.getWireSystemsWithElement(element).stream().filter(wireSystem -> wireSystem != this && wireSystem.color == colorButFinal).forEach(wireSystems::removeWireSystem);
-                            elements.add(element);
+                            elementBuilder.add(element);
                             queue.addAll(getConnectedElementsOfElement(wireSystems.world, element));
                             Arrays.stream(EnumFacing.VALUES).forEach(side -> queue.add(new WireElement(element.blockPos, side)));
                         }
                     } else if (element.type == WireElement.Type.EMITTER_SIDE) {
                         if (holder.getPluggable(element.emitterSide) instanceof IWireEmitter) {
-                            elements.add(new WireElement(element.blockPos, element.emitterSide));
+                            elementBuilder.add(new WireElement(element.blockPos, element.emitterSide));
                         }
                     }
                 }
@@ -168,8 +168,8 @@ public final class WireSystem {
             }
         }
 
-        this.elements = elements.build();
-        this.color = color;
+        this.elements = elementBuilder.build();
+        this.color = tempColor;
 
         this.cachedHashCode = this.computeHashCode();
         this.cachedWiresHashCode = this.computeCachedWiresHashCode();

--- a/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
+++ b/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.base.Predicates;
 
@@ -62,7 +63,11 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     }
 
     public List<WireSystem> getWireSystemsWithElement(WireSystem.WireElement element) {
-        return wireSystems.keySet().stream().filter(wireSystem -> wireSystem.hasElement(element)).collect(Collectors.toList());
+        return getWireSystemsWithElementAsReadOnlyStream(element).collect(Collectors.toList());
+    }
+
+    public Stream<WireSystem> getWireSystemsWithElementAsReadOnlyStream(WireSystem.WireElement element) {
+        return wireSystems.keySet().stream().filter(wireSystem -> wireSystem.hasElement(element));
     }
 
     public void removeWireSystem(WireSystem wireSystem) {

--- a/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
+++ b/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Predicates;
 
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -48,6 +49,8 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     public final List<EntityPlayerMP> changedPlayers = new ArrayList<>();
     public final Map<WireSystem.WireElement, IWireEmitter> emittersCache = new HashMap<>();
 
+    private final Map<WireSystem.WireElement, List<WireSystem>> elementsToWireSystemsIndex = new HashMap<>();
+
     public WorldSavedDataWireSystems() {
         super(DATA_NAME);
     }
@@ -76,7 +79,7 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     }
 
     public void buildAndAddWireSystem(WireSystem.WireElement element) {
-        WireSystem wireSystem = new WireSystem().build(this, element);
+        WireSystem wireSystem = new WireSystem(this, element);
         if(!wireSystem.isEmpty()) {
             wireSystems.put(wireSystem, false);
             wireSystems.put(wireSystem, wireSystem.update(this));
@@ -182,7 +185,7 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
         NBTTagList entriesList = nbt.getTagList("entries", Constants.NBT.TAG_COMPOUND);
         for(int i = 0; i < entriesList.tagCount(); i++) {
             NBTTagCompound entry = entriesList.getCompoundTagAt(i);
-            wireSystems.put(new WireSystem().readFromNBT(entry.getCompoundTag("wireSystem")), entry.getBoolean("powered"));
+            wireSystems.put(new WireSystem(entry.getCompoundTag("wireSystem")), entry.getBoolean("powered"));
         }
     }
 

--- a/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
+++ b/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
@@ -8,16 +8,15 @@ package buildcraft.transport.wire;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.base.Predicates;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -66,22 +65,41 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     }
 
     public List<WireSystem> getWireSystemsWithElement(WireSystem.WireElement element) {
-        return getWireSystemsWithElementAsReadOnlyStream(element).collect(Collectors.toList());
+        List<WireSystem> wireSystems = this.elementsToWireSystemsIndex.get(element);
+        return wireSystems != null ? new ArrayList<>(wireSystems) : Collections.emptyList();
     }
 
-    public Stream<WireSystem> getWireSystemsWithElementAsReadOnlyStream(WireSystem.WireElement element) {
-        return wireSystems.keySet().stream().filter(wireSystem -> wireSystem.hasElement(element));
+    public List<WireSystem> getWireSystemsWithElementAsReadOnlyList(WireSystem.WireElement element) {
+        return this.elementsToWireSystemsIndex.getOrDefault(element, Collections.emptyList());
     }
 
     public void removeWireSystem(WireSystem wireSystem) {
         wireSystems.remove(wireSystem);
+        wireSystem.elements.forEach(elementIn -> {
+            elementsToWireSystemsIndex.computeIfPresent(elementIn, (element, wireSystems) -> {
+                wireSystems.remove(wireSystem);
+                return wireSystems.isEmpty() ? null : wireSystems;
+            });
+        });
         markStructureChanged();
+    }
+
+    public void addWireSystem(WireSystem wireSystem, boolean powered) {
+        if (this.wireSystems.put(wireSystem, powered) == null) {
+            wireSystem.elements.forEach(systemElement -> {
+                List<WireSystem> wireSystems = this.elementsToWireSystemsIndex.computeIfAbsent(systemElement, unused -> new ArrayList<>());
+                if (wireSystems.contains(wireSystem)) {
+                    throw new IllegalStateException();
+                }
+                wireSystems.add(wireSystem);
+            });
+        }
     }
 
     public void buildAndAddWireSystem(WireSystem.WireElement element) {
         WireSystem wireSystem = new WireSystem(this, element);
         if(!wireSystem.isEmpty()) {
-            wireSystems.put(wireSystem, false);
+            this.addWireSystem(wireSystem, false);
             wireSystems.put(wireSystem, wireSystem.update(this));
         }
         markStructureChanged();
@@ -133,12 +151,13 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
 
     public void tick() {
         if(gatesChanged) {
-            wireSystems.keySet().stream()
-                    .filter(wireSystem -> {
-                        boolean newPowered = wireSystem.update(this);
-                        return wireSystems.put(wireSystem, newPowered) != newPowered;
-                    })
-                    .forEach(changedSystems::add);
+            wireSystems.replaceAll((wireSystem, oldPowered) -> {
+                boolean newPowered = wireSystem.update(this);
+                if (oldPowered != newPowered) {
+                    changedSystems.add(wireSystem);
+                }
+                return newPowered;
+            });
         }
         world.getPlayers(EntityPlayerMP.class, Predicates.alwaysTrue()).forEach(player -> {
             Map<Integer, WireSystem> changedWires = this.wireSystems.keySet().stream()
@@ -182,10 +201,12 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         wireSystems.clear();
+        this.elementsToWireSystemsIndex.clear();
+
         NBTTagList entriesList = nbt.getTagList("entries", Constants.NBT.TAG_COMPOUND);
         for(int i = 0; i < entriesList.tagCount(); i++) {
             NBTTagCompound entry = entriesList.getCompoundTagAt(i);
-            wireSystems.put(new WireSystem(entry.getCompoundTag("wireSystem")), entry.getBoolean("powered"));
+            this.addWireSystem(new WireSystem(entry.getCompoundTag("wireSystem")), entry.getBoolean("powered"));
         }
     }
 

--- a/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
+++ b/common/buildcraft/transport/wire/WorldSavedDataWireSystems.java
@@ -65,8 +65,8 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     }
 
     public List<WireSystem> getWireSystemsWithElement(WireSystem.WireElement element) {
-        List<WireSystem> wireSystems = this.elementsToWireSystemsIndex.get(element);
-        return wireSystems != null ? new ArrayList<>(wireSystems) : Collections.emptyList();
+        List<WireSystem> wireSystemsWithElement = this.elementsToWireSystemsIndex.get(element);
+        return wireSystemsWithElement != null ? new ArrayList<>(wireSystemsWithElement) : Collections.emptyList();
     }
 
     public List<WireSystem> getWireSystemsWithElementAsReadOnlyList(WireSystem.WireElement element) {
@@ -87,11 +87,11 @@ public class WorldSavedDataWireSystems extends WorldSavedData {
     public void addWireSystem(WireSystem wireSystem, boolean powered) {
         if (this.wireSystems.put(wireSystem, powered) == null) {
             wireSystem.elements.forEach(systemElement -> {
-                List<WireSystem> wireSystems = this.elementsToWireSystemsIndex.computeIfAbsent(systemElement, unused -> new ArrayList<>());
-                if (wireSystems.contains(wireSystem)) {
+                List<WireSystem> wireSystemsWithElement = this.elementsToWireSystemsIndex.computeIfAbsent(systemElement, unused -> new ArrayList<>());
+                if (wireSystemsWithElement.contains(wireSystem)) {
                     throw new IllegalStateException();
                 }
-                wireSystems.add(wireSystem);
+                wireSystemsWithElement.add(wireSystem);
             });
         }
     }


### PR DESCRIPTION
This PR optimizes `WireManager#isPowered(EnumWirePart)` and methods used by it in the following ways:

- The very expensive `WireSystem#hashCode()` is pre-computed and stored in a field
  - This makes the `HashMap` lookups when accessing `WorldSavedDataWireSystems#wireSystems` significantly faster (`HashMap#get(Object)` previously took around 30% of `WireManager#isPowered(EnumWirePart)`'s total CPU time according to my profiling, and now doesn't even get picked up by VisualVM any more)
- Added a `Map<WireSystem.WireElement, List<WireSystem>>` to `WorldSavedDataWireSystems` which makes it possible to implement `WorldSavedDataWireSystems#getWireSystemsWithElement(WireSystem.WireElement)` efficiently
  - The previous implementation iterated over every `WireSystem.WireElement` in every `WireSystem` on every call to `WorldSavedDataWireSystems#getWireSystemsWithElement(WireSystem.WireElement)`, which doesn't scale very well (especially when you consider that it gets called once per tick, per gate trigger, per pipe wire attached to the same pipe as the gate)
- Replaced stream API usage in various hot spots in `WireManager`/`WorldSavedDataWireSystems` with the fully written-out "normal" code, as the very deep call chains caused by using streams were badly limiting the JVM's ability to inline things, and also filling up the heap very quickly with a lot of garbage (no inlining -> no escape analysis -> objects actually land on the heap -> incalculable pain and suffering)
  - No, this isn't just micro-optimization, it actually gave me a ~2.5x boost by itself
- (Not an optimization) Made `WireSystem` immutable, as modifying it would have affected the hash code changing (would have been annoying to deal with invalidating the cached hash code), not to mention that allowing it to be modified kinda conflicts with its primary role as a `HashMap` key in `WorldSavedDataWireSystems`. IMO this is much cleaner and will certainly prevent anyone from trying to use it incorrectly, however the rest of the optimizations can still function without this change if necessary.

Extra bonus fixes and improvements:
- Used `Map#replaceAll(BiFunction)` in `WorldSavedDataWireSystems#tick()` to avoid a pointless `put` for every `WireSystem` every time a gate changes
- Used `World#markChunkDirty(BlockPos, TileEntity)` in `TileBC_Neptune#markChunkDirty()` rather than explicitly getting the chunk and calling `markDirty()`, this ensures the tile entity actually gets saved when using Cubic Chunks is being used

All together, this reduced the total CPU time spent in `WireManager#isPowered(EnumWirePart)` by as much as 200x (times, not percent!) on one of my larger worlds, shaving off a solid 30ms per tick.

Not sure about code style, let me know if I should change anything :)