### PR TITLE
Add GitHub Actions CI workflow (additive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+# Additive GitHub Actions CI for BuildCraft 8.0.x (1.12.2).
+# Does NOT replace the existing Jenkinsfile - it provides PR check runs
+# and a no-Jenkins-infra build path. Mirrors the Jenkins pipeline:
+#   - Checkout + recursive submodules
+#   - Build stage (./gradlew build -x test)  -> archive build/libs/*.jar
+#   - Test stage  (./gradlew test)           -> publish + archive TEST-*.xml
+
+on:
+  push:
+    branches: [8.0.x-1.12.2]
+  pull_request:
+  workflow_dispatch:
+
+# Mirrors Jenkins "disableConcurrentBuilds()"
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  build-and-test:
+    name: Build & Test (JDK 8)
+    runs-on: ubuntu-latest
+    # ForgeGradle decompiles MC 1.12.2 on first run; give it room.
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: "8"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build (skip tests)
+        run: ./gradlew build -x test --no-daemon --console=plain
+        env:
+          GRADLE_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=512m"
+
+      - name: Upload build artifacts (jars)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-libs
+          path: build/libs/*.jar
+          if-no-files-found: ignore
+
+      - name: Test
+        run: ./gradlew test --no-daemon --console=plain
+        env:
+          GRADLE_OPTS: "-Xmx2g -XX:MaxMetaspaceSize=512m"
+
+      - name: Publish Test Report
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: "**/build/test-results/test/TEST-*.xml"
+          check_name: "JUnit Test Report"
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: "**/build/test-results/test/TEST-*.xml"
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
Adds a GitHub Actions CI workflow (`.github/workflows/ci.yml`) that mirrors the existing Jenkins pipeline:
- Checkout with recursive submodules
- `./gradlew build -x test` (archives `build/libs/*.jar`)
- `./gradlew test` with JUnit result publishing

## Why
- Enables CI check runs on pull requests (currently no PR CI exists).
- Provides a build path without requiring Jenkins infrastructure.

## Notes
- **Additive only** - the `Jenkinsfile` is untouched; both can coexist.
- Tested green on the fork (build + 34 test result files + report).

Happy to adjust triggers, JDK version, or artifact handling if the team prefers a different setup.