### PR TITLE
feat(builders): add Excavate toggle to the Builder GUI

### DIFF
--- a/buildcraft_resources/assets/buildcraft/lang/en_US.lang
+++ b/buildcraft_resources/assets/buildcraft/lang/en_US.lang
@@ -965,3 +965,5 @@ advancements.buildcraftbuilders.building_for_the_future.description=Set a filler
 
 advancements.buildcraftbuilders.destroying_the_world.title=Destorying the world
 advancements.buildcraftbuilders.destroying_the_world.description=Have two or more 64 x 64 sized quarries running at once at full speed
+
+gui.builder.canExcavate=Excavate

--- a/common/buildcraft/builders/gui/GuiBuilder.java
+++ b/common/buildcraft/builders/gui/GuiBuilder.java
@@ -10,6 +10,9 @@ import net.minecraft.util.ResourceLocation;
 
 import buildcraft.lib.gui.GuiBC8;
 import buildcraft.lib.gui.GuiIcon;
+import buildcraft.lib.gui.button.GuiImageButton;
+import buildcraft.lib.gui.button.IButtonBehaviour;
+import buildcraft.lib.gui.elem.ToolTip;
 import buildcraft.lib.gui.pos.GuiRectangle;
 
 import buildcraft.builders.container.ContainerBuilder;
@@ -48,22 +51,23 @@ public class GuiBuilder extends GuiBC8<ContainerBuilder> {
             );
         }
 
-//        buttonList.add(
-//                new GuiButtonSmall(
-//                        this,
-//                        0,
-//                        rootElement.getX() + (ICON_GUI.width - 100) / 2,
-//                        rootElement.getY() + 50,
-//                        100,
-//                        "Can Excavate"
-//                )
-//                        .setToolTip(ToolTip.createLocalized("gui.builder.canExcavate"))
-//                        .setBehaviour(IButtonBehaviour.TOGGLE)
-//                        .setActive(container.tile.canExcavate())
-//                        .registerListener((button, buttonId, buttonKey) ->
-//                                container.tile.sendCanExcavate(button.isButtonActive())
-//                        )
-//        );
+        // "Don't excavate" (canExcavate) toggle.
+        // The logic already exists on TileBuilder; this just exposes it in the GUI.
+        // Reuses the shared toggle frames from buildcraftcore's list_new.png so no new texture asset is needed.
+        GuiImageButton buttonExcavate = new GuiImageButton(
+                mainGui,
+                0,
+                (int) (mainGui.rootElement.getX() + 161),
+                (int) (mainGui.rootElement.getY() + 8),
+                11,
+                new ResourceLocation("buildcraftcore:textures/gui/list_new.png"),
+                176, 16, 176, 28);
+        buttonExcavate.setToolTip(ToolTip.createLocalized("gui.builder.canExcavate"));
+        buttonExcavate.setBehaviour(IButtonBehaviour.TOGGLE);
+        buttonExcavate.setActive(container.tile.canExcavate());
+        buttonExcavate.registerListener((button, buttonKey) ->
+                container.tile.sendCanExcavate(button.isButtonActive()));
+        mainGui.shownElements.add(buttonExcavate);
     }
 
     @Override


### PR DESCRIPTION
## Summary
The Builder has long supported `canExcavate` on its tile (the same plumbing the Filler uses via `NET_CAN_EXCAVATE`), but it was never exposed in the Builder's GUI. This adds an **Excavate** toggle button so players can disable block breaking and have the Builder only place.

- `GuiBuilder`: add an Excavate toggle using the existing `TileBuilder#canExcavate` / `sendCanExcavate` methods.
- `en_US.lang`: add the `gui.builder.canExcavate` localization key (mirrors the Filler's "Excavate" / "Do Not Excavate" wording).

This brings the Builder in line with the Filler's excavate UX.

## Test plan
- Open a Builder GUI on 1.12.2 (Forge 14.23.5.2859).
- Toggle Excavate off and confirm the Builder only places and does not break existing blocks.
- Toggle back on and confirm normal excavate behaviour returns.
