### PR TITLE
[1.12.2] Fix lasers searching for targets when unnecessary

### DIFF
--- a/common/buildcraft/silicon/tile/TileLaser.java
+++ b/common/buildcraft/silicon/tile/TileLaser.java
@@ -85,7 +85,9 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
 
     @Override
     public void setWorldUpdated(World world, BlockPos eventPos, IBlockState oldState, IBlockState newState, int flags) {
-        this.worldHasUpdated = true;
+        if (oldState.getMaterial() != newState.getMaterial()) {
+            this.worldHasUpdated = true;
+        }
     }
 
     private void findPossibleTargets() {


### PR DESCRIPTION
While profiling a server, I noticed lasers (N < 50) were responsible for a lot of the tick time, spending it searching for targets. Because some surrounding blocks were updating every tick, `setWorldUpdated` got triggered just as often, making the lasers search for targets every time.
As far as I could tell though, all that matters is whether the block material changed: specifically, whether a block started/stopped blocking the laser, or started/stopped being a viable target.
Adding a check for it made lasers disappear from subsequent profiles (and didn't seem to break anything).