### PR TITLE
Fix #4740, #4749, #4751 - NPE crash, power hook return type, assembly table refresh

### DIFF
--- a/common/buildcraft/lib/misc/GuiUtil.java
+++ b/common/buildcraft/lib/misc/GuiUtil.java
@@ -445,6 +445,9 @@ public class GuiUtil {
     }
 
     public static List<String> getUnFormattedTooltip(ItemStack stack) {
+        if (stack.isEmpty() || stack.getItem() == null) {
+            return Collections.singletonList(getStackDisplayName(stack));
+        }
         Minecraft mc = Minecraft.getMinecraft();
         List<String> list = stack.getTooltip(mc.player, getTooltipFlags());
         if (list.isEmpty()) {
@@ -459,9 +462,14 @@ public class GuiUtil {
             // Temp workaround for headcrumbs
             // TODO: Remove this after https://github.com/BuildCraft/BuildCraft/issues/4268 is fixed from their side! */
             Item item = stack.getItem();
-            String info = item.getRegistryName() + " " + item.getClass() + " (" + stack.serializeNBT() + ")";
-            BCLog.logger.warn("[lib.guide] Found null display name! " + info);
-            name = "!!NULL stack.getDisplayName(): " + info;
+            if (item != null) {
+                String info = item.getRegistryName() + " " + item.getClass() + " (" + stack.serializeNBT() + ")";
+                BCLog.logger.warn("[lib.guide] Found null display name! " + info);
+                name = "!!NULL stack.getDisplayName(): " + info;
+            } else {
+                BCLog.logger.warn("[lib.guide] Found null display name AND null item! " + stack.serializeNBT());
+                name = "!!NULL stack.getDisplayName(): " + stack.serializeNBT();
+            }
         }
         return name;
     }

--- a/common/buildcraft/silicon/tile/TileAssemblyTable.java
+++ b/common/buildcraft/silicon/tile/TileAssemblyTable.java
@@ -42,6 +42,8 @@ import buildcraft.lib.tile.TileBC_Neptune;
 import buildcraft.lib.tile.item.ItemHandlerManager;
 import buildcraft.lib.tile.item.ItemHandlerSimple;
 
+import net.minecraftforge.items.IItemHandlerModifiable;
+
 import buildcraft.silicon.EnumAssemblyRecipeState;
 
 public class TileAssemblyTable extends TileLaserTableBase {
@@ -61,6 +63,15 @@ public class TileAssemblyTable extends TileLaserTableBase {
     @Override
     public IdAllocator getIdAllocator() {
         return IDS;
+    }
+
+    @Override
+    protected void onSlotChange(IItemHandlerModifiable handler, int slot, net.minecraft.item.ItemStack before,
+        net.minecraft.item.ItemStack after) {
+        super.onSlotChange(handler, slot, before, after);
+        if (!world.isRemote) {
+            updateRecipes();
+        }
     }
 
     private void updateRecipes() {

--- a/common/buildcraft/transport/pipe/flow/IPipeTransportPowerHook.java
+++ b/common/buildcraft/transport/pipe/flow/IPipeTransportPowerHook.java
@@ -13,8 +13,10 @@ public interface IPipeTransportPowerHook {
     /** Override default behavior on receiving energy into the pipe.
      *
      * @return The amount of power used, or -1 for default behavior. */
-    int receivePower(EnumFacing from, long val);
+    long receivePower(EnumFacing from, long val);
 
-    /** Override default requested power. */
-    int requestPower(EnumFacing from, long amount);
+    /** Override default requested power.
+     *
+     * @return The amount of power requested, or -1 for default behavior. */
+    long requestPower(EnumFacing from, long amount);
 }

--- a/common/buildcraft/transport/pipe/flow/PipeFlowPower.java
+++ b/common/buildcraft/transport/pipe/flow/PipeFlowPower.java
@@ -418,7 +418,8 @@ public class PipeFlowPower extends PipeFlow implements IFlowPower, IDebuggable {
 
         Section s = sections.get(from);
         if (pipe.getBehaviour() instanceof IPipeTransportPowerHook) {
-            s.nextPowerQuery += ((IPipeTransportPowerHook) pipe.getBehaviour()).requestPower(from, amount);
+            long hooked = ((IPipeTransportPowerHook) pipe.getBehaviour()).requestPower(from, amount);
+            s.nextPowerQuery += (hooked >= 0 ? hooked : amount);
         } else {
             s.nextPowerQuery += amount;
         }
@@ -476,6 +477,14 @@ public class PipeFlowPower extends PipeFlow implements IFlowPower, IDebuggable {
 
             internalPower += internalNextPower;
             internalNextPower = 0;
+
+            if (pipe.getBehaviour() instanceof IPipeTransportPowerHook) {
+                IPipeTransportPowerHook hook = (IPipeTransportPowerHook) pipe.getBehaviour();
+                long used = hook.receivePower(side, internalPower);
+                if (used >= 0) {
+                    internalPower -= used;
+                }
+            }
         }
 
         @Override


### PR DESCRIPTION
## Fixes

### #4740 - Lists GUI NullPointerException crash
**File:** common/buildcraft/lib/misc/GuiUtil.java - Added null checks for stack.getItem() == null in getUnFormattedTooltip() to prevent NPE when rendering tooltips for certain mod items (e.g. HarvestCraft seed items). Also protected the fallback in getStackDisplayName() from null item.

### #4749 - IPipeTransportPowerHook return type and missing receivePower hook
**Files:** IPipeTransportPowerHook.java, PipeFlowPower.java - Changed eceivePower and equestPower return types from int to long. Fixed equestPower -1 fallback logic that previously accumulated negative values. Added missing eceivePower hook call in Section.step() that was never being invoked.

### #4751 - Assembly Table crafting options not updating on item swap
**File:** common/buildcraft/silicon/tile/TileAssemblyTable.java - Override onSlotChange() callback to immediately trigger updateRecipes() when items are swapped via the GUI, instead of waiting for the next tick.