### PR TITLE
Improve lasers performance

### DIFF
--- a/common/buildcraft/lib/client/render/laser/LaserCompiledBuffer.java
+++ b/common/buildcraft/lib/client/render/laser/LaserCompiledBuffer.java
@@ -6,6 +6,8 @@
 
 package buildcraft.lib.client.render.laser;
 
+import java.util.concurrent.TimeUnit;
+
 import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TIntArrayList;
 
@@ -19,14 +21,36 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class LaserCompiledBuffer {
     private static final int DOUBLE_STRIDE = 5;
     private static final int INT_STRIDE = 2;
+    private static final long LIGHTMAP_REFRESH_INTERVAL = TimeUnit.SECONDS.toNanos(5);
     private final int vertices;
     private final double[] da;
     private final int[] ia;
+    private final int minBlockLight;
+    private long lastLightmapRefresh;
 
     public LaserCompiledBuffer(int vertices, double[] da, int[] ia) {
+        this(vertices, da, ia, 0);
+    }
+
+    public LaserCompiledBuffer(int vertices, double[] da, int[] ia, int minBlockLight) {
         this.vertices = vertices;
         this.da = da;
         this.ia = ia;
+        this.minBlockLight = minBlockLight;
+        this.lastLightmapRefresh = System.nanoTime();
+    }
+
+    public void refreshLightmapIfNeeded(long time) {
+        if (time - lastLightmapRefresh < LIGHTMAP_REFRESH_INTERVAL) {
+            return;
+        }
+        for (int i = 0; i < vertices; i++) {
+            int doubleIndex = DOUBLE_STRIDE * i;
+            ia[INT_STRIDE * i + 1] = LaserRenderer_BC8.computeLightmap(
+                da[doubleIndex], da[doubleIndex + 1], da[doubleIndex + 2], minBlockLight
+            );
+        }
+        lastLightmapRefresh = time;
     }
 
     /** Assumes the buffer uses {@link DefaultVertexFormats#BLOCK} */
@@ -52,12 +76,18 @@ public class LaserCompiledBuffer {
 
     public static class Builder implements ILaserRenderer {
         private final boolean useNormalColour;
+        private final int minBlockLight;
         private final TDoubleArrayList doubleData = new TDoubleArrayList();
         private final TIntArrayList intData = new TIntArrayList();
         private int vertices = 0;
 
         public Builder(boolean useNormalColour) {
+            this(useNormalColour, 0);
+        }
+
+        public Builder(boolean useNormalColour, int minBlockLight) {
             this.useNormalColour = useNormalColour;
+            this.minBlockLight = minBlockLight;
         }
 
         @Override
@@ -86,7 +116,7 @@ public class LaserCompiledBuffer {
         }
 
         public LaserCompiledBuffer build() {
-            return new LaserCompiledBuffer(vertices, doubleData.toArray(), intData.toArray());
+            return new LaserCompiledBuffer(vertices, doubleData.toArray(), intData.toArray(), minBlockLight);
         }
     }
 }

--- a/common/buildcraft/lib/client/render/laser/LaserRenderer_BC8.java
+++ b/common/buildcraft/lib/client/render/laser/LaserRenderer_BC8.java
@@ -6,6 +6,7 @@
 
 package buildcraft.lib.client.render.laser;
 
+import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -15,12 +16,15 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalNotification;
 
+import gnu.trove.map.hash.TLongIntHashMap;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.profiler.Profiler;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 
@@ -35,6 +39,11 @@ public class LaserRenderer_BC8 {
     private static final Map<LaserType, CompiledLaserType> COMPILED_LASER_TYPES = new HashMap<>();
     private static final LoadingCache<LaserData_BC8, LaserCompiledList> COMPILED_STATIC_LASERS;
     private static final LoadingCache<LaserData_BC8, LaserCompiledBuffer> COMPILED_DYNAMIC_LASERS;
+    private static final TLongIntHashMap BLOCK_LIGHTMAP_CACHE = new TLongIntHashMap();
+    private static final TLongIntHashMap SKY_LIGHTMAP_CACHE = new TLongIntHashMap();
+    private static WeakReference<World> dynamicLaserWorld = new WeakReference<>(null);
+    private static WeakReference<World> lightmapCacheWorld = new WeakReference<>(null);
+    private static long lightmapCacheTick = Long.MIN_VALUE;
 
     public static final VertexFormat FORMAT_LESS, FORMAT_ALL;
 
@@ -45,7 +54,8 @@ public class LaserRenderer_BC8 {
             .build(CacheLoader.from(LaserRenderer_BC8::makeStaticLaser));
 
         COMPILED_DYNAMIC_LASERS = CacheBuilder.newBuilder()//
-            .expireAfterWrite(5, TimeUnit.SECONDS)//
+            .maximumSize(4096)//
+            .expireAfterAccess(60, TimeUnit.SECONDS)//
             .build(CacheLoader.from(LaserRenderer_BC8::makeDynamicLaser));
 
         FORMAT_LESS = new VertexFormat();
@@ -62,6 +72,10 @@ public class LaserRenderer_BC8 {
 
     public static void clearModels() {
         COMPILED_LASER_TYPES.clear();
+        COMPILED_STATIC_LASERS.invalidateAll();
+        COMPILED_DYNAMIC_LASERS.invalidateAll();
+        dynamicLaserWorld = new WeakReference<>(null);
+        clearLightmapCache();
     }
 
     private static CompiledLaserType compileType(LaserType laserType) {
@@ -79,7 +93,7 @@ public class LaserRenderer_BC8 {
     }
 
     private static LaserCompiledBuffer makeDynamicLaser(LaserData_BC8 data) {
-        LaserCompiledBuffer.Builder renderer = new LaserCompiledBuffer.Builder(data.enableDiffuse);
+        LaserCompiledBuffer.Builder renderer = new LaserCompiledBuffer.Builder(data.enableDiffuse, data.minBlockLight);
         makeLaser(data, renderer);
         return renderer.build();
     }
@@ -100,6 +114,7 @@ public class LaserRenderer_BC8 {
     public static int computeLightmap(double x, double y, double z, int minBlockLight) {
         World world = Minecraft.getMinecraft().world;
         if (world == null) return 0;
+        updateLightmapCache(world);
         int blockLight =
             minBlockLight >= 15 ? 15 : Math.max(minBlockLight, getLightFor(world, EnumSkyBlock.BLOCK, x, y, z));
         int skyLight = getLightFor(world, EnumSkyBlock.SKY, x, y, z);
@@ -107,6 +122,7 @@ public class LaserRenderer_BC8 {
     }
 
     private static int getLightFor(World world, EnumSkyBlock type, double x, double y, double z) {
+        TLongIntHashMap lightmapCache = type == EnumSkyBlock.BLOCK ? BLOCK_LIGHTMAP_CACHE : SKY_LIGHTMAP_CACHE;
         int max = 0;
         int count = 0;
         int sum = 0;
@@ -130,7 +146,14 @@ public class LaserRenderer_BC8 {
         for (int xp = xl; xp <= xu; xp++) {
             for (int yp = yl; yp <= yu; yp++) {
                 for (int zp = zl; zp <= zu; zp++) {
-                    int light = world.getLightFor(type, new BlockPos(x + xp, y + yp, z + zp));
+                    long packedPos = packLightPos(x + xp, y + yp, z + zp);
+                    int light;
+                    if (lightmapCache.containsKey(packedPos)) {
+                        light = lightmapCache.get(packedPos);
+                    } else {
+                        light = world.getLightFor(type, unpackLightPos(packedPos));
+                        lightmapCache.put(packedPos, light);
+                    }
                     if (light > 0) {
                         sum += light;
                         count++;
@@ -147,6 +170,44 @@ public class LaserRenderer_BC8 {
         }
     }
 
+    private static void updateDynamicLaserWorld(World world) {
+        if (dynamicLaserWorld.get() == world) {
+            return;
+        }
+        COMPILED_DYNAMIC_LASERS.invalidateAll();
+        dynamicLaserWorld = new WeakReference<>(world);
+    }
+
+    private static void updateLightmapCache(World world) {
+        long worldTime = world.getTotalWorldTime();
+        if (lightmapCacheWorld.get() == world && lightmapCacheTick == worldTime) {
+            return;
+        }
+        BLOCK_LIGHTMAP_CACHE.clear();
+        SKY_LIGHTMAP_CACHE.clear();
+        lightmapCacheWorld = new WeakReference<>(world);
+        lightmapCacheTick = worldTime;
+    }
+
+    private static void clearLightmapCache() {
+        BLOCK_LIGHTMAP_CACHE.clear();
+        SKY_LIGHTMAP_CACHE.clear();
+        lightmapCacheWorld = new WeakReference<>(null);
+        lightmapCacheTick = Long.MIN_VALUE;
+    }
+
+    private static long packLightPos(double x, double y, double z) {
+        return packLightPos(MathHelper.floor(x), MathHelper.floor(y), MathHelper.floor(z));
+    }
+
+    private static long packLightPos(int x, int y, int z) {
+        return ((long) x & 0x3FFFFFFL) << 38 | ((long) y & 0xFFFL) | ((long) z & 0x3FFFFFFL) << 12;
+    }
+
+    private static BlockPos unpackLightPos(long packedPos) {
+        return new BlockPos((int) (packedPos >> 38), (int) (packedPos & 0xFFFL), (int) (packedPos << 26 >> 38));
+    }
+
     public static void renderLaserStatic(LaserData_BC8 data) {
         Profiler profiler = Minecraft.getMinecraft().mcProfiler;
         profiler.startSection("compute");
@@ -159,9 +220,12 @@ public class LaserRenderer_BC8 {
 
     /** Assumes the buffer uses {@link DefaultVertexFormats#BLOCK} */
     public static void renderLaserDynamic(LaserData_BC8 data, BufferBuilder buffer) {
-        Profiler profiler = Minecraft.getMinecraft().mcProfiler;
+        Minecraft minecraft = Minecraft.getMinecraft();
+        updateDynamicLaserWorld(minecraft.world);
+        Profiler profiler = minecraft.mcProfiler;
         profiler.startSection("compute");
         LaserCompiledBuffer compiled = COMPILED_DYNAMIC_LASERS.getUnchecked(data);
+        compiled.refreshLightmapIfNeeded(System.nanoTime());
         profiler.endStartSection("render");
         compiled.render(buffer);
         profiler.endSection();

--- a/common/buildcraft/silicon/tile/TileLaser.java
+++ b/common/buildcraft/silicon/tile/TileLaser.java
@@ -54,6 +54,8 @@ import buildcraft.silicon.client.render.AdvDebuggerLaser;
 
 public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable, ILocalBlockUpdateSubscriber {
     private static final int TARGETING_RANGE = 6;
+    private static final int RENDER_POWER_LEVELS = 4;
+    private static final int MAX_RENDER_POWER_INDEX = RENDER_POWER_LEVELS - 1;
 
     private final SafeTimeTracker clientLaserMoveInterval = new SafeTimeTracker(5, 10);
     private final SafeTimeTracker serverTargetMoveInterval = new SafeTimeTracker(10, 20);
@@ -66,6 +68,8 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
     private final AverageLong avgPower = new AverageLong(100);
     private long averageClient;
     private final MjBattery battery;
+    private BlockPos lastRenderTargetPos;
+    private int lastRenderState = -1;
 
     public TileLaser() {
         super();
@@ -166,6 +170,16 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
         return 4 * MjAPI.MJ;
     }
 
+    private int getRenderState() {
+        long average = (long) avgPower.getAverage();
+        if (average <= 200_000) {
+            return 0;
+        }
+        average += 200_000;
+        int index = (int) (average * MAX_RENDER_POWER_INDEX / getMaxPowerPerTick());
+        return Math.min(index, MAX_RENDER_POWER_INDEX) + 1;
+    }
+
     @Override
     public void update() {
         if (world.isRemote) {
@@ -179,7 +193,6 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
         // set target tile on server side
         avgPower.tick();
 
-        BlockPos previousTargetPos = targetPos;
         if (worldHasUpdated) {
             findPossibleTargets();
             worldHasUpdated = false;
@@ -209,7 +222,10 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
             avgPower.clear();
         }
 
-        if (!Objects.equals(previousTargetPos, targetPos) || true) {
+        int renderState = getRenderState();
+        if (!Objects.equals(lastRenderTargetPos, targetPos) || lastRenderState != renderState) {
+            lastRenderTargetPos = targetPos;
+            lastRenderState = renderState;
             sendNetworkUpdate(NET_RENDER_DATA);
         }
 


### PR DESCRIPTION
## Summary

This PR drastically cuts the Server and Client cost of lasers, by :
- Increasing the laser beam rebuild rate from 5s (always) to 60s (since last used), while capping the cache to 4k entries, to avoid excessive memory usage
- Caching the light map for the client tick so that we do not re-query the same data multiple times. Lasers themselves refresh their lighting every 5s max (reflecting the old 5s cache), if they are not rebuilt by that time. This is mainly optimizing the vertices in the same beam, the chance of 2 lasers refreshing at the same tick and crossing the same blocks being fairly low.
- Send render state change packets only when the state actually changes, instead of every tick. This means there should be very few packets past the warm-up period (1)

(1) This comes with one caveat: the client debug battery/average snapshots only refresh on actual target/color changes, rather than every tick. This is, however, mitigated by a forced sync every 10s or so. This means a packet should be sent every 200 ticks instead of every tick.


## Performance testing

The test was performed in a void world with 9x9 lasers pointing to a single table crafting diamond chipsets. The lasers were past the warm-up period, meaning the color was stable, and no target change was carried.

Without these optimization :
- Server: https://spark.lucko.me/YNFbuVsOd0
- Client: https://spark.lucko.me/8XXqzTQD88

With these optimization :
- Server: https://spark.lucko.me/BNW3zik9QH
- Client: https://spark.lucko.me/NMC4RkYNNf

## Top costs from the Server spark
| Method | Before % | After % | Change % |
| :--- | ---: | ---: | ---: |
| buildcraft.silicon.tile.TileLaser.func_73660_a | 1.185% | 0.318% | -73.17% |
| buildcraft.lib.tile.TileBC_Neptune.sendNetworkUpdate | 0.956% | 0.002% | -99.77% |
| buildcraft.lib.misc.MessageUtil.lambda$sendToAllWatching$0 | 0.887% | 0.002% | -99.75% |
| buildcraft.lib.misc.MessageUtil.sendToAllWatching | 0.887% | 0.002% | -99.75% |
| buildcraft.lib.net.MessageManager.sendTo | 0.885% | 0.002% | -99.75% |

## Top costs from the Client spark
| Method | Before % | After % | Change % |
| :--- | ---: | ---: | ---: |
| buildcraft.silicon.client.render.RenderLaser.renderTileEntityFast | 1.033% | 0.689% | -33.33% |
| buildcraft.lib.client.render.laser.LaserRenderer_BC8.renderLaserDynamic | 1.029% | 0.687% | -33.26% |
| buildcraft.lib.client.render.laser.LaserRenderer_BC8.makeDynamicLaser | 0.800% | 0.049% | -93.89% |
| buildcraft.lib.client.render.laser.LaserRenderer_BC8.makeLaser | 0.800% | 0.042% | -94.72% |
| buildcraft.lib.client.render.laser.CompiledLaserType.bakeFor | 0.784% | 0.027% | -96.60% |
| buildcraft.lib.client.render.laser.LaserContext.addPoint | 0.747% | 0.020% | -97.32% |
| buildcraft.lib.client.render.laser.LaserRenderer_BC8.computeLightmap | 0.747% | 0.407% | -45.54% |
| buildcraft.lib.client.render.laser.LaserRenderer_BC8.getLightFor | 0.744% | 0.051% | -93.13% |