### PR TITLE
fix(builders): harden SnapshotBuilder.tick() against NPE

### DIFF
--- a/common/buildcraft/builders/snapshot/SnapshotBuilder.java
+++ b/common/buildcraft/builders/snapshot/SnapshotBuilder.java
@@ -276,6 +276,13 @@ public abstract class SnapshotBuilder<T extends ITileForSnapshotBuilder> impleme
 
         boolean checkResultsChanged = false;
 
+        // Defensive guard: snapshot may be in a cancelled / not-yet-built state
+        // (checkOrder == null after cancel(), or buildingInfo not ready during load
+        // ordering). Touching checkOrder.length or getBuildingInfo() here would NPE.
+        if (checkOrder == null || getBuildingInfo() == null) {
+            return false;
+        }
+
         tile.getWorldBC().profiler.startSection("scan");
         for (int i = 0; i < CHECKS_PER_TICK; i++) {
             if (check(indexToPos(currentCheckIndex))) {


### PR DESCRIPTION
## Summary
`SnapshotBuilder.tick()` could throw a `NullPointerException` on the server path when `checkOrder` was `null` (e.g. after `cancel()`) or `buildingInfo` was not yet ready during load ordering. This adds a defensive early-return guard so the builder no longer crashes the server tick loop.

## Test plan
- Run a Builder / Architect build, cancel it mid-way and reload the world; confirm no NPE in the server log.
