### PR TITLE
[1.7.10] Add API for setting pipe render state and pluggable state

### DIFF
--- a/common/buildcraft/transport/TileGenericPipe.java
+++ b/common/buildcraft/transport/TileGenericPipe.java
@@ -70,8 +70,8 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler,
 		IDebuggable, IPipeConnection {
 
 	public boolean initialized = false;
-	public final PipeRenderState renderState = new PipeRenderState();
-	public final PipePluggableState pluggableState = new PipePluggableState();
+	public final PipeRenderState renderState = createRenderState();
+	public final PipePluggableState pluggableState = createPluggableState();
 	public final CoreState coreState = new CoreState();
 	public boolean[] pipeConnectionsBuffer = new boolean[6];
 
@@ -256,6 +256,14 @@ public class TileGenericPipe extends TileEntity implements IFluidHandler,
 	}
 
 	public TileGenericPipe() {
+	}
+
+	protected PipeRenderState createRenderState() {
+		return new PipeRenderState();
+	}
+
+	protected PipePluggableState createPluggableState() {
+		return new PipePluggableState();
 	}
 
 	@Override


### PR DESCRIPTION
Logistics Pipes [reflects](https://github.com/RS485/LogisticsPipes/blob/9e9f97a9af89fd2591311e0f78e6959488221b98/common/logisticspipes/proxy/buildcraft/subproxies/LPBCTileGenericPipe.java#L60-L61) into `TileGenericPipe` which no longer works with modern java. Add API to make that unnecessary.

Backport from GTNH: https://github.com/GTNewHorizons/BuildCraft/pull/15
Here is our fix for LP: https://github.com/GTNewHorizons/LogisticsPipes/pull/21

(as requested by asie)