### PR TITLE
Fix chunk unload leaking lasers' block listener

### DIFF
--- a/common/buildcraft/silicon/tile/TileLaser.java
+++ b/common/buildcraft/silicon/tile/TileLaser.java
@@ -298,6 +298,14 @@ public class TileLaser extends TileBC_Neptune implements ITickable, IDebuggable,
         }
     }
 
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        if (!world.isRemote) {
+            LocalBlockUpdateNotifier.instance(world).removeSubscriberFromUpdateNotifications(this);
+        }
+    }
+
     @Nonnull
     @Override
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
When a chunk unloads, invalidate() is not called (instead it's onChunkUnload), causing the Block Listener to not be unregistered. Then the laser is loaded again and re-registers the listener, causing registrations to accumulate and severely affecting performances.