### PR TITLE
[1.4.7] Fix creation of particles owned by the server world

### DIFF
--- a/common/buildcraft/core/proxy/CoreProxyClient.java
+++ b/common/buildcraft/core/proxy/CoreProxyClient.java
@@ -101,7 +101,7 @@ public class CoreProxyClient extends CoreProxy {
 	/* GFX */
 	@Override
 	public void obsidianPipePickup(World world, EntityItem item, TileEntity tile) {
-		FMLClientHandler.instance().getClient().effectRenderer.addEffect(new TileEntityPickupFX(world, item, tile));
+		FMLClientHandler.instance().getClient().effectRenderer.addEffect(new TileEntityPickupFX(getClientWorld(), item, tile));
 	}
 
 	@Override


### PR DESCRIPTION
<img src="https://files.y2k.diy/av/circle/lumin.webp" width="40" height="40" align="center"> <b>Lumin</b> commented:

this results in bizarre crashes such as the following:

```
java.lang.NullPointerException: Cannot invoke "aoe.c(aoe, double)" because the return value of "java.util.List.get(int)" is null
	at lq.d(Entity.java:769)
	at aze.j_(SourceFile:29)
	at azr.a(EffectRenderer.java:76)
	at net.minecraft.client.Minecraft.l(Minecraft.java:1905)
	at net.minecraft.client.Minecraft.J(Minecraft.java:848)
	at net.minecraft.client.Minecraft.run(Minecraft.java:773)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

due to the effects of `clear()` on `World.collidingBoundingBoxes` tearing between threads when particles do collision. the particles get ticked on the client thread, but try to touch the server world. textbook example of the logical vs physical side mismatch mistakes that proxies encourage.

we discovered this while fixing an instance of it in forestry with a bytecode patch, and the same code tripped a crash in buildcraft. so here's the source fix for that, as we've been requested multiple times to send upstream prs rather than doing bytecode patches.

i did not immediately see other places that buildcraft makes the same mistake. this is a bit of a bandage, but it works fine in practice. obviously this should instead send a packet.