### PR TITLE
fix(energy): add missing blockstate for the MJ Dynamo block

### DIFF
--- a/buildcraft_resources/assets/buildcraftenergy/blockstates/mj_dynamo.json
+++ b/buildcraft_resources/assets/buildcraftenergy/blockstates/mj_dynamo.json
@@ -1,0 +1,8 @@
+{
+    "forge_marker": 1,
+    "variants": {
+        "normal": {
+            "model": "buildcraftenergy:block/mj_dynamo_base"
+        }
+    }
+}

--- a/buildcraft_resources/assets/buildcraftenergy/models/block/mj_dynamo_base.json
+++ b/buildcraft_resources/assets/buildcraftenergy/models/block/mj_dynamo_base.json
@@ -1,0 +1,6 @@
+{
+    "parent": "block/cube_all",
+    "textures": {
+        "all": "buildcraftenergy:blocks/mj_dynamo/side"
+    }
+}


### PR DESCRIPTION
## Summary
The `mj_dynamo` block (added in `6ba8099fa` "Add RF Pipes and optional RF <-> MJ engines") ships a block model but is **missing its `blockstates/mj_dynamo.json`**. Forge therefore fails to resolve the `mj_dynamo#normal` variant at load time, logging a model-load exception and rendering the block as missing-texture (black/purple) whenever `B:enableMjDynamo=true`.

This adds:
- `blockstates/mj_dynamo.json` → maps the `normal` variant to a simple cube base model.
- `models/block/mj_dynamo_base.json` → vanilla `cube_all` using the existing `blocks/mj_dynamo/side` texture.

The actual block geometry/animation is drawn by `RenderDynamoMJ` (FastTESR), so the new files only satisfy Forge's variant resolution.

## Test plan
- Set `B:enableMjDynamo=true` in `config/buildcraft/main.cfg`.
- Load the game; confirm no `Exception loading model for variant buildcraftenergy:mj_dynamo#normal` in the log and the block is no longer missing-texture.
